### PR TITLE
Wen/fix scale inv triton

### DIFF
--- a/tests/pytorch/test_cast_transpose_triton.py
+++ b/tests/pytorch/test_cast_transpose_triton.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
 import pytest
 import torch
 import triton

--- a/transformer_engine/pytorch/cast_transpose_triton.py
+++ b/transformer_engine/pytorch/cast_transpose_triton.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
 import torch
 
 import transformer_engine_torch as tex
@@ -209,8 +212,6 @@ def te_cast_transpose_dbias_triton(input, input_scale, amax_out, scale_inv_out, 
     best_config = _transpose_triton_dbias.best_config
     block_m_1 = int(best_config.kwargs['BLOCK_M'])
 
-    grid2 = lambda META: (triton.cdiv(N, META['BLOCK_N']),)
-    #_reduce_bias_triton[grid2](partial_dbias, dbias_out, partial_dbias.stride(0), partial_dbias.stride(1), triton.cdiv(M, block_m_1), N)
     dbias_out = reduce_dbias_kernel(partial_dbias[0:triton.cdiv(M, block_m_1)], input.dtype)
     return dbias_out, cast_out, trans_out
 

--- a/transformer_engine/pytorch/cast_transpose_triton.py
+++ b/transformer_engine/pytorch/cast_transpose_triton.py
@@ -193,7 +193,7 @@ def te_cast_transpose_dbias_triton(input, input_scale, amax_out, scale_inv_out, 
     dbias_out = torch.empty(N, dtype=input.dtype, device='cuda')
 
     if M == 0 or N == 0:
-        return dbias_out, cast_out, trans_out
+        return dbias_out.zero_(), cast_out, trans_out
 
     MIN_BLOCK_M = 64 ## This needs to be changed if minimum block size m changed
     partial_dbias = torch.empty(triton.cdiv(M, MIN_BLOCK_M), N, dtype=torch.float32, device='cuda')

--- a/transformer_engine/pytorch/cast_transpose_triton.py
+++ b/transformer_engine/pytorch/cast_transpose_triton.py
@@ -38,7 +38,7 @@ def get_fp8_max(dtype: tex.DType):
         key=['M', 'N']
 )
 @triton.jit
-def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, stride_bm, M, N, scale_ptr, amax_ptr, max_fp8: tl.constexpr, use_noop: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, GROUP_M: tl.constexpr):
+def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, stride_bm, M, N, scale_ptr, amax_ptr, scale_inv_ptr, max_fp8: tl.constexpr, use_noop: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, GROUP_M: tl.constexpr):
     if use_noop:
         noop = tl.load(noop_ptr)
         if noop == 1.0:
@@ -78,8 +78,10 @@ def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, s
 
     amax = tl.max(tl.abs(a))
     tl.atomic_max(amax_ptr, amax, sem='relaxed')
+    scale_inv_out = tl.fdiv(1.0, scale)
+    tl.store(scale_inv_ptr, scale_inv_out)
 
-def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans_out, amax_out, otype):
+def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans_out, amax_out, scale_inv_out, otype):
 
     M, N = input.shape
     
@@ -93,7 +95,7 @@ def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans
         use_noop = False
     
     grid = lambda META: (triton.cdiv(M, META['BLOCK_M']) * triton.cdiv(N, META['BLOCK_N']),)
-    _cast_transpose_triton[grid](input, noop_flag, triton.reinterpret(cast_out, tl_dtype), triton.reinterpret(trans_out, tl_dtype), input.stride(0), input.stride(1), trans_out.stride(0), trans_out.stride(1), M, N, input_scale, amax_out, get_fp8_max(otype), use_noop)
+    _cast_transpose_triton[grid](input, noop_flag, triton.reinterpret(cast_out, tl_dtype), triton.reinterpret(trans_out, tl_dtype), input.stride(0), input.stride(1), trans_out.stride(0), trans_out.stride(1), M, N, input_scale, amax_out, scale_inv_out, get_fp8_max(otype), use_noop)
 
 ##########################################
 #### cast_transpose_dbias
@@ -107,7 +109,7 @@ def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans
         key=['M', 'N']
 )
 @triton.jit
-def _transpose_triton_dbias(A, C, T, stride_am, stride_an, stride_bn, stride_bm, M, N, scale_ptr, amax_ptr, partial_dbias, fp8_max: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, GROUP_M: tl.constexpr):
+def _transpose_triton_dbias(A, C, T, stride_am, stride_an, stride_bn, stride_bm, M, N, scale_ptr, amax_ptr, scale_inv_ptr, partial_dbias, fp8_max: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, GROUP_M: tl.constexpr):
     pid = tl.program_id(0)
     scale = tl.load(scale_ptr)
 
