### PR TITLE
[ROCm] temporary workaround to disable CK compilation in rocm6.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ Currently ROCm TE supports two backends, AOTriton and CK, for fused attention.
 To enable specific backends, the following environment variables can be used:
 
 * NVTE_FUSED_ATTN - enable the fused attention, default = 1;
-* NVTE_FUSED_ATTN_CK - enable the CK backend, default = 1;
+* NVTE_FUSED_ATTN_CK - enable the CK backend, default = 0 (will enable after CK fix rocm6.2 issues);
 * NVTE_FUSED_ATTN_AOTRITON - enable the AOTriton backend, default = 1.
 
 NVTE_FUSED_ATTN has higher priority than NVTE_FUSED_ATTN_CK and NVTE_FUSED_ATTN_AOTRITON. 

--- a/setup.py
+++ b/setup.py
@@ -450,6 +450,9 @@ def setup_common_extension() -> CMakeExtension:
     if use_rocm:
       if os.getenv("NVTE_USE_HIPBLASLT") is not None:
         cmake_flags.append("-DUSE_HIPBLASLT=ON")
+      # TODO: enable CK after rocm6.2 issues are fixed
+      if (not int(os.getenv("NVTE_FUSED_ATTN", "1"))) or (not int(os.getenv("NVTE_FUSED_ATTN_CK", "0"))):
+        cmake_flags.append("-DFUSED_ATTN_CK_KERNELS_NO_COMPILE=ON")
       if os.getenv("NVTE_AOTRITON_PATH"):
         aotriton_path = Path(os.getenv("NVTE_AOTRITON_PATH"))
         cmake_flags.append(f"-DAOTRITON_PATH={aotriton_path}")

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -461,7 +461,8 @@ def test_gpt_selective_activation_recompute(dtype, bs, model, fp8, fp8_model_par
     outputs_recompute = _test_e2e_selective_recompute(bs, dtype, config, fp8, fp8_model_params, recompute=True)
     if IS_HIP_EXTENSION:
         use_fused_attn = int(os.getenv("NVTE_FUSED_ATTN", "1"))
-        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "1"))
+        # TODO: enable CK after rocm6.2 issues fixed
+        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "0"))
         # TODO: wait for the ck branch supporting determinism
         if use_fused_attn and (not use_fused_attn_ck):
             # AOTriton backend and non-fused attn are deterministic
@@ -563,7 +564,8 @@ def test_gpt_full_activation_recompute(dtype, bs, model, fp8, fp8_model_params):
         else:
             # TODO: wait for the ck branch supporting determinism
             use_fused_attn = int(os.getenv("NVTE_FUSED_ATTN", "1"))
-            use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "1"))
+            # TODO: enable CK after rocm6.2 issues fixed
+            use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "0"))
             if use_fused_attn and (not use_fused_attn_ck):
                 # AOTriton backend and non-fused attn are deterministic
                 assert_all_equal(outputs, outputs_recompute)
@@ -673,7 +675,8 @@ def test_gpt_checkpointing(dtype, bs, model):
     if IS_HIP_EXTENSION: 
         use_hipblaslt = (os.getenv("NVTE_USE_HIPBLASLT") is not None)
         use_fused_attn = int(os.getenv("NVTE_FUSED_ATTN", "1"))
-        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "1"))
+        # TODO: enable CK after rocm6.2 issues fixed
+        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "0"))
         # ck fused_attn non-determinism requires higher tolerance
         if use_fused_attn and use_fused_attn_ck:
             # TODO: wait for the ck branch supporting determinism
@@ -1343,7 +1346,8 @@ def test_gpt_fp8_parameters(dtype, bs, model):
     outputs_fp8_params = _test_gpt_fp8_parameters(bs, dtype, config, True)
     if IS_HIP_EXTENSION:
         use_fused_attn = int(os.getenv("NVTE_FUSED_ATTN", "1"))
-        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "1"))
+        # TODO: enable CK after rocm6.2 issues fixed
+        use_fused_attn_ck = int(os.getenv("NVTE_FUSED_ATTN_CK", "0"))
         # TODO: wait for the ck branch supporting determinism
         if use_fused_attn and (not use_fused_attn_ck):
             assert_all_equal(outputs, outputs_fp8_params)

