### PR TITLE
[ROCm] support bias and alibi in the ck backend

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -309,10 +309,6 @@ class FusedAttnRunner:
                     "B1SS, BHSS and 11SS bias shapes are only supported for "
                     "the F16_arbitrary_seqlen backend."
                 )
-            elif is_hip_extension and self.bias_shape=="B1SS":
-                pytest.skip(
-                    "B1SS, bias shapes are not supported for rocm fused attn"
-                )
 
     def _setup_inputs(self):
         self._check_configs()

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -304,7 +304,7 @@ class FusedAttnRunner:
                     "B1SS, BHSS and 11SS bias shapes are only supported for "
                     "AttnMaskType.NO_MASK and AttnMaskType.CAUSAL_MASK."
                 )
-            elif not is_hip_extension and self.backend != NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
+            elif (not is_hip_extension()) and self.backend != NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
                 pytest.skip(
                     "B1SS, BHSS and 11SS bias shapes are only supported for "
                     "the F16_arbitrary_seqlen backend."

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -32,6 +34,7 @@ from transformer_engine.jax.cpp_extensions import FusedAttnHelper
 from transformer_engine.transformer_engine_jax import NVTE_Fused_Attn_Backend
 
 from utils import assert_allclose
+from transformer_engine.jax import is_hip_extension
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -301,10 +304,14 @@ class FusedAttnRunner:
                     "B1SS, BHSS and 11SS bias shapes are only supported for "
                     "AttnMaskType.NO_MASK and AttnMaskType.CAUSAL_MASK."
                 )
-            elif self.backend != NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
+            elif not is_hip_extension and self.backend != NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
                 pytest.skip(
                     "B1SS, BHSS and 11SS bias shapes are only supported for "
                     "the F16_arbitrary_seqlen backend."
+                )
+            elif is_hip_extension and self.bias_shape=="B1SS":
+                pytest.skip(
+                    "B1SS, bias shapes are not supported for rocm fused attn"
                 )
 
     def _setup_inputs(self):
@@ -571,7 +578,7 @@ class FusedAttnRunner:
 
             # Assume all batch has the same actual_seqlen, probably needs to extend the tests
             bias_mask = self.mask[0, 0]
-
+            
             # Assert all masked dbias are 0s
             assert_allclose(
                 jnp.where(bias_mask, primitive_dbias, 0),

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -513,7 +513,7 @@ model_configs_alibi_slopes = {
 }
 
 
-@pytest.mark.skipif(not _flash_attn_2_3_plus, reason="Flash-attn 2.3+ is required.")
+@pytest.mark.skipif((not IS_HIP_EXTENSION) and (not _flash_attn_2_3_plus), reason="Flash-attn 2.3+ is required.")
 @pytest.mark.parametrize("dtype", param_types_lean)
 @pytest.mark.parametrize("model_configs", [model_configs_alibi_slopes])
 @pytest.mark.parametrize("model", model_configs_alibi_slopes.keys())

--- a/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
+++ b/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
@@ -52,27 +52,17 @@ def test_cp_with_flash_attention(dtype, model, qkv_format):
         check=True,
     )
 
-#TODO: release bias tests once CK/AOTriton support bias
-if IS_HIP_EXTENSION:
-    model_configs_fused_attn = {
-        #   test:             b,  h, hg,   d,    sq,   skv,   p,      mask,      bias
-        "cp_1_0": ModelConfig(2, 12, 12, 128,  4096,  4096, 0.0,  "causal", "no_bias"),  # MHA
-        "cp_1_1": ModelConfig(2, 12, 12, 128,  4096,  4096, 0.0, "no_mask", "no_bias"),  # MHA
-        "cp_2_0": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "causal", "no_bias"),  # GQA
-        "cp_2_1": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "no_mask", "no_bias"),  # GQA
-    }
-else:
-    model_configs_fused_attn = {
-        #   test:             b,  h, hg,   d,   sq,  skv,   p,      mask,              bias
-        "cp_1_0": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "causal", "no_bias"),  # MHA
-        "cp_1_1": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "no_mask", "no_bias"),  # MHA
-        "cp_1_2": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "causal", "post_scale_bias"),  # MHA
-        "cp_1_3": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "no_mask", "post_scale_bias"),  # MHA
-        "cp_2_0": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "causal", "no_bias"),  # GQA
-        "cp_2_1": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "no_mask", "no_bias"),  # GQA
-        "cp_2_2": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "causal", "post_scale_bias"),  # GQA
-        "cp_2_3": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "no_mask", "post_scale_bias"),  # GQA
-    }
+model_configs_fused_attn = {
+    #   test:             b,  h, hg,   d,   sq,  skv,   p,      mask,              bias
+    "cp_1_0": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "causal", "no_bias"),  # MHA
+    "cp_1_1": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "no_mask", "no_bias"),  # MHA
+    "cp_1_2": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "causal", "post_scale_bias"),  # MHA
+    "cp_1_3": ModelConfig(2, 12, 12, 128, 4096, 4096, 0.0, "no_mask", "post_scale_bias"),  # MHA
+    "cp_2_0": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "causal", "no_bias"),  # GQA
+    "cp_2_1": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "no_mask", "no_bias"),  # GQA
+    "cp_2_2": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "causal", "post_scale_bias"),  # GQA
+    "cp_2_3": ModelConfig(2, 12, 1, 128, 4096, 4096, 0.0, "no_mask", "post_scale_bias"),  # GQA
+}
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 7), reason="cuDNN 8.9.7+ is required.")

