### PR TITLE
Fix crash on hipblaslt algo selection. Add test precision workaround …

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -24,7 +24,7 @@ from transformer_engine.pytorch.utils import (
     is_bf16_compatible,
 )
 if IS_HIP_EXTENSION:
-    from transformer_engine.pytorch.utils import is_mi200
+    from transformer_engine.pytorch.utils import is_mi200, is_mi308
 
 from transformer_engine.pytorch import (
     DotProductAttention,
@@ -1864,7 +1864,11 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
     # TODO: wait for the full determinism fix from hipblaslt
     if IS_HIP_EXTENSION:
         if use_hipblaslt():
-            torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous())
+            tols = dtype_tols(dtype)
+            if dtype in (torch.float16, torch.bfloat16) and is_mi308():
+                # mi308 hipblaslt precision issue
+                tols["atol"] = 5e-3
+            torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous(), **tols)
         else:
             assert torch.equal(y_bshd, y_sbhd.transpose(0, 1).contiguous()), "Tensors are not equal"
     else:

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -670,6 +670,7 @@ def test_gpt_full_activation_recompute(dtype, bs, model, fp8, fp8_model_params, 
         pytest.skip(reason_for_no_fp8)
 
     config = model_configs[model]
+    torch.compiler.reset() # avoid cache size limit overflow
 
     if not use_reentrant:
         # Non-reentrant checkpoint becomes non-deterministic with bias+GELU fusion
@@ -1808,7 +1809,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
         device="cuda",
         attn_input_format="bshd",
     )
-    
+
     #TODO: release after rocm fused attn support var seq len features
     if not IS_HIP_EXTENSION:
         torch.manual_seed(0)
@@ -1838,7 +1839,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
         for (n1, p1), (n2, p2) in zip(
             block_bshd.named_parameters(), block_sbhd.named_parameters()
         ):
-            assert torch.all(torch.eq(p1, p2)), f"{n1} and {n2} not identical"      
+            assert torch.all(torch.eq(p1, p2)), f"{n1} and {n2} not identical"
 
     x_sbhd = torch.randn(
         (config.seq_len, bs, config.hidden_size),
@@ -1877,7 +1878,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             y_bshd,
             y_sbhd.transpose(0, 1).contiguous(),
         )
-    
+
     # TODO: wait for rocm fused attn support var seqlen
     if not IS_HIP_EXTENSION:
         # THD is not supported in float32 and on GPUs older than Ampere, skip the test here

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1867,7 +1867,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             tols = dtype_tols(dtype)
             if dtype in (torch.float16, torch.bfloat16) and is_mi308():
                 # mi308 hipblaslt precision issue
