### PR TITLE
Hide unnecessary symbols (cherry-pick 407110d9)

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -43,6 +43,10 @@ if(USE_CUDA)
     set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
   endif()
 
+  # Hide non-necessary symbols in shared object.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libtransformer_engine.version")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libtransformer_engine.version")
+
   find_package(CUDAToolkit REQUIRED)
 
   # Check for cuDNN frontend API
@@ -336,6 +340,8 @@ else()
     set(HIP_HCC_FLAGS "${HIP_HCC_FLAGS} --offload-arch=${rocm_arch}")
   endforeach()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${HIP_HCC_FLAGS}")
+  # Hide non-necessary symbols in shared object.
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libtransformer_engine.version")
 endif()
 
 # Install library

--- a/transformer_engine/common/libtransformer_engine.version
+++ b/transformer_engine/common/libtransformer_engine.version
@@ -1,0 +1,4 @@
+{
+	global: *nvte*; *transformer_engine*;
+	local: *;
+};


### PR DESCRIPTION
# Description

Only export necessary TE methods from shared object.

Fixes:
Various test crash caused by wrong symbol dynamic linking, likely including SWDEV-469313

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Changes

Cherry pick 407110d9 (part of IFU 1.11 and FA support)
Apply corresponding changes for ROCm

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