--- a/transformer_engine/common/ck_fused_attn/CMakeLists.txt
+++ b/transformer_engine/common/ck_fused_attn/CMakeLists.txt
@@ -52,7 +52,8 @@ file(COPY_FILE ${__CK_SOURCE_DIR}/example/ck_tile/01_fmha/fmha_bwd.hpp ${CMAKE_C
 set(ck_fused_attn_SOURCES)
 list(APPEND ck_fused_attn_SOURCES
        src/ck_fused_attn_fwd.cpp
-       src/ck_fused_attn_bwd.cpp)
+       src/ck_fused_attn_bwd.cpp
+       src/ck_fused_attn_utils.cpp)
 
 file(GLOB_RECURSE CK_FA_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gen_src/*.cpp")
 list(APPEND ck_fused_attn_SOURCES ${CK_FA_FILES})

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -93,6 +93,7 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
   void* dv_ptr, 
   uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* dbias_expanded_ptr,
   void* dbias_ptr,
   void* workspace_ptr,
   hipStream_t stream);

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -29,19 +29,30 @@ enum MaskType {
   window_generic = 3,
 };
 
+// keep sync with bias_enum in bias.hpp
+enum BiasType{
+  no_bias          = 0,
+  elementwise_bias = 1,
+  alibi            = 2,
+};
+
+
 hipError_t ck_attn_fwd(
   DType dtype,
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
   const void* q_ptr, 
   uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
   const void* k_ptr, 
   uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
   const void* v_ptr, 
   uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* bias_ptr,
+  const void* alibi_slope_ptr,
   bool is_training,
   float scaling_factor,
   float dropout_probability,
   uint64_t philox_seed, uint64_t philox_offset,
+  BiasType attn_bias_type,
   MaskType attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   void* o_ptr, 
@@ -52,13 +63,15 @@ hipError_t ck_attn_fwd(
   
 hipError_t ck_attn_bwd(  
   DType dtype,
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
   const void* q_ptr, 
   uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
   const void* k_ptr, 
   uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
   const void* v_ptr, 
   uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* bias_ptr,
+  const void* alibi_slope_ptr,
   const void* o_ptr, 
   uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
   const void* lse_ptr, 
@@ -67,6 +80,7 @@ hipError_t ck_attn_bwd(
   float scaling_factor,
   float dropout_probability,
   uint64_t philox_seed, uint64_t philox_offset,
+  BiasType attn_bias_type,
   MaskType attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   void* dq_ptr, 
@@ -79,6 +93,7 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
   void* dv_ptr, 
   uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* dbias_ptr,
   void* workspace_ptr,
   hipStream_t stream);
 

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -13,6 +13,7 @@
 #include "bias.hpp"
 #include "mask.hpp"
 #include "fmha_bwd.hpp"
+#include "ck_fused_attn_utils.hpp"
 
 namespace ck_fused_attn{
 
@@ -83,13 +84,15 @@ switch (dtype) {                                            \
 
 hipError_t ck_attn_bwd(  
   DType dtype,
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
   const void* q_ptr, 
   uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
   const void* k_ptr, 
   uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
   const void* v_ptr, 
   uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* bias_ptr,
+  const void* alibi_slope_ptr,
   const void* o_ptr, 
   uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
   const void* lse_ptr, 
@@ -97,6 +100,7 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_do, uint64_t stride_h_do, uint64_t stride_s_do,
   float scaling_factor, float dropout_probability,
   uint64_t philox_seed, uint64_t philox_offset,
+  BiasType attn_bias_type,
   MaskType attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   void* dq_ptr, 
@@ -109,11 +113,12 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
   void* dv_ptr, 
   uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* dbias_ptr,
   void* workspace_ptr,
   hipStream_t stream){
 
   bool has_dropout = (dropout_probability > 0.f);
-  bool has_dbias = false;
+  bool has_dbias = dbias_ptr!=nullptr;
   bool is_mqa_gqa = (h > hg);
 
   /* CK input parameters */
@@ -133,11 +138,22 @@ hipError_t ck_attn_bwd(
   bool s_randval = false;
   bool is_deterministic = false;
 
-  bias_enum bias_type = bias_enum::no_bias;
-  mask_enum mask_type;
-  int32_t left, right;
-  ck_tile::stream_config stream_config{stream};
+  bias_enum bias_type;
+  BiasShape bias_shape; 
+  if (attn_bias_type==BiasType::no_bias){
+    bias_type = bias_enum::no_bias;
+  }else if (attn_bias_type==BiasType::elementwise_bias){
+    bias_type = bias_enum::elementwise_bias;
+    bias_shape = get_bias_shape(b, h, bias_b, bias_h);
+  }else if (attn_bias_type==BiasType::alibi){
+    bias_type = bias_enum::alibi;
+  }else{
+    //TODO: better error out system
+    throw std::runtime_error("Invalid bias_type in ck_fused_attn.");
+  }
 
+  mask_enum mask_type;
+  ck_tile::index_t left, right;
   if (attn_mask_type == MaskType::no_mask){
     mask_type = mask_enum::no_mask;
   }else if(attn_mask_type == MaskType::mask_top_left){
@@ -149,6 +165,8 @@ hipError_t ck_attn_bwd(
   }
   left = window_size_left;
   right = window_size_right;
+
+  ck_tile::stream_config stream_config{stream};
 
   ck_tile::index_t shape_seqlen_q = seqlen_q;
   ck_tile::index_t shape_seqlen_k = seqlen_k;
@@ -172,8 +190,8 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t stride_q = stride_s_q;
     const ck_tile::index_t stride_k = stride_s_k;
     const ck_tile::index_t stride_v = stride_s_v;
-    // TODO: support bias later
-    const ck_tile::index_t stride_bias = 0;
+    // bias of shape (bias_b, bias_h, s_q, s_kv)
+    const ck_tile::index_t stride_bias = max_seqlen_k;
     const ck_tile::index_t stride_o = stride_s_o;
     const ck_tile::index_t stride_randval = max_seqlen_k;
     const ck_tile::index_t stride_do = stride_s_do;
@@ -182,14 +200,13 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t stride_dv = stride_s_dv;
     const ck_tile::index_t stride_dkv_expanded = stride_s_dkv_expanded;
     const ck_tile::index_t stride_dq_acc = h*d; //dq_acc of shape (B, S, H, D)
-    // TODO: support bias later
-    const ck_tile::index_t stride_dbias = 0;
+    // dbias is of the same shape as bias
+    const ck_tile::index_t stride_dbias = max_seqlen_k;
     // setup nhead_stride_* arguments
     const ck_tile::index_t nhead_stride_q = stride_h_q;
     const ck_tile::index_t nhead_stride_k = stride_h_k;
     const ck_tile::index_t nhead_stride_v = stride_h_v;
-    // TODO: support bias later
-    const ck_tile::index_t nhead_stride_bias = 0;
+    const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
     const ck_tile::index_t nhead_stride_o = stride_h_o;
     const ck_tile::index_t nhead_stride_randval =
         shape_seqlen_q * max_seqlen_k;
@@ -200,13 +217,13 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t nhead_stride_dk = stride_h_dk;
     const ck_tile::index_t nhead_stride_dv = stride_h_dv;
     const ck_tile::index_t nhead_stride_dkv_expanded = stride_h_dkv_expanded;
-    const ck_tile::index_t nhead_stride_dbias = max_seqlen_k;
+    const ck_tile::index_t nhead_stride_dbias = nhead_stride_bias;
     const ck_tile::index_t nhead_stride_dq_acc = d; //dq_acc of shape (B, S, H, D)
     // setup batch_stride_* arguments
     const ck_tile::index_t batch_stride_q = stride_b_q;
     const ck_tile::index_t batch_stride_k = stride_b_k;
     const ck_tile::index_t batch_stride_v = stride_b_v;
-    const ck_tile::index_t batch_stride_bias = 0;
+    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: (bias_shape==BiasShape::kBHSS? bias_h* max_seqlen_q * max_seqlen_k: max_seqlen_q*max_seqlen_k);
     const ck_tile::index_t batch_stride_o = stride_b_o;
     const ck_tile::index_t batch_stride_randval =
         nhead * shape_seqlen_q * max_seqlen_k;
@@ -216,15 +233,14 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t batch_stride_dk = stride_b_dk;
     const ck_tile::index_t batch_stride_dv = stride_b_dv;
     const ck_tile::index_t batch_stride_dkv_expanded = stride_b_dkv_expanded;
-    const ck_tile::index_t batch_stride_dbias =
-        nhead * shape_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t batch_stride_dbias = batch_stride_bias;
     const ck_tile::index_t batch_stride_dq_acc = h*s_q*d; //dq_acc of shape (B, S, H, D)
     const ck_tile::index_t split_stride_dq_acc = b * h * s_q * d;
 
     return fmha_bwd_args{q_ptr,
                          k_ptr,
                          v_ptr,
-                         nullptr,
+                         bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr,
                          o_ptr,
                          lse_ptr,
                          do_ptr,
@@ -233,7 +249,7 @@ hipError_t ck_attn_bwd(
                          dq_ptr,
                          is_mqa_gqa? dk_expanded_ptr:dk_ptr,
                          is_mqa_gqa? dv_expanded_ptr:dv_ptr,
-                         nullptr, // dbias_ptr
+                         dbias_ptr,
                          dq_acc_ptr, //dq_acc_buf
                          nullptr,//cu_seqlen_q
                          nullptr,//cu_seqlen_kv
@@ -251,7 +267,7 @@ hipError_t ck_attn_bwd(
                          stride_q,
                          stride_k,
                          stride_v,
-                         stride_bias,
+                         bias_type==bias_enum::alibi? 0: stride_bias,
                          stride_o,
                          stride_randval,
                          stride_do,

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -66,6 +66,96 @@ __global__ void dk_dv_reduce(
   }
 }
 
+// define dbias_reduce functions only for fp16 and bf16 types
+template<typename DataType>
+__global__ void dbias_reduce_11ss(
+  uint64_t b, uint64_t h, uint64_t s_q, uint64_t s_kv,
+  const DataType *dbias_expanded,
+  DataType *dbias){
+  
+  const uint64_t stride_h = s_q*s_kv;
+  const uint64_t stride_b = h*s_q*s_kv;
+  for(uint64_t ss_idx = blockIdx.x*blockDim.x + threadIdx.x; ss_idx < s_q*s_kv; ss_idx += blockDim.x * gridDim.x){
+    //sum over b, h dims both
+    float sum_dbias = 0.0f;
+    for(uint64_t b_idx = 0; b_idx< b; b_idx++){
+      for(uint64_t h_idx = 0; h_idx < h; h_idx++){
+        if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+          // bf16 requires special casting in CK
+          sum_dbias += ck_tile::bf16_to_float(dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx]);
+        }else{
+          sum_dbias += dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx];
+        }
+      }
+    }
+    if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+      dbias[ss_idx] = ck_tile::float_to_bf16(sum_dbias);
+    }else{
+      dbias[ss_idx] = sum_dbias;
+    }
+  }
+}
+
+// define dbias_reduce functions only for fp16 and bf16 types
+template<typename DataType>
+__global__ void dbias_reduce_1hss(
+  uint64_t b, uint64_t h, uint64_t s_q, uint64_t s_kv,
+  const DataType *dbias_expanded,
+  DataType *dbias){
+  
+  const uint64_t stride_h = s_q*s_kv;
+  const uint64_t stride_b = h*s_q*s_kv;
+  for(uint64_t ss_idx = blockIdx.x*blockDim.x + threadIdx.x; ss_idx < s_q*s_kv; ss_idx += blockDim.x * gridDim.x){
+    for(uint64_t h_idx = 0; h_idx < h; h_idx++){
+      //sum over b dims only
+      float sum_dbias = 0.0f;
+      for(uint64_t b_idx = 0; b_idx< b; b_idx++){
+        if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+          // bf16 requires special casting in CK
+          sum_dbias += ck_tile::bf16_to_float(dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx]);
+        }else{
+          sum_dbias += dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx];
+        }
+      }
+      if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+        dbias[ss_idx + h_idx*stride_h] = ck_tile::float_to_bf16(sum_dbias);
+      }else{
+        dbias[ss_idx + h_idx*stride_h] = sum_dbias;
+      }
+    }
+  }
+}
+
+// define dbias_reduce functions only for fp16 and bf16 types
+template<typename DataType>
+__global__ void dbias_reduce_b1ss(
+  uint64_t b, uint64_t h, uint64_t s_q, uint64_t s_kv,
+  const DataType *dbias_expanded,
+  DataType *dbias){
+  
+  const uint64_t stride_h = s_q*s_kv;
+  const uint64_t stride_b = h*s_q*s_kv;
+  for(uint64_t ss_idx = blockIdx.x*blockDim.x + threadIdx.x; ss_idx < s_q*s_kv; ss_idx += blockDim.x * gridDim.x){
+    for(uint64_t b_idx = 0; b_idx< b; b_idx++){
+      //sum over h dims only
+      float sum_dbias = 0.0f;
+      for(uint64_t h_idx = 0; h_idx < h; h_idx++){
+        if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+          // bf16 requires special casting in CK
+          sum_dbias += ck_tile::bf16_to_float(dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx]);
+        }else{
+          sum_dbias += dbias_expanded[b_idx*stride_b + h_idx*stride_h+ss_idx];
+        }
+      }
+      if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+        dbias[ss_idx + b_idx*stride_h] = ck_tile::float_to_bf16(sum_dbias);
+      }else{
+        dbias[ss_idx + b_idx*stride_h] = sum_dbias;
+      }
+    }
+  }
+}
+
 #define CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, type, ...)   \
 switch (dtype) {                                            \
   case DType::kFloat16: {                                   \
@@ -113,6 +203,7 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
   void* dv_ptr, 
   uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* dbias_expanded_ptr,
   void* dbias_ptr,
   void* workspace_ptr,
   hipStream_t stream){
@@ -201,29 +292,33 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t stride_dkv_expanded = stride_s_dkv_expanded;
     const ck_tile::index_t stride_dq_acc = h*d; //dq_acc of shape (B, S, H, D)
     // dbias is of the same shape as bias
+    // but ck only take dbias with BHSS
     const ck_tile::index_t stride_dbias = max_seqlen_k;
     // setup nhead_stride_* arguments
     const ck_tile::index_t nhead_stride_q = stride_h_q;
     const ck_tile::index_t nhead_stride_k = stride_h_k;
     const ck_tile::index_t nhead_stride_v = stride_h_v;
+    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
     const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
     const ck_tile::index_t nhead_stride_o = stride_h_o;
     const ck_tile::index_t nhead_stride_randval =
         shape_seqlen_q * max_seqlen_k;
     const ck_tile::index_t nhead_stride_do = stride_h_do;
-    // TODO: buffer?
     const ck_tile::index_t nhead_stride_lsed = max_seqlen_q;
     const ck_tile::index_t nhead_stride_dq = stride_h_dq;
     const ck_tile::index_t nhead_stride_dk = stride_h_dk;
     const ck_tile::index_t nhead_stride_dv = stride_h_dv;
     const ck_tile::index_t nhead_stride_dkv_expanded = stride_h_dkv_expanded;
-    const ck_tile::index_t nhead_stride_dbias = nhead_stride_bias;
+    // dbias can only be of BHSS
+    const ck_tile::index_t nhead_stride_dbias = max_seqlen_q * max_seqlen_k;
     const ck_tile::index_t nhead_stride_dq_acc = d; //dq_acc of shape (B, S, H, D)
     // setup batch_stride_* arguments
     const ck_tile::index_t batch_stride_q = stride_b_q;
     const ck_tile::index_t batch_stride_k = stride_b_k;
     const ck_tile::index_t batch_stride_v = stride_b_v;
-    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: (bias_shape==BiasShape::kBHSS? bias_h* max_seqlen_q * max_seqlen_k: max_seqlen_q*max_seqlen_k);
+    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
+    // for B1SS and BHSS, batch stride for bias are both bias_h x s_q x s_kv (bias_h==1 for B1SS and bias_h == h for BHSS)
+    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: bias_h* max_seqlen_q * max_seqlen_k;
     const ck_tile::index_t batch_stride_o = stride_b_o;
     const ck_tile::index_t batch_stride_randval =
         nhead * shape_seqlen_q * max_seqlen_k;
@@ -233,14 +328,15 @@ hipError_t ck_attn_bwd(
     const ck_tile::index_t batch_stride_dk = stride_b_dk;
     const ck_tile::index_t batch_stride_dv = stride_b_dv;
     const ck_tile::index_t batch_stride_dkv_expanded = stride_b_dkv_expanded;
-    const ck_tile::index_t batch_stride_dbias = batch_stride_bias;
+    // for dbias, use h since h can be different from bias_h
+    const ck_tile::index_t batch_stride_dbias = h* max_seqlen_q * max_seqlen_k;
     const ck_tile::index_t batch_stride_dq_acc = h*s_q*d; //dq_acc of shape (B, S, H, D)
     const ck_tile::index_t split_stride_dq_acc = b * h * s_q * d;
 
     return fmha_bwd_args{q_ptr,
                          k_ptr,
                          v_ptr,
-                         bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr,
+                         bias_type==bias_enum::no_bias? nullptr : (bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr),
                          o_ptr,
                          lse_ptr,
                          do_ptr,
@@ -249,7 +345,7 @@ hipError_t ck_attn_bwd(
                          dq_ptr,
                          is_mqa_gqa? dk_expanded_ptr:dk_ptr,
                          is_mqa_gqa? dv_expanded_ptr:dv_ptr,
-                         dbias_ptr,
+                         has_dbias? (bias_shape==BiasShape::kBHSS ? dbias_ptr: dbias_expanded_ptr): nullptr,
                          dq_acc_ptr, //dq_acc_buf
                          nullptr,//cu_seqlen_q
                          nullptr,//cu_seqlen_kv
@@ -436,6 +532,50 @@ hipError_t ck_attn_bwd(
         static_cast<CK_TILE_TYPE*>(dk_ptr),
         static_cast<CK_TILE_TYPE*>(dv_ptr),
         stride_b_dk, stride_h_dk, stride_s_dk););
+  }
+  if(has_dbias && bias_shape!=BiasShape::kBHSS){
+    // reduction kernels required for 11SS, 1HSS, and B1SS
+    assert(dbias_ptr!=dbias_expanded_ptr);
+    constexpr int THREADS_PER_BLOCK = 1024;
+    dim3 block(THREADS_PER_BLOCK);
+    dim3 grid(ceil(1.0 * s_q * s_kv/THREADS_PER_BLOCK));
+    if(bias_shape==BiasShape::k11SS){
+      if (ck_fused_attn_log_config){
+        std::cout<<std::endl<<"run dbias_reduce_11SS: "<<std::endl;
+        std::cout<<"dbias_ptr: "<<dbias_ptr<<std::endl;
+        std::cout<<"dbias_expanded_ptr: "<<dbias_expanded_ptr<<std::endl;
+      }
+      CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
+        hipLaunchKernelGGL(
+          dbias_reduce_11ss<CK_TILE_TYPE>, grid, block, 0, stream,
+          b, h, s_q, s_kv,
+          static_cast<CK_TILE_TYPE*>(dbias_expanded_ptr),
+          static_cast<CK_TILE_TYPE*>(dbias_ptr));); 
+    }else if(bias_shape==BiasShape::k1HSS){
+      if (ck_fused_attn_log_config){
+        std::cout<<std::endl<<"run dbias_reduce_1HSS: "<<std::endl;
+        std::cout<<"dbias_ptr: "<<dbias_ptr<<std::endl;
+        std::cout<<"dbias_expanded_ptr: "<<dbias_expanded_ptr<<std::endl;
+      }
+      CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
+        hipLaunchKernelGGL(
+          dbias_reduce_1hss<CK_TILE_TYPE>, grid, block, 0, stream,
+          b, h, s_q, s_kv,
+          static_cast<CK_TILE_TYPE*>(dbias_expanded_ptr),
+          static_cast<CK_TILE_TYPE*>(dbias_ptr));); 
+    }else if(bias_shape==BiasShape::kB1SS){
+      if (ck_fused_attn_log_config){
+        std::cout<<std::endl<<"run dbias_reduce_B1SS: "<<std::endl;
+        std::cout<<"dbias_ptr: "<<dbias_ptr<<std::endl;
+        std::cout<<"dbias_expanded_ptr: "<<dbias_expanded_ptr<<std::endl;
+      }
+      CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
+        hipLaunchKernelGGL(
+          dbias_reduce_b1ss<CK_TILE_TYPE>, grid, block, 0, stream,
+          b, h, s_q, s_kv,
+          static_cast<CK_TILE_TYPE*>(dbias_expanded_ptr),
+          static_cast<CK_TILE_TYPE*>(dbias_ptr));); 
+    }
   }
   return hipSuccess;
 }

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -8,15 +8,17 @@
 
 namespace ck_fused_attn{
 BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h){
-  if(bias_b==1 && bias_h==1){
+  //identify BHSS with high priority to include scenaiors when b=1 and h=1
+  //reduce the chance of dbias_expand_ptr usage
+  if(bias_b==b && bias_h==h){
     // treat as 1 if b or h is 1
-    return BiasShape::k11SS;
+    return BiasShape::kBHSS;
   }else if(bias_b==1 && bias_h==h){
     return BiasShape::k1HSS;
   }else if(bias_b==b && bias_h==1){
     return BiasShape::kB1SS;
-  }else if(bias_b==b && bias_h==h){
-    return BiasShape::kBHSS;
+  }else if(bias_b==1 && bias_h==1){
+    return BiasShape::k11SS;
   }else{
     //should not happen
     throw std::runtime_error("Invalid bias_shape in ck_fused_attn.");

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -1,0 +1,27 @@
+/*************************************************************************
+ * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * License for AMD contributions = MIT. See LICENSE for more information
+ ************************************************************************/
+
+#include "ck_fused_attn_utils.hpp"
+
+namespace ck_fused_attn{
+BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h){
+  if(bias_b==1 && bias_h==1){
+    // treat as 1 if b or h is 1
+    return BiasShape::k11SS;
+  }else if(bias_b==1 && bias_h==h){
+    return BiasShape::k1HSS;
+  }else if(bias_b==b && bias_h==1){
+    return BiasShape::kB1SS;
+  }else if(bias_b==b && bias_h==h){
+    return BiasShape::kBHSS;
+  }else{
+    //should not happen
+    throw std::runtime_error("Invalid bias_shape in ck_fused_attn.");
+  }
+  return BiasShape::kNumBiasShapes;
+}
+
+}//namespace ck_fused_attn

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
@@ -1,0 +1,27 @@
+/*************************************************************************
+ * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * License for AMD contributions = MIT. See LICENSE for more information
+ ************************************************************************/
+
+#ifndef CK_FUSED_ATTN_UTILS_H
+#define CK_FUSED_ATTN_UTILS_H
+
+#include <iostream>
+#include<cstdint>
+
+namespace ck_fused_attn{
+
+// element-wise bias shape
+enum BiasShape{
+  k11SS = 0,
+  k1HSS = 1,
+  kB1SS = 2,
+  kBHSS = 3,
+  kNumBiasShapes  /*!< Number of supported bias shapes */
+};
+
+BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+
+}//namespace ck_fused_attn
+#endif // CK_FUSED_ATTN_UTILS_H

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.h
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.h
@@ -35,10 +35,10 @@ void fused_attn_aotriton_fwd_qkvpacked(
   size_t b, size_t h, size_t max_seqlen, size_t d,
   bool is_training, float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_QKV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  const Tensor* input_QKV,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -46,11 +46,11 @@ void fused_attn_aotriton_bwd_qkvpacked(
   size_t b, size_t h, size_t max_seqlen, size_t d,
   float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_QKV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* input_QKV, const Tensor* input_O, const Tensor* input_dO,
+  const Tensor* output_S,
   Tensor* output_dQKV,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 
@@ -58,11 +58,11 @@ void fused_attn_aotriton_fwd_kvpacked(
   size_t b, size_t h_q, size_t h_kv, size_t max_seqlen_q, size_t max_seqlen_kv, size_t d,
   bool is_training, float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  const Tensor* input_Q, const Tensor* input_KV,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -70,12 +70,12 @@ void fused_attn_aotriton_bwd_kvpacked(
   size_t b, size_t h_q, size_t h_kv, size_t max_seqlen_q, size_t max_seqlen_kv, size_t d,
   float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_O, const Tensor* input_dO,
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dKV,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 
@@ -83,11 +83,11 @@ void fused_attn_aotriton_fwd(
   size_t b, size_t h_q, size_t h_kv, size_t max_seqlen_q, size_t max_seqlen_kv, size_t d,
   bool is_training, float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -95,12 +95,12 @@ void fused_attn_aotriton_bwd(
   size_t b, size_t h_q, size_t h_kv, size_t max_seqlen_q, size_t max_seqlen_kv, size_t d,
   float attn_scale, float dropout, 
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
-  const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_O, const Tensor* input_dO, 
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dK, Tensor* output_dV,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 }  // namespace transformer_engine

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -113,8 +113,8 @@ bool is_ck_backend_supported(
     return false;
   }
   
-  // CK does not support bias now
-  if(!(bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)){
+  // CK does not support pre_scale bias
+  if(!(bias_type == NVTE_Bias_Type::NVTE_NO_BIAS || bias_type == NVTE_Bias_Type::NVTE_ALIBI || bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS)){
     if(nvte_log_ck_config){
       std::cout<<"CK fused attn does not support bias"<<std::endl;
     }
@@ -141,11 +141,20 @@ bool is_ck_backend_supported(
 
 
 #ifdef USE_FUSED_ATTN_CK
-ck_fused_attn::DType nvte_to_ck_dtype(NVTEDType t_dtype){
-#define CAST_TYPE(aname, dtname) if (t_dtype == NVTEDType::aname) return ck_fused_attn::DType::dtname
-  CAST_TYPE(kNVTEFloat16, kFloat16);
-  CAST_TYPE(kNVTEBFloat16, kBFloat16);
+ck_fused_attn::DType nvte_to_ck_dtype(DType t_dtype){
+#define CAST_TYPE(aname, dtname) if (t_dtype == DType::aname) return ck_fused_attn::DType::dtname
+  CAST_TYPE(kFloat16, kFloat16);
+  CAST_TYPE(kBFloat16, kBFloat16);
   return ck_fused_attn::DType::kNumTypes;
+#undef CAST_TYPE
+}
+
+ck_fused_attn::BiasType nvte_to_ck_bias_type(NVTE_Bias_Type t_bias_type){
+#define CAST_TYPE(aname, dtname) if (t_bias_type == NVTE_Bias_Type::aname) return ck_fused_attn::BiasType::dtname
+  CAST_TYPE(NVTE_NO_BIAS, no_bias);
+  CAST_TYPE(NVTE_POST_SCALE_BIAS, elementwise_bias);
+  CAST_TYPE(NVTE_ALIBI, alibi);
+  return ck_fused_attn::BiasType::no_bias;
 #undef CAST_TYPE
 }
 
@@ -175,14 +184,30 @@ ck_fused_attn::MaskType set_ck_mask(NVTE_Mask_Type nvte_mask_type, int64_t nvte_
   return ck_fused_attn::MaskType::window_generic;
 }
 
+__global__ 
+void generate_alibi_slope(uint64_t h, float* alibi_slope_ptr){
+  for(int id = blockIdx.x * blockDim.x + threadIdx.x; id < h; id += blockDim.x * gridDim.x){
+    int n = exp2(floor(log2(h)));
+    double m_0 = exp2(-8.0/n);
+    if(id < n){
+      //first n elements are pow(m_0, [1, 2, 3, ... n])
+      alibi_slope_ptr[id] = pow(m_0, id + 1);
+    }else{
+      double m_hat_0 = exp2(-4.0/n);
+      //(n+1, ... h) elements are pow(m_hat_0, [1, 3, 5, ...])
+      alibi_slope_ptr[id] = pow(m_hat_0, 1 + (id - n)*2);
+    }
+  }
+}
+
 // actual fwd implementation, calling ck api directly
 void fused_attn_ck_fwd_impl(
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
   bool is_training, float scaling_factor, float dropout_probability,
   NVTE_QKV_Layout layout,
   NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
   int64_t window_size_left, int64_t window_size_right,
-  void *devPtrQ, void *devPtrK, void *devPtrV, 
+  void *devPtrQ, void *devPtrK, void *devPtrV, void* devPtrBias,
   void *devPtrSoftmaxAux, void *devPtrO,
   const uint64_t* devPtrDropoutSeed, const uint64_t* devPtrDropoutOffset,
   //void* devPtrCuSeqlensQ, void* devPtrCuSeqlensKV,
@@ -195,6 +220,10 @@ void fused_attn_ck_fwd_impl(
   // Currently ck fused attn does not need workspace in fwd pass
   if(workspace==nullptr){
     *workspace_size = 0;
+    // ck requires an alibi slope array even if in standard (vanilla) mode
+    if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
+      (*workspace_size)+= h*sizeof(float);
+    }
     return;
   }
 
@@ -223,6 +252,16 @@ void fused_attn_ck_fwd_impl(
     cudaMemcpy(&philox_seed, devPtrDropoutSeed, sizeof(uint64_t), cudaMemcpyDeviceToHost);
     cudaMemcpy(&philox_offset, devPtrDropoutOffset, sizeof(uint64_t), cudaMemcpyDeviceToHost);
   }
+  
+  void* devPtrAlibiSlope = nullptr;
+  if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
+    devPtrAlibiSlope = workspace;
+    dim3 block, grid;
+    block.x = 1024;
+    grid.x = ceil(h/1024.);
+    //assign standard alibi slope
+    hipLaunchKernelGGL(generate_alibi_slope, grid, block, 0, stream, h, static_cast<float*>(devPtrAlibiSlope));
+  }
 
   bool nvte_log_ck_config = false;
   if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
@@ -244,6 +283,8 @@ void fused_attn_ck_fwd_impl(
     std::cout<<"is_training: "<<is_training<<", ";
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed: "<<philox_seed<<", philox_offset: "<<philox_offset<<", ";
+    std::cout<<"bias_type: "<<bias_type<<std::endl;
+    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<", ";
     std::cout<<"mask_type: "<<mask_type<<std::endl;
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
   }
@@ -251,15 +292,18 @@ void fused_attn_ck_fwd_impl(
   NVTE_CHECK_CUDA(
     ck_attn_fwd(
       dtype,
-      b, h, hg, s_q, s_kv, d,
+      b, h, hg, s_q, s_kv, d, bias_b, bias_h,
       devPtrQ, 
       q_stride[0], q_stride[1], q_stride[2],
       devPtrK, 
       k_stride[0], k_stride[1], k_stride[2],
       devPtrV, 
       v_stride[0], v_stride[1], v_stride[2],
+      devPtrBias,
+      devPtrAlibiSlope,
       is_training, scaling_factor, dropout_probability,
       philox_seed, philox_offset,
+      nvte_to_ck_bias_type(bias_type),
       set_ck_mask(mask_type, window_size_left, window_size_right),
       window_size_left, window_size_right,
       devPtrO,
@@ -281,15 +325,16 @@ size_t ck_dtype_size(ck_fused_attn::DType t_dtype){
 }
 
 void fused_attn_ck_bwd_impl(
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
   float scaling_factor, float dropout_probability, 
   NVTE_QKV_Layout layout,
   NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
   int64_t window_size_left, int64_t window_size_right,
   void* devPtrQ, void* devPtrK, void* devPtrV,
-  void* devPtrO, void* devPtrSoftmaxAux, 
+  void* devPtrO, void* devPtrSoftmaxAux, void* devPtrBias,
   void* devPtrdQ, void* devPtrdK, void* devPtrdV, 
   void* devPtrdO, 
+  void* devPtrdBias,
   const uint64_t* devPtrDropoutSeed, 
   const uint64_t* devPtrDropoutOffset,
   ck_fused_attn::DType dtype,
@@ -309,6 +354,10 @@ void fused_attn_ck_bwd_impl(
       // allocate dk, dv (or dkv) as if h=hg
       size_t dkv_expanded_size = 2*b*h*s_kv*d*ck_dtype_size(dtype);
       *workspace_size += dkv_expanded_size;
+    }
+    // ck requires an alibi slope array even if in standard (vanilla) mode
+    if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
+      (*workspace_size)+= h*sizeof(float);
     }
     return;
   }
@@ -348,8 +397,9 @@ void fused_attn_ck_bwd_impl(
     cudaMemcpy(&philox_seed, devPtrDropoutSeed, sizeof(uint64_t), cudaMemcpyDeviceToHost);
     cudaMemcpy(&philox_offset, devPtrDropoutOffset, sizeof(uint64_t), cudaMemcpyDeviceToHost);
   }
+
   // First b*h*sq*sizeof(float) in workspace are for lse
-  // The remaining are for dq_acc_ptr
+  // The next section are for dq_acc_ptr
   void* dq_acc_ptr = static_cast<void *>(static_cast<int8_t*>(workspace) + b*h*s_q*sizeof(float));
   // like dq, dq_acc mem also requires zeroing out
   //dq_acc is of shape (B, S, H, D)
@@ -382,6 +432,28 @@ void fused_attn_ck_bwd_impl(
     NVTE_CHECK_CUDA(cudaMemsetAsync(dk_expanded_ptr, 0, 2*ck_dtype_size(dtype)*b*h*s_kv*d, stream));
   }
 
+  void* devPtrAlibiSlope = nullptr;
+  if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
+    // alibi slope is the last section in the workspace buffer
+    if(is_mqa_gqa){
+      devPtrAlibiSlope = static_cast<void *>(static_cast<int8_t*>(dk_expanded_ptr) + 2*b*h*s_kv*d*ck_dtype_size(dtype));
+    }else{
+      // devPtrAlibiSlope at the end of dq_acc_ptr if no mqa/gqa temp buffer needed
+      devPtrAlibiSlope = static_cast<void *>(static_cast<int8_t*>(dq_acc_ptr) + b*h*s_q*d*sizeof(float));
+    }
+
+    dim3 block, grid;
+    block.x = 1024;
+    grid.x = ceil(h/1024.);
+    //assign standard alibi slope
+    hipLaunchKernelGGL(generate_alibi_slope, grid, block, 0, stream, h, static_cast<float*>(devPtrAlibiSlope));
+  }
+  
+  if(devPtrdBias!=nullptr){
+    // zero out dbias
+    NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdBias, 0, ck_dtype_size(dtype)*bias_b*bias_h*s_q*s_kv, stream));
+  }
+
   bool nvte_log_ck_config = false;
   if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
     if (env_p != nullptr && std::string(env_p) == "1")
@@ -401,6 +473,8 @@ void fused_attn_ck_bwd_impl(
     std::cout<<"o_stride: ("<<o_stride[0]<<", "<<o_stride[1]<<", "<<o_stride[2]<<", "<<o_stride[3]<<"), ";
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed: "<<philox_seed<<", philox_offset: "<<philox_offset<<", ";
+    std::cout<<"bias_type: "<<bias_type<<std::endl;
+    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<", ";
     std::cout<<"mask_type: "<<mask_type<<std::endl;
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
   }
@@ -408,13 +482,15 @@ void fused_attn_ck_bwd_impl(
   NVTE_CHECK_CUDA(
     ck_attn_bwd(
       dtype,
-      b, h, hg, s_q, s_kv, d,
+      b, h, hg, s_q, s_kv, d, bias_b, bias_h,
       devPtrQ,
       q_stride[0], q_stride[1], q_stride[2],
       devPtrK,
       k_stride[0], k_stride[1], k_stride[2],
       devPtrV,
       v_stride[0], v_stride[1], v_stride[2],
+      devPtrBias,
+      devPtrAlibiSlope,
       devPtrO,
       o_stride[0], o_stride[1], o_stride[2],
       devPtrSoftmaxAux,
@@ -422,6 +498,7 @@ void fused_attn_ck_bwd_impl(
       o_stride[0], o_stride[1], o_stride[2], //dO and O share the same stride
       scaling_factor, dropout_probability,
       philox_seed, philox_offset,
+      nvte_to_ck_bias_type(bias_type),
       set_ck_mask(mask_type, window_size_left, window_size_right),
       window_size_left, window_size_right,
       devPtrdQ,
@@ -434,6 +511,7 @@ void fused_attn_ck_bwd_impl(
       k_stride[0], k_stride[1], k_stride[2], //dK and K share the same stride
       devPtrdV,
       v_stride[0], v_stride[1], v_stride[2], //dV and V share the same stride
+      devPtrdBias,
       workspace,
       stream));
 }
@@ -447,14 +525,14 @@ void fused_attn_ck_fwd_qkvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_QKV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream){
 
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType QKV_type = static_cast<NVTEDType>(input_QKV->data.dtype);
+  const DType QKV_type = input_QKV->data.dtype;
   void *devPtrQKV = input_QKV->data.dptr;
   // determine the stride based on qkv layout
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
@@ -468,21 +546,71 @@ void fused_attn_ck_fwd_qkvpacked(
   void *devPtrK = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + stride);
   void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + 2 * stride);
 
-  //save the input rng state to Aux_CTX_Tensors
-  output_rng_state->data.dptr = input_rng_state->data.dptr;
+  void *devPtrBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    bias_b = input_Bias->data.shape[0];
+    bias_h = input_Bias->data.shape[1];
+  }
+  void *devPtrO = output_O->data.dptr;
+  void *devPtrS = nullptr;
+
+  if (Aux_CTX_Tensors->size == 0) {
+    if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
+      Aux_CTX_Tensors->size = 3;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h, max_seqlen, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+      Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+      output_bias->data.dptr = nullptr;
+      output_bias->data.shape = {bias_b, bias_h, max_seqlen, max_seqlen};
+      output_bias->data.dtype = QKV_type;
+    } else {
+      Aux_CTX_Tensors->size = 2;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h, max_seqlen, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+    }
+  } else if (Aux_CTX_Tensors->size == 2) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+  } else if (Aux_CTX_Tensors->size == 3) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+    Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+    output_bias->data.dptr = devPtrBias;
+  } else {
+    NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
+  }
 
   size_t workspace_size = 0;
 
   fused_attn_ck_fwd_impl(
-    b, h, h, max_seqlen, max_seqlen, d,
+    b, h, h, max_seqlen, max_seqlen, d, bias_b, bias_h,
     is_training, attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
-    devPtrQ, devPtrK, devPtrV, 
-    output_M->data.dptr, output_O->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
+    devPtrQ, devPtrK, devPtrV, devPtrBias,
+    devPtrS, devPtrO,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -512,15 +640,16 @@ void fused_attn_ck_bwd_qkvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_QKV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQKV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream){
 
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType QKV_type = static_cast<NVTEDType>(input_QKV->data.dtype);
+  const DType QKV_type = input_QKV->data.dtype;
   //input tensor
   void *devPtrQKV = input_QKV->data.dptr;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
@@ -533,6 +662,20 @@ void fused_attn_ck_bwd_qkvpacked(
   void *devPtrQ = static_cast<void *>(devPtrQKV);
   void *devPtrK = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + stride);
   void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + 2 * stride);
+  void *devPtrSoftmaxStats = output_S->data.dptr;
+
+  void *devPtrO = input_O->data.dptr;
+  void *devPtrdO = input_dO->data.dptr;
+  void *devPtrBias = nullptr;
+  void *devPtrdBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    devPtrdBias = output_dBias->data.dptr;
+    bias_b = output_dBias->data.shape[0];
+    bias_h = output_dBias->data.shape[1];
+  }
 
   // output tensor
   void *devPtrdQKV = output_dQKV->data.dptr;
@@ -543,17 +686,17 @@ void fused_attn_ck_bwd_qkvpacked(
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
-    b, h, h, max_seqlen, max_seqlen, d,
+    b, h, h, max_seqlen, max_seqlen, d, bias_b, bias_h,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
     devPtrQ, devPtrK, devPtrV, 
-    input_O->data.dptr, input_M->data.dptr,
+    devPtrO, devPtrSoftmaxStats, devPtrBias,
     devPtrdQ, devPtrdK, devPtrdV, 
-    input_dO->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
+    devPtrdO, devPtrdBias,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -583,44 +726,94 @@ void fused_attn_ck_fwd_kvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream){
 
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType Q_type = static_cast<NVTEDType>(input_Q->data.dtype);
-  const NVTEDType KV_type = static_cast<NVTEDType>(input_KV->data.dtype);
+  const DType QKV_type = input_Q->data.dtype;
   //input tensor
+  void *devPtrQ = input_Q->data.dptr;
   void *devPtrKV = input_KV->data.dptr;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   size_t stride = 0;
   if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_2HD) {
-    stride = nvte_dtype_size(Q_type)*h_kv*d;
+    stride = nvte_dtype_size(QKV_type)*h_kv*d;
   } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_H2D) {
-    stride = nvte_dtype_size(Q_type) * d;
+    stride = nvte_dtype_size(QKV_type) * d;
   }
   void *devPtrK = devPtrKV;
   void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrKV) + stride);
 
-  //save the input rng state to Aux_CTX_Tensors
-  output_rng_state->data.dptr = input_rng_state->data.dptr;
+  void *devPtrBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    bias_b = input_Bias->data.shape[0];
+    bias_h = input_Bias->data.shape[1];
+  }
+  void *devPtrO = output_O->data.dptr;
+  void *devPtrS = nullptr;
+
+  if (Aux_CTX_Tensors->size == 0) {
+    if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
+      Aux_CTX_Tensors->size = 3;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h_q, max_seqlen_q, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+      Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+      output_bias->data.dptr = nullptr;
+      output_bias->data.shape = {bias_b, bias_h, max_seqlen_q, max_seqlen_kv};
+      output_bias->data.dtype = QKV_type;
+    } else {
+      Aux_CTX_Tensors->size = 2;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h_q, max_seqlen_q, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+    }
+  } else if (Aux_CTX_Tensors->size == 2) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+  } else if (Aux_CTX_Tensors->size == 3) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+    Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+    output_bias->data.dptr = devPtrBias;
+  } else {
+    NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
+  }
   
   size_t workspace_size = 0;
 
   fused_attn_ck_fwd_impl(
-    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d,
+    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
     is_training, attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
-    input_Q->data.dptr, devPtrK, devPtrV, 
-    output_M->data.dptr, output_O->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
-    nvte_to_ck_dtype(Q_type),
+    devPtrQ, devPtrK, devPtrV, devPtrBias,
+    devPtrS, devPtrO,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
+    nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
     stream);
