### PR TITLE
Increase test tolerance on MI308 with hipBalsLt

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1876,6 +1876,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             tols = dtype_tols(dtype)
             if dtype in (torch.float16, torch.bfloat16) and is_mi308():
                 # mi308 hipblaslt precision issue
+                tols["rtol"] = tols["rtol"] * 3
                 tols["atol"] = 2e-3
             torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous(), **tols)
         else:

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1876,8 +1876,10 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             tols = dtype_tols(dtype)
             if dtype in (torch.float16, torch.bfloat16) and is_mi308():
                 # mi308 hipblaslt precision issue
-                tols["rtol"] = tols["rtol"] * 3
                 tols["atol"] = 2e-3
+                _, use_aotriton, use_ck = rocm_attn_backend()
+                if use_aotriton and not use_ck:
+                    tols["rtol"] = tols["rtol"] * 3
             torch.testing.assert_close(y_bshd, y_sbhd.transpose(0, 1).contiguous(), **tols)
         else:
             assert torch.equal(y_bshd, y_sbhd.transpose(0, 1).contiguous()), "Tensors are not equal"


### PR DESCRIPTION
# Description

Increase rtol for float16 and bf16 in test_numerics::hidden_states_format on MI308 with hipBlasLt

Fixes #11006 AOTrion 0.8.2 updgrade
w/a for #11077 Numeric test error on MI308

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
