### PR TITLE
JAX: runtime ROCm detection is the same as compile time. Removed dupl…

### DIFF
--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -16,26 +16,8 @@ from jax.interpreters.mlir import dtype_to_ir_type
 from transformer_engine.transformer_engine_jax import DType as TEDType
 
 from ..sharding import get_padded_spec as te_get_padded_spec
+from ..util import is_hip_extension, jnp_float8_e4m3_type, jnp_float8_e5m2_type
 
-
-# check whether AMD GPU is loaded
-@cache
-def is_hip_extension() -> bool:
-  has_rocm = False
-  #iterate through all devices in jax
-  for dev in jax.devices():
-    if "rocm" in dev.client.platform_version:
-      has_rocm=True
-      break
-  return has_rocm
-
-if not is_hip_extension():
-    jnp_float8_e4m3_type = jnp.float8_e4m3fn
-    jnp_float8_e5m2_type = jnp.float8_e5m2
-else:
-    jnp_float8_e4m3_type = jnp.float8_e4m3fnuz
-    jnp_float8_e5m2_type = jnp.float8_e5m2fnuz
- 
 
 def te_dtype_to_jax_dtype(te_dtype):
     """

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -16,7 +16,7 @@ import jax.numpy as jnp
 from flax.core.frozen_dict import FrozenDict
 from flax.linen import fp8_ops
 
-from .util import is_hip_extension
+from .util import is_hip_extension, jnp_float8_e4m3_type, jnp_float8_e5m2_type
 
 from transformer_engine.transformer_engine_jax import DType
 
@@ -30,13 +30,6 @@ from transformer_engine.common.recipe import DelayedScaling, Format
 from transformer_engine.jax.sharding import global_shard_guard
 from transformer_engine.jax.sharding import MeshResource
 
-if not is_hip_extension():
-    jnp_float8_e4m3_type = jnp.float8_e4m3fn
-    jnp_float8_e5m2_type = jnp.float8_e5m2
-else:
-    jnp_float8_e4m3_type = jnp.float8_e4m3fnuz
-    jnp_float8_e5m2_type = jnp.float8_e5m2fnuz
- 
 _is_fp8_available = None
 _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]

--- a/transformer_engine/jax/util.py
+++ b/transformer_engine/jax/util.py
@@ -1,13 +1,27 @@
 # Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 # License for AMD contributions = MIT. See LICENSE for more information
-import jax
-# check whether AMD GPU is loaded
-def is_hip_extension() -> bool:
-  has_rocm = False
-  #iterate through all devices in jax
-  for dev in jax.devices():
-    if "rocm" in dev.client.platform_version:
-      has_rocm=True
-      break
-  return has_rocm
+from functools import cache
+import importlib.metadata
+import jax, jax.numpy as jnp
+import re
 
+# check whether ROCm is supported by JAX
+@cache
+def is_hip_extension() -> bool:
+  if any(re.match(r'jax-rocm\d+-plugin', d.metadata['Name'])
+             for d in importlib.metadata.distributions()):
+    return True
+  try:
+    import jaxlib.rocm #pre JAX 0.4.30 way
+    return True
+  except ImportError:
+    pass
+  return False
+
+
+if not is_hip_extension():
+  jnp_float8_e4m3_type = jnp.float8_e4m3fn
+  jnp_float8_e5m2_type = jnp.float8_e5m2
+else:
+  jnp_float8_e4m3_type = jnp.float8_e4m3fnuz
+  jnp_float8_e5m2_type = jnp.float8_e5m2fnuz


### PR DESCRIPTION
…icated code

# Description

Updated how JAX ROCm support is detected runtime to be similar to compile time.
Removed duplicated ROCm specific code

Fixes 

CI failures on Torch+JAX docker. Original way of ROCm JAX detection with devices enumeration modified default ROCm device on multi-GPU systems. Because it is called on library initialization it affected Torch tests. Moreover, it is time consuming

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] Code refractor

## Changes

- Removed duplicated is_hip_extension and FP8 data type definition in JAX plugin
- is_hip_extension checks ROCm support in JAX similar to build-time instead of enumerating devices 