@@ -649,48 +842,64 @@ void fused_attn_ck_bwd_kvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dKV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream){
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType Q_type = static_cast<NVTEDType>(input_Q->data.dtype);
-  const NVTEDType KV_type = static_cast<NVTEDType>(input_KV->data.dtype);
+  const DType QKV_type = input_Q->data.dtype;
   //input tensor
+  void *devPtrQ = input_Q->data.dptr;
   void *devPtrKV = input_KV->data.dptr;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   size_t stride = 0;
   if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_2HD) {
-    stride = nvte_dtype_size(Q_type) * h_kv * d;
+    stride = nvte_dtype_size(QKV_type) * h_kv * d;
   } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_H2D) {
-    stride = nvte_dtype_size(Q_type) * d;
+    stride = nvte_dtype_size(QKV_type) * d;
   }
   void *devPtrK = devPtrKV;
   void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrKV) + stride);
 
+  void *devPtrO = input_O->data.dptr;
+  void *devPtrdO = input_dO->data.dptr;
+  void *devPtrBias = nullptr;
+  void *devPtrdBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    devPtrdBias = output_dBias->data.dptr;
+    bias_b = output_dBias->data.shape[0];
+    bias_h = output_dBias->data.shape[1];
+  }
   // output tensor
+  void *devPtrdQ = output_dQ->data.dptr;
   void *devPtrdKV = output_dKV->data.dptr;
   void *devPtrdK = devPtrdKV;
   void *devPtrdV = static_cast<void *>(static_cast<int8_t *>(devPtrdKV) + stride);
 
