### PR TITLE
Add gfx942 into te jax extension build

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -77,6 +77,7 @@ def setup_jax_extension(
         rocm_home, _ = rocm_path()
         macros=[("USE_ROCM",None)]
         cxx_flags.extend(["-D__HIP_PLATFORM_AMD__", "-I{}/include".format(str(rocm_home))])
+        nvcc_flags.extend(["--offload-arch={}".format(os.getenv("NVTE_ROCM_ARCH", "gfx942"))])
     else:
         macros=[]
 


### PR DESCRIPTION
# Description

Pass ROCM GPU arch (NVTE_ROCM_ARCH) into TE jax extension nvcc flags

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

Enable building TE during docker image building

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