--- a/transformer_engine/common/ck_fused_attn/CMakeLists.txt
+++ b/transformer_engine/common/ck_fused_attn/CMakeLists.txt
@@ -10,40 +10,48 @@ set(ck_fused_attn_SOURCES)
 list(APPEND ck_fused_attn_SOURCES
        src/ck_fused_attn.cpp)
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gen_src)
-#fwd list
-execute_process(
-  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-  --direction fwd --list_blobs ${CMAKE_CURRENT_SOURCE_DIR}/gen_src/fwd_blob_list.txt -r 1
-)
-#fwd kernels
-execute_process(
-  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-  --direction fwd --output_dir ${CMAKE_CURRENT_SOURCE_DIR}/gen_src -r 1
-)
-
-#bwd list
-execute_process(
-  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-  --direction bwd --list_blobs ${CMAKE_CURRENT_SOURCE_DIR}/gen_src/bwd_blob_list.txt -r 1
-)
-#bwd kernels
-execute_process(
-  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-  --direction bwd --output_dir ${CMAKE_CURRENT_SOURCE_DIR}/gen_src -r 1
-)
-
-
-file(GLOB_RECURSE CK_FA_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gen_src/*.cpp")
-list(APPEND ck_fused_attn_SOURCES ${CK_FA_FILES})
-message(STATUS "Found the following CK fused attention files:")
-foreach(file ${CK_FA_FILES})
-  message(STATUS " ${file}")
-endforeach()
+if(NOT FUSED_ATTN_CK_KERNELS_NO_COMPILE)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gen_src)
+  #fwd list
+  execute_process(
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+    --direction fwd --list_blobs ${CMAKE_CURRENT_SOURCE_DIR}/gen_src/fwd_blob_list.txt -r 1
+  )
+  #fwd kernels
+  execute_process(
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+    --direction fwd --output_dir ${CMAKE_CURRENT_SOURCE_DIR}/gen_src -r 1
+  )
+  
+  #bwd list
+  execute_process(
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+    --direction bwd --list_blobs ${CMAKE_CURRENT_SOURCE_DIR}/gen_src/bwd_blob_list.txt -r 1
+  )
+  #bwd kernels
+  execute_process(
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+    --direction bwd --output_dir ${CMAKE_CURRENT_SOURCE_DIR}/gen_src -r 1
+  )
+  
+  
+  file(GLOB_RECURSE CK_FA_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gen_src/*.cpp")
+  list(APPEND ck_fused_attn_SOURCES ${CK_FA_FILES})
+  message(STATUS "Found the following CK fused attention files:")
+  foreach(file ${CK_FA_FILES})
+    message(STATUS " ${file}")
+  endforeach()
+endif()
 
 add_library(ck_fused_attn STATIC ${ck_fused_attn_SOURCES})
 set(CK_FUSED_ATTN_COMPILE_OPTIONS)
-list(APPEND CK_FUSED_ATTN_COMPILE_OPTIONS -Wno-undefined-func-template -DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=0 -fgpu-flush-denormals-to-zero -Wno-float-equal -ftemplate-backtrace-limit=0  -fPIC  -Wno-gnu-line-marker -Wunused-variable -Werror)
+list(APPEND CK_FUSED_ATTN_COMPILE_OPTIONS -Wno-undefined-func-template -DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=0 -fgpu-flush-denormals-to-zero -Wno-float-equal -ftemplate-backtrace-limit=0  -fPIC  -Wno-gnu-line-marker -Wunused-variable)
+
+if(NOT FUSED_ATTN_CK_KERNELS_NO_COMPILE)
+  list(APPEND CK_FUSED_ATTN_COMPILE_OPTIONS -Werror)
+else()
+  target_compile_definitions(ck_fused_attn PUBLIC FUSED_ATTN_CK_NO_KERNEL)
+endif()
 
 set(CK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../3rdparty/composable_kernel/include")
 message(STATUS "ck_include_dir: ${CK_INCLUDE_DIR}")

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn.cpp
@@ -235,11 +235,14 @@ hipError_t ck_attn_fwd(
     std::cout<<"dropout_seed: "<<std::get<0>(fmha_args.drop_seed_offset)<<", ";
     std::cout<<"dropout_offset: "<<std::get<1>(fmha_args.drop_seed_offset)<<std::endl;
   }
+//TODO: enable kernel compilation after CK fixed numerical issues
+#ifndef FUSED_ATTN_CK_NO_KERNEL 
   float average_runtime = fmha_fwd(fmha_traits, fmha_args, stream_config);
   if(average_runtime < 0){
     //TODO: better error out system
     throw std::runtime_error("fused attn configs not supported in ck_fused_attn fwd pass.");
   }
+#endif
   return hipSuccess;
 }
 
@@ -505,11 +508,14 @@ hipError_t ck_attn_bwd(
     std::cout<<"dropout_seed: "<<std::get<0>(fmha_args.drop_seed_offset)<<", ";
     std::cout<<"dropout_offset: "<<std::get<1>(fmha_args.drop_seed_offset)<<std::endl;
   }
+//TODO: enable kernel compilation after CK fixed numerical issues
+#ifndef FUSED_ATTN_CK_NO_KERNEL 
   float average_runtime = fmha_bwd(fmha_traits, fmha_args, stream_config);
   if(average_runtime < 0){
     //TODO: better error out system
     throw std::runtime_error("fused attn configs not supported in ck_fused_attn bwd pass.");
   }
+#endif
   return hipSuccess;
 }
 

--- a/transformer_engine/common/ck_fused_attn/src/fmha_bwd.hpp
+++ b/transformer_engine/common/ck_fused_attn/src/fmha_bwd.hpp
@@ -337,4 +337,7 @@ struct fmha_bwd_traits
     bool has_dropout;
     // TODO: padding check is inside this api
 };
+//TODO: enable kernel compilation after CK fixed numerical issues
+#ifndef FUSED_ATTN_CK_NO_KERNEL 
 float fmha_bwd(fmha_bwd_traits, fmha_bwd_args, const ck_tile::stream_config&);
+#endif

--- a/transformer_engine/common/ck_fused_attn/src/fmha_fwd.hpp
+++ b/transformer_engine/common/ck_fused_attn/src/fmha_fwd.hpp
@@ -290,4 +290,7 @@ struct fmha_fwd_traits
     bool do_fp8_static_quant;
     // TODO: padding check is inside this api
 };
+//TODO: enable kernel compilation after CK fixed numerical issues
+#ifndef FUSED_ATTN_CK_NO_KERNEL 
 float fmha_fwd(fmha_fwd_traits, fmha_fwd_args, const ck_tile::stream_config&);
+#endif

--- a/transformer_engine/common/fused_attn_rocm/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn.cpp
@@ -79,13 +79,14 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
         size_t head_dim) {
   using namespace transformer_engine;
   
-  // by default, both ck and aotriton backends are enabled
-  bool nvte_fused_attn_ck = true;
+  // by default, aotriton backend is enabled
+  // CK is temporarily disabled until ck fixed rocm6.2 issues
+  bool nvte_fused_attn_ck = false;
   bool nvte_fused_attn_aotriton = true;
   
   if (const char* env_p = std::getenv("NVTE_FUSED_ATTN_CK") ) {
-    if (env_p != nullptr && std::string(env_p) == "0")
-      nvte_fused_attn_ck = false;
+    if (env_p != nullptr && std::string(env_p) != "0")
+      nvte_fused_attn_ck = true;
   }
   if (const char* env_p = std::getenv("NVTE_FUSED_ATTN_AOTRITON") ) {
     if (env_p != nullptr && std::string(env_p) == "0")


### PR DESCRIPTION
Use NVTE_FUSED_ATTN_CK=0 to skip actual ck kernels compilation. 
To disable CK compilation in rocm6.2, either specify NVTE_FUSED_ATTN=0 or do nothing since NVTE_FUSED_ATTN_CK is by default 0, when do pip install.
To enable CK compilation in rocm6.0 or 6.1, need to specify NVTE_FUSED_ATTN_CK=1 when do pip install

Tested in both rocm6.1 and rocm6.2