+  void *devPtrSoftmaxStats = output_S->data.dptr;
+
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
-    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d,
+    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
-    input_Q->data.dptr, devPtrK, devPtrV, 
-    input_O->data.dptr, input_M->data.dptr,
-    output_dQ->data.dptr, devPtrdK, devPtrdV, 
-    input_dO->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
-    nvte_to_ck_dtype(Q_type),
+    devPtrQ, devPtrK, devPtrV, 
+    devPtrO, devPtrSoftmaxStats, devPtrBias,
+    devPtrdQ, devPtrdK, devPtrdV, 
+    devPtrdO, devPtrdBias,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
+    nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
     stream);
@@ -719,32 +928,84 @@ void fused_attn_ck_fwd(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream){
 
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType Q_type = static_cast<NVTEDType>(input_Q->data.dtype);
-  const NVTEDType KV_type = static_cast<NVTEDType>(input_K->data.dtype);
-  //save the input rng state to Aux_CTX_Tensors
-  output_rng_state->data.dptr = input_rng_state->data.dptr;
+  const DType QKV_type = input_Q->data.dtype;
 
+  void *devPtrQ = input_Q->data.dptr;
+  void *devPtrK = input_K->data.dptr;
+  void *devPtrV = input_V->data.dptr;
+  void *devPtrO = output_O->data.dptr;
+  void *devPtrS = nullptr;
+  void *devPtrBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    bias_b = input_Bias->data.shape[0];
+    bias_h = input_Bias->data.shape[1];
+  }
+
+  if (Aux_CTX_Tensors->size == 0) {
+    if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
+      Aux_CTX_Tensors->size = 3;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h_q, max_seqlen_q, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+      Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+      output_bias->data.dptr = nullptr;
+      output_bias->data.shape = {bias_b, bias_h, max_seqlen_q, max_seqlen_kv};
+      output_bias->data.dtype = QKV_type;
+    } else {
+      Aux_CTX_Tensors->size = 2;
+      Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+      output_S->data.dptr = nullptr;
+      output_S->data.shape = {b, h_q, max_seqlen_q, 1};
+      output_S->data.dtype = DType::kFloat32;
+      Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+      output_rng_state->data.dptr = nullptr;
+      output_rng_state->data.shape = {2};
+      output_rng_state->data.dtype = DType::kInt64;
+    }
+  } else if (Aux_CTX_Tensors->size == 2) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+  } else if (Aux_CTX_Tensors->size == 3) {
+    Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
+    devPtrS = output_S->data.dptr;
+    Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
+    output_rng_state->data.dptr = rng_state->data.dptr;
+    Tensor *output_bias = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[2]);
+    output_bias->data.dptr = devPtrBias;
+  } else {
+    NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
+  }
   size_t workspace_size = 0;
 
   fused_attn_ck_fwd_impl(
-    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d,
+    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
     is_training, attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
-    input_Q->data.dptr, input_K->data.dptr, input_V->data.dptr, 
-    output_M->data.dptr, output_O->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
-    nvte_to_ck_dtype(Q_type),
+    devPtrQ, devPtrK, devPtrV, devPtrBias, 
+    devPtrS, devPtrO,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
+    nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
     stream);
