### PR TITLE
Fixed ROCm support detection for JAX 0.4.30+

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -309,7 +309,7 @@ def get_frameworks() -> List[str]:
         if "jax" in _frameworks:
             if not any(re.match(r'jax-rocm\d+-plugin', d.metadata['Name']) for d in importlib.metadata.distributions()):
                 try:
-                    import jaxlib.rocm
+                    import jaxlib.rocm #pre JAX 0.4.30 way
                 except ImportError:
                     if "jax" in _requested_frameworks:
                         _unsupported_frameworks.append("jax")


### PR DESCRIPTION
# Description

Build script checks for jax_rocm plugin to detect ROCm support in JAX 0.4.30+

Fixes # (issue)

SWDEV-494922 Fixes installation on new JAX 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

