### PR TITLE
hipcc_bin UnboundLocalError

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -187,6 +187,7 @@ def rocm_build() -> bool:
 def rocm_path() -> Tuple[str, str]:
     """ROCm root path and HIPCC binary path as a tuple"""
     """If ROCm installation is not specified, use default /opt/rocm path"""
+    hipcc_bin = None
     if os.getenv("ROCM_PATH"):
         rocm_home = Path(os.getenv("ROCM_PATH"))
         hipcc_bin = rocm_home / "bin" / "hipcc"


### PR DESCRIPTION
Installation Error is the environment variable ROCM_PATH is not predefined.
# Description
I
Please include a brief summary of the changes, relevant motivation, and context.

if the ROCM_PATH environment variable path is not set, this leads to "UnboundLocalError: cannot access local variable 'hipcc_bin' where it is not associated with a value." This is because the first if block is not executed, and hence, there is no variable of "hipcc_bin" in the function.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ x] The functionality is complete
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