@@ -145,6 +147,8 @@ def _transpose_triton_dbias(A, C, T, stride_am, stride_an, stride_bn, stride_bm,
     tl.store(T, fp8_a, mask=mask)
     amax = tl.max(tl.abs(a))
     tl.atomic_max(amax_ptr, amax, sem='relaxed')
+    scale_inv_out = tl.fdiv(1.0, scale)
+    tl.store(scale_inv_ptr, scale_inv_out)
 
 # There is a Triton bug that makes this kernel produce incorrect result
 # Not in use for now
@@ -180,7 +184,7 @@ def _reduce_bias_triton(A, out, stride_am, stride_an, M, N, BLOCK_M: tl.constexp
 def reduce_dbias_kernel(partial_dbias, dtype):
     return partial_dbias.to(torch.float32).sum(axis=0).to(dtype)
 
-def te_cast_transpose_dbias_triton(input, input_scale, amax_out, otype):
+def te_cast_transpose_dbias_triton(input, input_scale, amax_out, scale_inv_out, otype):
     M, N = input.shape
     cast_out = torch.empty(M, N, dtype=torch.uint8, device='cuda')
     trans_out = torch.empty(N, M, dtype=torch.uint8, device='cuda')
@@ -199,7 +203,7 @@ def te_cast_transpose_dbias_triton(input, input_scale, amax_out, otype):
     tl_dtype = get_triton_dtype(otype)
     
     grid = lambda META: (triton.cdiv(M, META['BLOCK_M']) * triton.cdiv(N, META['BLOCK_N']),)
-    _transpose_triton_dbias[grid](input, triton.reinterpret(cast_out, tl_dtype), triton.reinterpret(trans_out, tl_dtype), input.stride(0), input.stride(1), trans_out.stride(0), trans_out.stride(1), M, N, input_scale, amax_out, partial_dbias, get_fp8_max(otype))
+    _transpose_triton_dbias[grid](input, triton.reinterpret(cast_out, tl_dtype), triton.reinterpret(trans_out, tl_dtype), input.stride(0), input.stride(1), trans_out.stride(0), trans_out.stride(1), M, N, input_scale, amax_out, scale_inv_out, partial_dbias, get_fp8_max(otype))
     best_config = _transpose_triton_dbias.best_config
     block_m_1 = int(best_config.kwargs['BLOCK_M'])
 

--- a/transformer_engine/pytorch/cast_transpose_triton.py
+++ b/transformer_engine/pytorch/cast_transpose_triton.py
@@ -78,8 +78,9 @@ def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, s
 
     amax = tl.max(tl.abs(a))
     tl.atomic_max(amax_ptr, amax, sem='relaxed')
-    scale_inv_out = tl.fdiv(1.0, scale)
-    tl.store(scale_inv_ptr, scale_inv_out)
+    if pid == 0:
+        scale_inv_out = tl.fdiv(1.0, scale)
+        tl.store(scale_inv_ptr, scale_inv_out)
 
 def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans_out, amax_out, scale_inv_out, otype):
 
@@ -147,8 +148,9 @@ def _transpose_triton_dbias(A, C, T, stride_am, stride_an, stride_bn, stride_bm,
     tl.store(T, fp8_a, mask=mask)
     amax = tl.max(tl.abs(a))
     tl.atomic_max(amax_ptr, amax, sem='relaxed')
-    scale_inv_out = tl.fdiv(1.0, scale)
-    tl.store(scale_inv_ptr, scale_inv_out)
+    if pid == 0:
+        scale_inv_out = tl.fdiv(1.0, scale)
+        tl.store(scale_inv_ptr, scale_inv_out)
 
 # There is a Triton bug that makes this kernel produce incorrect result
 # Not in use for now

--- a/transformer_engine/pytorch/cpp_extensions/transpose.py
+++ b/transformer_engine/pytorch/cpp_extensions/transpose.py
@@ -69,6 +69,7 @@ def fp8_cast_transpose_fused(
                 cast_out,
                 transpose_out,
                 fp8_scales["amax"][0][fp8_scales_offsets['amax_offset']],
+                fp8_scales["scale_inv"][fp8_scales_offsets['scale_inv_offset']],
                 otype,
             )
         else:
@@ -113,6 +114,7 @@ def fp8_cast_transpose_bgrad_fused(
             inp,
             fp8_scales["scale"][fp8_scales_offsets['scale_offset']],
             fp8_scales["amax"][0][fp8_scales_offsets['amax_offset']],
+            fp8_scales["scale_inv"][fp8_scales_offsets['scale_inv_offset']],
             otype,
         )
     else:

--- a/transformer_engine/pytorch/cpp_extensions/transpose.py
+++ b/transformer_engine/pytorch/cpp_extensions/transpose.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.


### PR DESCRIPTION
# Description

Fix the scale_inv writing in cast_transpose triton kernels after IFU to v1.11

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes
Adding the scale_inv writing logic with commit 58a142b8ac75c85fdb0fb478c73cde196f3404f1, 42e9fa740ad605739169d26eddfac02405360d20, and c9ca981512a556262560fac8cbd4caaa30115596

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