@@ -773,32 +1034,53 @@ void fused_attn_ck_bwd(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dK, Tensor* output_dV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream){
 #ifdef USE_FUSED_ATTN_CK
-  const NVTEDType Q_type = static_cast<NVTEDType>(input_Q->data.dtype);
-  const NVTEDType KV_type = static_cast<NVTEDType>(input_K->data.dtype);
+  const DType QKV_type = input_Q->data.dtype;
+
+  void *devPtrQ = input_Q->data.dptr;
+  void *devPtrK = input_K->data.dptr;
+  void *devPtrV = input_V->data.dptr;
+  void *devPtrO = input_O->data.dptr;
+  void *devPtrdO = input_dO->data.dptr;
+  void *devPtrBias = nullptr;
+  void *devPtrdBias = nullptr;
+  size_t bias_b = 0;
+  size_t bias_h = 0;
+  if ((bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) && (bias_type != NVTE_Bias_Type::NVTE_ALIBI)) {
+    devPtrBias = input_Bias->data.dptr;
+    devPtrdBias = output_dBias->data.dptr;
+    bias_b = output_dBias->data.shape[0];
+    bias_h = output_dBias->data.shape[1];
+  }
+
+  void *devPtrdQ = output_dQ->data.dptr;
+  void *devPtrdK = output_dK->data.dptr;
+  void *devPtrdV = output_dV->data.dptr;
+  void *devPtrSoftmaxStats = output_S->data.dptr;
 
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
-    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d,
+    b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
     window_size_left, window_size_right,
-    input_Q->data.dptr, input_K->data.dptr, input_V->data.dptr, 
-    input_O->data.dptr, input_M->data.dptr,
-    output_dQ->data.dptr, output_dK->data.dptr, output_dV->data.dptr, 
-    input_dO->data.dptr,
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr), 
-    reinterpret_cast<const uint64_t *>(input_rng_state->data.dptr) + 1,
-    nvte_to_ck_dtype(Q_type),
+    devPtrQ, devPtrK, devPtrV, 
+    devPtrO, devPtrSoftmaxStats, devPtrBias,
+    devPtrdQ, devPtrdK, devPtrdV, 
+    devPtrdO, devPtrdBias,
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr), 
+    reinterpret_cast<const uint64_t *>(rng_state->data.dptr) + 1,
+    nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
     stream);

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -216,6 +216,11 @@ void fused_attn_ck_fwd_impl(
   size_t *workspace_size,
   cudaStream_t stream){
 
+  bool nvte_log_ck_config = false;
+  if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
+    if (env_p != nullptr && std::string(env_p) == "1")
+      nvte_log_ck_config = true;
+  }
   // Exit to request upper level API to allocate memory if needed
   // Currently ck fused attn does not need workspace in fwd pass
   if(workspace==nullptr){
@@ -223,6 +228,10 @@ void fused_attn_ck_fwd_impl(
     // ck requires an alibi slope array even if in standard (vanilla) mode
     if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
       (*workspace_size)+= h*sizeof(float);
+    }
+
+    if (nvte_log_ck_config) {
+      std::cout<<std::endl<<"attn_fwd(ck) requested workspace of size "<<*workspace_size<<std::endl;
     }
     return;
   }
