### PR TITLE
[ROCm] enable nvfuser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,10 @@ Execute the following command to test them after a successfuly installation with
 
 .. code-block:: bash
 
-  ROCBLAS_STREAM_ORDER_ALLOC=1 NVTE_BIAS_GELU_NVFUSION=0 NVTE_FUSED_ATTN=0 NVTE_FLASH_ATTN=0 pytest tests/pytorch/<testname>
+  ROCBLAS_STREAM_ORDER_ALLOC=1 NVTE_FUSED_ATTN=0 NVTE_FLASH_ATTN=0 pytest tests/pytorch/<testname>
 
 `ROCBLAS_STREAM_ORDER_ALLOC=1` can be dropped when the hipGraph feature is fully supported in Pytorch on AMDGPUs. 
-The other environmental variables are required since our ROCm Transformer Engine has not supported bias gelu nv fusion, fused attention, or flash attention yet. 
+The other environmental variables are required since our ROCm Transformer Engine has not supported fused attention or flash attention yet. 
 
 Examples
 --------

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -9,14 +9,10 @@ from typing import Callable, Optional, Tuple
 import torch
 
 from torch.utils.cpp_extension import IS_HIP_EXTENSION
-if IS_HIP_EXTENSION:
-  def identity(ob):
-    return ob
-  jit_fuser = identity
-else:
-  jit_fuser = torch.jit.script
-  if torch.__version__ >= "2" and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
-    jit_fuser = torch.compile
+
+jit_fuser = torch.jit.script
+if torch.__version__ >= "2" and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
+  jit_fuser = torch.compile
 
 # Decorator to disable Torch Dynamo
 # See: https://github.com/NVIDIA/TransformerEngine/issues/308
@@ -27,7 +23,6 @@ if torch.__version__ >= "2":
 
 
 def set_jit_fusion_options() -> None:
-  # skip jit fusion under HIP env
   if not IS_HIP_EXTENSION:
     """Set PyTorch JIT layer fusion options."""
     # flags required to enable jit fusion kernels


### PR DESCRIPTION
In latest pytorch 2.1 dockers, no torch._C flag toggling needed to enable torch.jit.script or torch.compile