### PR TITLE
Add flags to run CI sGPU or mGPU only

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -10,9 +10,7 @@ The scripts return 0 in case of test success, and other values for testing error
 
 The scripts can be controlled by environment variables:
 * `TEST_LEVEL` specifies testing thoroughness. Levels 1 and 3 are currently defined and can be used to run in feature branch and main branch correspondingly. Default=99 (maximal thoroughness)
-* `TEST_JOBS` specifies the maximal number of background parallel test jobs on MGPU system (only pytorch and jax). Default=0 (disable background jobs).
-The actual number of jobs is limited to the number of available GPUs and each job is run on its own GPU. Distributed tests that require mGPU are run separately on all available GPUs.
-Jobs are distributed based on config: HIPBLASLT/ROCBLAS CK/AOTRITON/UNFUSED, thus the actual max number of jobs is 6 for Pytorch and 3 for JAX tests.
+* `TEST_SGPU` and `TEST_MGPU` instructs to run single-GPU tests or multi-GPU tests only that can be used to run several sGPU tests parallel on mGPU config
 * `JUNITXML_PREFIX` and `JUNITXML_SUFFIX` enable pytest (pytorch and jax) junitxml logging if set. Each test will generate a junitxml log with the full filename `JUNITXML_PREFIX<test_name>.<test_config>JUNITXML_SUFFIX`.
 If JUNITXML_PREFIX contains a path component, it is the caller's responsibility to create necessary directories.
 If `JUNITXML_PREFIX` contains only a directory (no filename prefix), it should end with `/`.

--- a/ci/_utils.sh
+++ b/ci/_utils.sh
@@ -13,6 +13,11 @@ TEST_DIR=${TE_PATH}tests/
 : ${TEST_LEVEL:=99} #Run all tests by default
 TEST_JOBS_MODE=""
 
+if [ -z "${TEST_SGPU}${TEST_MGPU}" ]; then
+    TEST_SGPU=1
+    TEST_MGPU=1
+fi
+
 _script_error_count=0
 _run_error_count=0
 
@@ -213,7 +218,7 @@ check_test_filter() {
 }
 
 start_message() {
-    echo "Started with TEST_LEVEL=$TEST_LEVEL at `date`"
+    echo "Started with TEST_LEVEL=$TEST_LEVEL sGPU='$TEST_SGPU' mGPU='$TEST_MGPU' at `date`"
     echo "ROCm: `ls -d /opt/rocm-*`"
     python --version
 }

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 
 DIR=`dirname $0`
 
 . $DIR/_utils.sh
+
+start_message
+if [ -z "$TEST_SGPU" ]; then
+    return_run_results
+    exit 0
+fi
 
 TEST_DIR=${TE_PATH}tests/cpp
 

--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -63,7 +63,11 @@ run_test_config() {
     run 1 test_fused_attn.py
     run_default_fa 1 test_helper.py
     run_default_fa 1 test_layer.py #it effectevly always uses unfused attention
-    run 1 test_praxis_layers.py
+    if [ $_fus_attn = "$_DEFAULT_FUSED_ATTN" ]; then
+        run 1 test_praxis_layers.py
+    else
+        run 3 test_praxis_layers.py
+    fi
     run_default_fa 1 test_sharding.py
     run_default_fa 1 test_softmax.py
 }

--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -110,14 +110,14 @@ for _fus_attn in auto ck aotriton; do
     fi
 
     if [ -n "$TEST_JOBS_MODE" ]; then
-        run_test_job "$_fus_attn"
+        test -n "$TEST_SGPU" && run_test_job "$_fus_attn"
     else
-        run_test_config
-        run_test_config_mgpu
+        test -n "$TEST_SGPU" && run_test_config
+        test -n "$TEST_MGPU" && run_test_config_mgpu
     fi
 done
 
-if [ -n "$TEST_JOBS_MODE" ]; then
+if [ -n "$TEST_JOBS_MODE" -a -n "$TEST_MGPU" ]; then
     finish_test_jobs
     for _fus_attn in $(get_test_config_list); do
         configure_fused_attn_env $_fus_attn && run_test_config_mgpu

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -113,15 +113,15 @@ for _gemm in hipblaslt rocblas; do
         fi
 
         if [ -n "$TEST_JOBS_MODE" ]; then
-            run_test_job "$_gemm-$_fus_attn"
+            test -n "$TEST_SGPU" && run_test_job "$_gemm-$_fus_attn"
         else
-            run_test_config
-            run_test_config_mgpu
+            test -n "$TEST_SGPU" && run_test_config
+            test -n "$TEST_MGPU" && run_test_config_mgpu
         fi
     done
 done
 
-if [ -n "$TEST_JOBS_MODE" ]; then
+if [ -n "$TEST_JOBS_MODE" -a -n "$TEST_MGPU" ]; then
     finish_test_jobs
     for _cfg in $(get_test_config_list); do
         _gemm=`echo $_cfg | cut -d- -f1`

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -60,9 +60,11 @@ run_test_config(){
     run 1 test_sanity.py
     run_default_fa 1 test_torch_save_load.py
     run_default_fa 1 fused_attn/test_fused_attn.py # Backend selection is controlled by the test
-    run_default_fa 1 triton_kernels/test_cast_transpose_triton.py
-    run_default_fa 1 triton_kernels/test_rmsnorm_triton.py
-    NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 run_default_fa 1 test_numerics.py
+    if [ $_gemm = "hipblaslt" ]; then
+        run_default_fa 1 triton_kernels/test_cast_transpose_triton.py
+        run_default_fa 1 triton_kernels/test_rmsnorm_triton.py
+        NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 run_default_fa 3 test_numerics.py
+    fi
 }
 
 run_test_config_mgpu(){


### PR DESCRIPTION
# Description

CI scripts flags to run single GPU only or multiple GPU only tests

Fixes https://github.com/ROCm/frameworks-internal/issues/11278

## Type of change

- [x] Infra/Build change

## Changes

- Add TEST_SGPU and TEST_MGPU environment variables to control which tests to run
- Update readme

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
