### PR TITLE
Fix undesired nv_fusion disabling after reentrant_activation_recompute

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1600,7 +1600,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
         if use_hipblaslt: 
             torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous())
         else:
-            torch.equal(y_bshd, y_sbhd.transpose(0, 1).contiguous())
+            assert torch.equal(y_bshd, y_sbhd.transpose(0, 1).contiguous()), "Tensors are not equal"
     else:
         # Check that results match
         torch.testing.assert_close(

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -696,6 +698,8 @@ def checkpoint(
 
     with _checkpoint_hook(new_frame, args, kwargs), te_forward_ctx, user_forward_ctx:
         out = function(*args, **kwargs)
+
+    _USE_REENTRANT_ACTIVATION_RECOMPUTE = True
 
     return out
 

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -10,6 +12,8 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import torch
 from torch.nn.parameter import Parameter
 from torch.nn import init
+
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 from .base import (
     get_workspace,
@@ -1536,7 +1540,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
                     )
 
             # Disable bias_gelu_nvfusion for determinism checkpointing in non-reentrant mode
-            if self.bias_gelu_nvfusion and not use_reentrant_activation_recompute():
+            if ( not IS_HIP_EXTENSION
+                and self.bias_gelu_nvfusion and not use_reentrant_activation_recompute() ):
                 self.bias_gelu_nvfusion = False
 
             from ..cpu_offload import CPUOffloadEnabled


### PR DESCRIPTION
# Description

Fix permanent disabling of bias_gelu_nv_fusion after using non-reentrant activation recompute.

Fixes # (issue)

https://github.com/ROCm/frameworks-internal/issues/9444

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Re-enable reentrant mode in checkpoint routine after completing non-reentrant pass
- Do not disable bias_gelu_nv_fusion when non-reentrant activation recompute is in progress, it currently does not cause issues for ROCm 
- Fixed tensor compare in rocBLAS path of test_numerics.py::test_transformer_layer_hidden_states_format