@@ -262,12 +271,7 @@ void fused_attn_ck_fwd_impl(
     //assign standard alibi slope
     hipLaunchKernelGGL(generate_alibi_slope, grid, block, 0, stream, h, static_cast<float*>(devPtrAlibiSlope));
   }
-
-  bool nvte_log_ck_config = false;
-  if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
-    if (env_p != nullptr && std::string(env_p) == "1")
-      nvte_log_ck_config = true;
-  }
+  
   if (nvte_log_ck_config) {
     std::cout<<std::endl<<"attn_fwd(ck): ";
     std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
@@ -342,6 +346,12 @@ void fused_attn_ck_bwd_impl(
   size_t *workspace_size,
   cudaStream_t stream) {
   
+  bool nvte_log_ck_config = false;
+  if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
+    if (env_p != nullptr && std::string(env_p) == "1")
+      nvte_log_ck_config = true;
+  } 
+
   bool is_mqa_gqa = (h > hg);
 
   // Exit to request upper level API to allocate memory if needed
@@ -358,9 +368,12 @@ void fused_attn_ck_bwd_impl(
     // ck requires an alibi slope array even if in standard (vanilla) mode
     if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
       (*workspace_size)+= h*sizeof(float);
-    }else if ((bias_type==NVTE_Bias_Type::NVTE_POST_SCALE_BIAS) && (devPtrdBias!=nullptr) && (bias_b!=b or bias_h!=h)){
+    }else if ((bias_type==NVTE_Bias_Type::NVTE_POST_SCALE_BIAS) && (bias_b!=b or bias_h!=h)){
       //ck requires a buffer dbias_expanded of size BHSS if bias is not BHSS
       (*workspace_size) += b*h*s_q*s_kv*ck_dtype_size(dtype);
+    }
+    if (nvte_log_ck_config) {
+      std::cout<<std::endl<<"attn_bwd(ck) requested workspace of size "<<*workspace_size<<std::endl;
     }
     return;
   }
