### PR TITLE
[ROCm] remove the extra sync in gqa/mqa bwd

### DIFF
--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -415,10 +415,6 @@ hipError_t ck_attn_bwd(
         static_cast<CK_TILE_TYPE*>(dk_ptr),
         static_cast<CK_TILE_TYPE*>(dv_ptr),
         stride_b_dk, stride_h_dk, stride_s_dk););
-    //reduce the dkv expanded to dk kv
-    if(hipStreamSynchronize(stream)!=hipSuccess){
-      throw std::runtime_error("failed sync in dk_dv_reduce in mqa/gqa.");
-    }
   }
   return hipSuccess;
 }


### PR DESCRIPTION
# Description

Remove the extra sync after reduce dk dv in MQA/GQA bwd with the CK backend. 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- ebab8564bbf35a9b83f956192e0b239445e5ac57

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
