### PR TITLE
workaround for FA3 version

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -132,6 +132,12 @@ if not IS_HIP_EXTENSION:
         )
 
         _use_flash_attn_3 = True
+else:
+    # temp workaround for ck_tile/fa3
+    _flash_attn_v3_version = PkgVersion(get_pkg_version("flash-attn"))
+    if  _flash_attn_v3_version >= PkgVersion("3.0.0"):
+        _flash_attn_max_version = _flash_attn_v3_version
+
 
 if _flash_attn_version >= _flash_attn_version_required:
     from flash_attn.flash_attn_interface import flash_attn_func, flash_attn_varlen_func

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -133,7 +133,7 @@ if not IS_HIP_EXTENSION:
 
         _use_flash_attn_3 = True
 else:
-    # temp workaround for ck_tile/fa3
+    # FA v3
     _flash_attn_v3_version = PkgVersion(get_pkg_version("flash-attn"))
     if  _flash_attn_v3_version >= PkgVersion("3.0.0"):
         _flash_attn_max_version = _flash_attn_v3_version


### PR DESCRIPTION
FA ck_file/fa3 updates version to 3.0.0. As TE only allows 2.7.3, it causes many training workload crash. This PR fixes FA3 version change. Thank you.