@@ -466,12 +479,7 @@ void fused_attn_ck_bwd_impl(
       NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdBias, 0, ck_dtype_size(dtype)*bias_b*bias_h*s_q*s_kv, stream));
     }
   }
-  
-  bool nvte_log_ck_config = false;
-  if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
-    if (env_p != nullptr && std::string(env_p) == "1")
-      nvte_log_ck_config = true;
-  }
+ 
   if (nvte_log_ck_config) {
     std::cout<<std::endl<<"attn_bwd(ck): ";
     std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -116,7 +116,7 @@ bool is_ck_backend_supported(
   // CK does not support pre_scale bias
   if(!(bias_type == NVTE_Bias_Type::NVTE_NO_BIAS || bias_type == NVTE_Bias_Type::NVTE_ALIBI || bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS)){
     if(nvte_log_ck_config){
-      std::cout<<"CK fused attn does not support bias"<<std::endl;
+      std::cout<<"CK fused attn does not support pre_scale bias"<<std::endl;
     }
     return false;
   }
@@ -284,7 +284,7 @@ void fused_attn_ck_fwd_impl(
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed: "<<philox_seed<<", philox_offset: "<<philox_offset<<", ";
     std::cout<<"bias_type: "<<bias_type<<std::endl;
-    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<", ";
+    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<"), ";
     std::cout<<"mask_type: "<<mask_type<<std::endl;
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
   }
@@ -358,6 +358,9 @@ void fused_attn_ck_bwd_impl(
     // ck requires an alibi slope array even if in standard (vanilla) mode
     if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
       (*workspace_size)+= h*sizeof(float);
+    }else if ((bias_type==NVTE_Bias_Type::NVTE_POST_SCALE_BIAS) && (devPtrdBias!=nullptr) && (bias_b!=b or bias_h!=h)){
+      //ck requires a buffer dbias_expanded of size BHSS if bias is not BHSS
+      (*workspace_size) += b*h*s_q*s_kv*ck_dtype_size(dtype);
     }
     return;
   }
@@ -405,7 +408,6 @@ void fused_attn_ck_bwd_impl(
   //dq_acc is of shape (B, S, H, D)
   NVTE_CHECK_CUDA(cudaMemsetAsync(dq_acc_ptr, 0, sizeof(float)*b*h*s_q*d, stream));
   
-  // TODO: temporary patch for mqa/gqa, remove once CK support stride specification directly
   void* dk_expanded_ptr = nullptr;
   void* dv_expanded_ptr = nullptr;
   std::array<uint64_t, 4> dkv_expanded_stride;
@@ -433,6 +435,7 @@ void fused_attn_ck_bwd_impl(
   }
 
   void* devPtrAlibiSlope = nullptr;
+  void* dbias_expanded_ptr = nullptr;
   if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
     // alibi slope is the last section in the workspace buffer
     if(is_mqa_gqa){
@@ -447,13 +450,23 @@ void fused_attn_ck_bwd_impl(
     grid.x = ceil(h/1024.);
     //assign standard alibi slope
     hipLaunchKernelGGL(generate_alibi_slope, grid, block, 0, stream, h, static_cast<float*>(devPtrAlibiSlope));
+  }else if((bias_type==NVTE_Bias_Type::NVTE_POST_SCALE_BIAS) && (devPtrdBias!=nullptr)){
+    if(bias_b!=b or bias_h!= h){
+      // dbias_expanded_ptr is the last section in the workspace buffer
+      if(is_mqa_gqa){
+        dbias_expanded_ptr = static_cast<void *>(static_cast<int8_t*>(dk_expanded_ptr) + 2*b*h*s_kv*d*ck_dtype_size(dtype));
+      }else{
+        // devPtrAlibiSlope at the end of dq_acc_ptr if no mqa/gqa temp buffer needed
+        dbias_expanded_ptr = static_cast<void *>(static_cast<int8_t*>(dq_acc_ptr) + b*h*s_q*d*sizeof(float));
+      }
+      // zeroing out dbias_expanded_ptr as CK requires that
+      NVTE_CHECK_CUDA(cudaMemsetAsync(dbias_expanded_ptr, 0, ck_dtype_size(dtype)*b*h*s_q*s_kv, stream));
+    }else{
+      // dbias_expanded_ptr not needed for BHSS shape
+      NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdBias, 0, ck_dtype_size(dtype)*bias_b*bias_h*s_q*s_kv, stream));
+    }
   }
   
-  if(devPtrdBias!=nullptr){
-    // zero out dbias
-    NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdBias, 0, ck_dtype_size(dtype)*bias_b*bias_h*s_q*s_kv, stream));
-  }
-
   bool nvte_log_ck_config = false;
   if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
     if (env_p != nullptr && std::string(env_p) == "1")
@@ -474,7 +487,7 @@ void fused_attn_ck_bwd_impl(
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed: "<<philox_seed<<", philox_offset: "<<philox_offset<<", ";
     std::cout<<"bias_type: "<<bias_type<<std::endl;
-    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<", ";
+    std::cout<<"(bias_b, bias_h): ("<<bias_b<<", "<<bias_h<<"), ";
     std::cout<<"mask_type: "<<mask_type<<std::endl;
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
   }
@@ -511,6 +524,7 @@ void fused_attn_ck_bwd_impl(
       k_stride[0], k_stride[1], k_stride[2], //dK and K share the same stride
       devPtrdV,
       v_stride[0], v_stride[1], v_stride[2], //dV and V share the same stride
+      dbias_expanded_ptr,
       devPtrdBias,
       workspace,
       stream));

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.h
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.h
@@ -35,9 +35,9 @@ void fused_attn_ck_fwd_qkvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_QKV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -47,10 +47,11 @@ void fused_attn_ck_bwd_qkvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_QKV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQKV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 
@@ -60,10 +61,10 @@ void fused_attn_ck_fwd_kvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -73,11 +74,12 @@ void fused_attn_ck_bwd_kvpacked(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_KV, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dKV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 
@@ -87,10 +89,10 @@ void fused_attn_ck_fwd(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_Bias, 
-  Tensor* output_O, Tensor* output_M, Tensor* output_rng_state,
+  Tensor* output_O, NVTETensorPack *Aux_CTX_Tensors,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor *workspace,
   cudaStream_t stream);
 
@@ -100,11 +102,12 @@ void fused_attn_ck_bwd(
   NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type, NVTE_Mask_Type attn_mask_type,
   int64_t window_size_left, int64_t window_size_right,
   const Tensor* input_Q, const Tensor* input_K, const Tensor* input_V, const Tensor* input_O, const Tensor* input_dO, const Tensor* input_Bias, 
+  const Tensor* output_S,
   Tensor* output_dQ, Tensor* output_dK, Tensor* output_dV,
+  Tensor* output_dBias,
   const Tensor* input_cu_seqlens_q,
   const Tensor* input_cu_seqlens_kv,
-  const Tensor* input_M,
-  const Tensor* input_rng_state,
+  const Tensor* rng_state,
   Tensor* workspace,
   cudaStream_t stream);
 }  // namespace transformer_engine