-                tols["atol"] = 5e-3
+                tols["atol"] = 2e-3
             torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous(), **tols)
         else:
             assert torch.equal(y_bshd, y_sbhd.transpose(0, 1).contiguous()), "Tensors are not equal"

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1151,6 +1151,7 @@ void hipblaslt_gemm(const Tensor *inputA,
     int tuneLoopCount = getIntEnv("TE_HIPBLASLT_TUNING_RUN_COUNT", 0, 0);
     int algoTuneCount = 1;
     std::vector<hipblasLtMatmulHeuristicResult_t> algoArr;
+    bool logTuning = getIntEnv("TE_HIPBLASLT_LOG_TUNING", 0, 0) != 0;
 
     if (tuneLoopCount)
     {
@@ -1199,7 +1200,7 @@ void hipblaslt_gemm(const Tensor *inputA,
         }
         idx = (idx + 1) % algoTotalCount;
       }
-      if (!cached_algo.algo.has_value())
+      if (logTuning && !cached_algo.algo.has_value())
       {
         std::cout << "[WARNING] Cannot find cached algoId " << cached_algo.algoId << " in hipBLASLt results" << std::endl;
       }
@@ -1213,9 +1214,10 @@ void hipblaslt_gemm(const Tensor *inputA,
       algoTuneCount = std::min(algoTuneCount, algoTotalCount);
       if (tuneLoopCount > 0)
       {
-        std::cout << "[INFO] Perform hipBLASLt algo selection on GPU" << device_id
-                  << " in range [" << firstAlgo << "-" << (algoTuneCount - 1) << "] with "
-                  << tuneLoopCount << " loops " << std::endl;
+        if (logTuning)
+          std::cout << "[INFO] Perform hipBLASLt algo selection on GPU" << device_id
+                    << " in range [" << firstAlgo << "-" << (algoTuneCount - 1) << "] with "
+                    << tuneLoopCount << " loops " << std::endl;
 
         hipStream_t profilingStream;
         NVTE_CHECK_CUDA(hipStreamCreateWithFlags(&profilingStream, hipStreamNonBlocking));
@@ -1281,9 +1283,10 @@ void hipblaslt_gemm(const Tensor *inputA,
         NVTE_CHECK_CUDA(hipStreamDestroy(profilingStream));
         if (bestAlgo >= 0)
         {
-          std::cout << "[INFO] Select hipBLASLt algo " << bestAlgo << " with time "
-                    << std::chrono::duration_cast<std::chrono::nanoseconds>(bestTime).count() / tuneLoopCount
-                    << " ns" << std::endl;
+          if (logTuning)
+            std::cout << "[INFO] Select hipBLASLt algo " << bestAlgo << " with time "
+                      << std::chrono::duration_cast<std::chrono::nanoseconds>(bestTime).count() / tuneLoopCount
+                      << " ns" << std::endl;
         }
       }
       else if (firstAlgo < algoTuneCount)
@@ -1304,10 +1307,8 @@ void hipblaslt_gemm(const Tensor *inputA,
       cached_algo.ws_size_min = algoArr[bestAlgo].workspaceSize;
       cached_algo.ws_size_max = workspaceSize;
 
-      if (const char* env_p = std::getenv("NVTE_LOG_GEMM_CONFIG") ) {
-        if (env_p != nullptr && std::string(env_p) == "1")
-          std::cout << "[INFO] Use hipBLASLt algo [" << bestAlgo << "] " << cached_algo.algoId << std::endl;
-      }
+      if (logTuning)
+        std::cout << "[INFO] Use hipBLASLt algo [" << bestAlgo << "] " << cached_algo.algoId << std::endl;
 
       algoCache.store(gemm_cfg, cached_algo);
     }

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/
@@ -1210,6 +1210,7 @@ void hipblaslt_gemm(const Tensor *inputA,
     {
 
       int bestAlgo = -1;
+      algoTuneCount = std::min(algoTuneCount, algoTotalCount);
       if (tuneLoopCount > 0)
       {
         std::cout << "[INFO] Perform hipBLASLt algo selection on GPU" << device_id
@@ -1287,10 +1288,6 @@ void hipblaslt_gemm(const Tensor *inputA,
       }
       else if (firstAlgo < algoTuneCount)
       {
-        if (firstAlgo != 0)
-        {
-          std::cout << "[INFO] Select hipBLASLt algo " << firstAlgo << std::endl;
-        }
         bestAlgo = firstAlgo;
       }
 
@@ -1306,6 +1303,11 @@ void hipblaslt_gemm(const Tensor *inputA,
       cached_algo.algoId = cached_algo.getAlgoId(algoArr[bestAlgo].algo);
       cached_algo.ws_size_min = algoArr[bestAlgo].workspaceSize;
       cached_algo.ws_size_max = workspaceSize;
+
+      if (const char* env_p = std::getenv("NVTE_LOG_GEMM_CONFIG") ) {
+        if (env_p != nullptr && std::string(env_p) == "1")
+          std::cout << "[INFO] Use hipBLASLt algo [" << bestAlgo << "] " << cached_algo.algoId << std::endl;
+      }
 
       algoCache.store(gemm_cfg, cached_algo);
     }

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -242,14 +242,14 @@ def _get_active_autocast_contexts():
 
     gpu_autocast_enabled = torch.is_autocast_enabled()
     gpu_autocast_dtype = torch.get_autocast_gpu_dtype()
-    gpu_autocast_ctx = torch.cuda.amp.autocast(
-        gpu_autocast_enabled, gpu_autocast_dtype, autocast_cached
+    gpu_autocast_ctx = torch.amp.autocast('cuda',
+        gpu_autocast_dtype, gpu_autocast_enabled, autocast_cached
     )
 
     cpu_autocast_enabled = torch.is_autocast_cpu_enabled()
     cpu_autocast_dtype = torch.get_autocast_cpu_dtype()
-    cpu_autocast_ctx = torch.cpu.amp.autocast(
-        cpu_autocast_enabled, cpu_autocast_dtype, autocast_cached
+    cpu_autocast_ctx = torch.amp.autocast('cpu',
+        cpu_autocast_dtype, cpu_autocast_enabled, autocast_cached
     )
 
     return gpu_autocast_ctx, cpu_autocast_ctx

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2022-2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -113,7 +113,7 @@ def dgelu_fused_(grad_output: torch.Tensor, inp: torch.Tensor) -> torch.Tensor:
 
 def bias_gelu_fused(inp: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
     """Disable native AMP for bias_gelu_fused_"""
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         if bias.numel() != 0:
             return bias_gelu_fused_(inp, bias)
         return gelu_fused_(inp)
@@ -123,7 +123,7 @@ def bgrad_dgelu_fused(
     grad_output: torch.Tensor, inp: torch.Tensor, bias: torch.Tensor
 ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
     """Disable native AMP for `bgrad_dgelu_fused_`"""
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         if bias.numel() != 0:
             return bgrad_dgelu_fused_(grad_output, inp, bias)
         return None, dgelu_fused_(grad_output, inp)
@@ -164,7 +164,7 @@ def bias_dropout_add_fused_train(
 ) -> torch.Tensor:
     """Disable native AMP and enable grad for BDA"""
     with torch.enable_grad():
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             return bias_dropout_add_fused_train_(x, bias, residual, prob)
 
 
@@ -180,7 +180,7 @@ def bias_dropout_add_fused_inference(
     x: torch.Tensor, bias: torch.Tensor, residual: torch.Tensor, prob: float
 ) -> torch.Tensor:
     """Disable native AMP for BDA"""
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return bias_dropout_add_fused_inference_(x, bias, residual, prob)
 
 

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -245,6 +245,10 @@ if IS_HIP_EXTENSION:
       import re
       return (re.search('AMD Instinct MI2.0', torch.cuda.get_device_name(torch.cuda.current_device())) is not None)
     
+    def is_mi308():
+      """check whether this machine is mi308"""
+      import re
+      return (re.search('AMD Instinct MI308', torch.cuda.get_device_name(torch.cuda.current_device())) is not None)
 
 def is_bf16_compatible() -> None:
     if IS_HIP_EXTENSION:


### PR DESCRIPTION
…on MI308. Add pytorch 2.5 support

# Description

-Fix crash in corner cases with hipBlasLt algo selection
-Guard selected hipblaslt algo logging with NVTE_LOG_GEMM_CONFIG
-Add workaround for numerical test error on MI308 with ROCm6.3
-Add torch.compiler reset to avoid test failure on pytorch 2.5 due to cache limit reaching

Fixes # (issue)

https://github.com/ROCm/frameworks-internal/issues/10435
https://github.com/ROCm/frameworks-internal/issues/10561
Crash on debugging https://github.com/ROCm/frameworks-internal/issues/9693

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