--- a/transformer_engine/common/fused_attn_rocm/utils.cpp
+++ b/transformer_engine/common/fused_attn_rocm/utils.cpp
@@ -13,22 +13,22 @@ namespace fused_attn_rocm {
 
 using namespace transformer_engine;
 
-size_t nvte_dtype_size(NVTEDType t_dtype){
+size_t nvte_dtype_size(DType t_dtype){
   switch(t_dtype){
-    case NVTEDType::kNVTEByte: 
+    case DType::kByte: 
       return 1;
-    case NVTEDType::kNVTEInt32: 
+    case DType::kInt32: 
       return 4;
-    case NVTEDType::kNVTEInt64: 
+    case DType::kInt64: 
       return 8;
-    case NVTEDType::kNVTEFloat32: 
+    case DType::kFloat32: 
       return 4;
-    case NVTEDType::kNVTEFloat16: 
+    case DType::kFloat16: 
       return 2;
-    case NVTEDType::kNVTEBFloat16: 
+    case DType::kBFloat16: 
       return 2;
-    case NVTEDType::kNVTEFloat8E4M3: 
-    case NVTEDType::kNVTEFloat8E5M2: 
+    case DType::kFloat8E4M3: 
+    case DType::kFloat8E5M2: 
       return 1;
     default:
       return 1;

--- a/transformer_engine/common/fused_attn_rocm/utils.h
+++ b/transformer_engine/common/fused_attn_rocm/utils.h
@@ -34,7 +34,7 @@ void generateMatrixStrides(
             uint64_t d, uint64_t* stride,
             NVTE_QKV_Layout layout, NVTE_QKV_Matrix matrix);
 
-size_t nvte_dtype_size(NVTEDType t_dtype);
+size_t nvte_dtype_size(DType t_dtype);
 
 
 }  // namespace fused_attn_rocm

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -550,6 +550,7 @@ def get_attention_backend(
             fu_core_attention_bias_shape = "bhss"
 
     if (
+        not IS_HIP_EXTENSION and
         use_fused_attention
         and fu_core_attention_bias_type == "post_scale_bias"
         and fu_core_attention_bias_shape != "1hss"
@@ -562,6 +563,14 @@ def get_attention_backend(
         else:
             # max512 backend will only support [1, h, s, s]
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
+    if (
+        IS_HIP_EXTENSION and
+        use_fused_attention
+        and fu_core_attention_bias_type == "post_scale_bias"
+    ):
+        if fu_core_attention_bias_shape not in ["11ss", "1hss", "b1ss", "bhss"]:
+            logger.debug("Disabling ROCm FusedAttention for Bias shape not in 11ss, 1hss, b1ss, bhss")
+            use_fused_attention = False
 
     # Filter: cuDNN support
     fused_attention_backend = None

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -549,6 +549,7 @@ def get_attention_backend(
         ):
             fu_core_attention_bias_shape = "bhss"
 
+    # rocm ck backend support all 4 bias shapes (11ss, 1hss, b1ss, and bhss)
     if (
         not IS_HIP_EXTENSION and
         use_fused_attention
@@ -563,14 +564,6 @@ def get_attention_backend(
         else:
             # max512 backend will only support [1, h, s, s]
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
-    if (
-        IS_HIP_EXTENSION and
-        use_fused_attention
-        and fu_core_attention_bias_type == "post_scale_bias"
-    ):
-        if fu_core_attention_bias_shape not in ["11ss", "1hss", "b1ss", "bhss"]:
-            logger.debug("Disabling ROCm FusedAttention for Bias shape not in 11ss, 1hss, b1ss, bhss")
-            use_fused_attention = False
 
     # Filter: cuDNN support
     fused_attention_backend = None

--- a/transformer_engine/pytorch/csrc/extensions/attention.cu
+++ b/transformer_engine/pytorch/csrc/extensions/attention.cu
@@ -200,7 +200,6 @@ std::vector<at::Tensor> fused_attn_fwd_qkvpacked(
   // output_tensors = [O, nvte_aux_tensor_pack.tensors]
   std::vector<at::Tensor> output_tensors;
   output_tensors.push_back(O);
-#ifndef USE_ROCM
   for (size_t i = 0; i < nvte_aux_tensor_pack.size; ++i) {
     auto tensor = reinterpret_cast<transformer_engine::Tensor *>(nvte_aux_tensor_pack.tensors[i]);
     // allocate memory for nvte_aux_tensor_pack.tensors
@@ -225,24 +224,6 @@ std::vector<at::Tensor> fused_attn_fwd_qkvpacked(
     output_tensors.push_back(output_tensor);
     tensor->data.dptr = output_tensor.data_ptr();
   }
-#else
-  //prepare the aux tensors
-  nvte_aux_tensor_pack.size = 2;
-  transformer_engine::Tensor* softmax_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[0]);
-  softmax_aux->data.dptr = nullptr;
-  softmax_aux->data.shape = {batch_size, num_attn_heads, max_seqlen, 1};
-  softmax_aux->data.dtype = transformer_engine::DType::kFloat32;
-  at::Tensor softmax_at_tensor;
-  softmax_at_tensor = allocateSpace(softmax_aux->data.shape, softmax_aux->data.dtype, false);
-  softmax_aux->data.dptr = softmax_at_tensor.data_ptr();
-  output_tensors.push_back(softmax_at_tensor);
-  
-  transformer_engine::Tensor* rng_state_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[1]);
-  rng_state_aux->data.dptr = rng_state.data_ptr();
-  rng_state_aux->data.shape = std::vector<size_t>{2};
-  rng_state_aux->data.dtype = transformer_engine::DType::kInt64;
-  output_tensors.push_back(rng_state);
-#endif
 
   // execute the kernel
   nvte_fused_attn_fwd_qkvpacked(
@@ -539,7 +520,6 @@ std::vector<at::Tensor> fused_attn_fwd_kvpacked(
   // output_tensors = [O, nvte_aux_tensor_pack.tensors]
   std::vector<at::Tensor> output_tensors;
   output_tensors.push_back(O);
-#ifndef USE_ROCM
   for (size_t i = 0; i < nvte_aux_tensor_pack.size; ++i) {
     auto tensor = reinterpret_cast<transformer_engine::Tensor *>(nvte_aux_tensor_pack.tensors[i]);
     // allocate memory for nvte_aux_tensor_pack.tensors
@@ -564,23 +544,6 @@ std::vector<at::Tensor> fused_attn_fwd_kvpacked(
     output_tensors.push_back(output_tensor);
     tensor->data.dptr = output_tensor.data_ptr();
   }
-#else
-  nvte_aux_tensor_pack.size = 2;
-  transformer_engine::Tensor* softmax_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[0]);
-  softmax_aux->data.dptr = nullptr;
-  softmax_aux->data.shape = {batch_size, num_attn_heads, max_seqlen_q, 1};
-  softmax_aux->data.dtype = transformer_engine::DType::kFloat32;
-  at::Tensor softmax_at_tensor;
-  softmax_at_tensor = allocateSpace(softmax_aux->data.shape, softmax_aux->data.dtype, false);
-  softmax_aux->data.dptr = softmax_at_tensor.data_ptr();
-  output_tensors.push_back(softmax_at_tensor);
-  
-  transformer_engine::Tensor* rng_state_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[1]);
-  rng_state_aux->data.dptr = rng_state.data_ptr();
-  rng_state_aux->data.shape = std::vector<size_t>{2};
-  rng_state_aux->data.dtype = transformer_engine::DType::kInt64;
-  output_tensors.push_back(rng_state);
-#endif
 
   // execute the kernel
   nvte_fused_attn_fwd_kvpacked(
@@ -915,7 +878,6 @@ std::vector<at::Tensor> fused_attn_fwd(
   // output_tensors = [O, nvte_aux_tensor_pack.tensors]
   std::vector<at::Tensor> output_tensors;
   output_tensors.push_back(O);
-#ifndef USE_ROCM
   for (size_t i = 0; i < nvte_aux_tensor_pack.size; ++i) {
     auto tensor = reinterpret_cast<transformer_engine::Tensor *>(nvte_aux_tensor_pack.tensors[i]);
     // allocate memory for nvte_aux_tensor_pack.tensors
@@ -940,24 +902,6 @@ std::vector<at::Tensor> fused_attn_fwd(
     output_tensors.push_back(output_tensor);
     tensor->data.dptr = output_tensor.data_ptr();
   }
-#else
-  nvte_aux_tensor_pack.size = 2;
-  transformer_engine::Tensor* softmax_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[0]);
-  softmax_aux->data.dptr = nullptr;
-  softmax_aux->data.shape = {batch_size, num_attn_heads, max_seqlen_q, 1};
-  softmax_aux->data.dtype = transformer_engine::DType::kFloat32;
-  at::Tensor softmax_at_tensor;
-  softmax_at_tensor = allocateSpace(softmax_aux->data.shape, softmax_aux->data.dtype, false);
-  softmax_aux->data.dptr = softmax_at_tensor.data_ptr();
-  output_tensors.push_back(softmax_at_tensor);
-
-  
-  transformer_engine::Tensor* rng_state_aux = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[1]);
-  rng_state_aux->data.dptr = rng_state.data_ptr();
-  rng_state_aux->data.shape = std::vector<size_t>{2};
-  rng_state_aux->data.dtype = transformer_engine::DType::kInt64;
-  output_tensors.push_back(rng_state);
-#endif
 
   // execute the kernel
   nvte_fused_attn_fwd(te_Q.data(), te_K.data(), te_V.data(), te_Bias.data(), te_S.data(),


### PR DESCRIPTION
# Description

Support the bias and alibi feature in the fused attention via the ck backend

Bias shapes supported includes: 11SS, 1HSS, BHSS. Currently we do not support B1SS.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

commit # 06a8c0413

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
