### PR TITLE
[ROCm] upgrade CK version and fix the module loading for v3 for multi-threads scenario

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,7 +249,6 @@ To enable FA v3 kernels, the following environment variables can be used:
 
 * NVTE_CK_USES_BWD_V3 - by default 0, if set to 1, some cases will call the bwd v3 dqdkdv kernel;
 * NVTE_CK_IS_V3_ATOMIC_FP32 - by default 1, if set to 0 will use atomic fp16/bf16(w/o convert_dq kernel) when NVTE_CK_USES_BWD_V3 is set to 1;
-* NVTE_CK_IS_V3_SPEC - by default 0, if set to 1 will call the specialized v3 kernel when NVTE_CK_USES_BWD_V3 is set to 1;
 * NVTE_CK_HOW_V3_BF16_CVT - by default 1, float to bf16 convert type when bwd_v3 is set to 1, 0:RTNE; 1:RTNA; 2:RTZ.
 
 Experimental Triton Kernels on ROCm

--- a/transformer_engine/common/ck_fused_attn/CMakeLists.txt
+++ b/transformer_engine/common/ck_fused_attn/CMakeLists.txt
@@ -19,15 +19,16 @@ set(__CK_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../3rdparty/composable_kern
 #fwd kernels list
 execute_process(
   COMMAND python3 ${__CK_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py
-  --api fwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/blob_list.txt
+  --api fwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/fwd_blob_list.txt
 )
 #bwd kernels list
 execute_process(
   COMMAND python3 ${__CK_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py
-  --api bwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/blob_list.txt --receipt 3
+  --api bwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/bwd_blob_list.txt --receipt 3
 )
 
-file(STRINGS ${CMAKE_CURRENT_BINARY_DIR}/gen_src/blob_list.txt FMHA_GEN_BLOBS)
+file(STRINGS ${CMAKE_CURRENT_BINARY_DIR}/gen_src/fwd_blob_list.txt FMHA_FWD_GEN_BLOBS)
+file(STRINGS ${CMAKE_CURRENT_BINARY_DIR}/gen_src/bwd_blob_list.txt FMHA_BWD_GEN_BLOBS)
 
 # generate the actual fwd kernel cpp files
 execute_process(
@@ -48,11 +49,17 @@ list(APPEND ck_fused_attn_SOURCES
        src/ck_fused_attn_utils.cpp)
 
 # Update all new and modified kernels and add to ck_fused_attn
-foreach(blob ${FMHA_GEN_BLOBS})
+foreach(blob ${FMHA_FWD_GEN_BLOBS})
   file(RELATIVE_PATH blob_path ${CMAKE_CURRENT_BINARY_DIR}/gen_src ${blob})
   file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp/${blob_path} ${blob} ONLY_IF_DIFFERENT)
 endforeach()
-list(APPEND ck_fused_attn_SOURCES ${FMHA_GEN_BLOBS})
+list(APPEND ck_fused_attn_SOURCES ${FMHA_FWD_GEN_BLOBS})
+foreach(blob ${FMHA_BWD_GEN_BLOBS})
+  file(RELATIVE_PATH blob_path ${CMAKE_CURRENT_BINARY_DIR}/gen_src ${blob})
+  file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp/${blob_path} ${blob} ONLY_IF_DIFFERENT)
+endforeach()
+list(APPEND ck_fused_attn_SOURCES ${FMHA_BWD_GEN_BLOBS})
+
 # remove all previously generated temporary files
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp)
 

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024 - 2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024 - 2025, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -99,7 +99,6 @@ hipError_t ck_attn_bwd(
   bool deterministic,
   bool uses_bwd_v3,
   bool is_v3_atomic_fp32,
-  bool is_v3_spec,
   int how_v3_bf16_cvt,
   hipStream_t stream);
 

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024 - 2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024 - 2025, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -209,7 +209,6 @@ hipError_t ck_attn_bwd(
   bool deterministic,
   bool uses_bwd_v3,
   bool is_v3_atomic_fp32,
-  bool is_v3_spec,
   int how_v3_bf16_cvt,
   hipStream_t stream){
 
@@ -288,7 +287,6 @@ hipError_t ck_attn_bwd(
                     s_randval, deterministic, 
                     uses_bwd_v3, // use_bwd_v3
                     is_v3_atomic_fp32, // is_v3_atomic_fp32
-                    is_v3_spec, // is_v3_spec
                     how_v3_bf16_cvt //how_v3_bf16_cvt 0:RTNE; 1:RTNA; 2:RTZ
                     };
 
@@ -439,7 +437,6 @@ hipError_t ck_attn_bwd(
     std::cout<<"is_deterministic: "<<fmha_traits.is_deterministic<<std::endl;
     std::cout<<"uses_bwd_v3: "<<fmha_traits.uses_bwd_v3<<std::endl;
     std::cout<<"is_v3_atomic_fp32: "<<fmha_traits.is_v3_atomic_fp32<<std::endl;
-    std::cout<<"is_v3_spec: "<<fmha_traits.is_v3_spec<<std::endl;
     std::cout<<"how_v3_bf16_cvt: "<<fmha_traits.how_v3_bf16_cvt<<std::endl;
 
     // fmha_args debug

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -256,9 +256,6 @@ void fused_attn_ck_fwd_impl(
   generateMatrixStrides(b, hg, s_q, s_kv, d, v_stride.data(),
                         layout, NVTE_QKV_Matrix::NVTE_V_Matrix);
 
-  std::array<uint64_t, 4> q_shape{b, h, s_q, d};
-  std::array<uint64_t, 4> kv_shape{b, hg, s_kv, d};
-
   std::array<uint64_t, 4> o_stride;
   generateMatrixStrides(b, h, s_q, s_kv, d, o_stride.data(),
                         layout, NVTE_QKV_Matrix::NVTE_O_Matrix);
@@ -408,8 +405,6 @@ void fused_attn_ck_bwd_impl(
   //q and o are having the same shape
   //k and v are having the same shape
   //x and dx are having the same shape and stride
-  std::array<uint64_t, 4> q_shape{b, h, s_q, d};
-  std::array<uint64_t, 4> kv_shape{b, hg, s_kv, d};
   
   // First b*h*sq*sizeof(float) in workspace are for lse
   // The next section are for dq_acc_ptr
@@ -481,7 +476,6 @@ void fused_attn_ck_bwd_impl(
   // default values follows the ck example setting
   bool nvte_ck_uses_bwd_v3 = getenv<int>("NVTE_CK_USES_BWD_V3", 0);
   bool nvte_ck_is_v3_atomic_fp32 = getenv<int>("NVTE_CK_IS_V3_ATOMIC_FP32", 1);
-  bool nvte_ck_is_v3_spec = getenv<int>("NVTE_CK_IS_V3_SPEC", 0);
   int nvte_ck_how_v3_bf16_cvt = getenv<int>("NVTE_CK_HOW_V3_BF16_CVT", 1);
 
   if (nvte_log_ck_config) {
@@ -543,7 +537,6 @@ void fused_attn_ck_bwd_impl(
       deterministic,
       nvte_ck_uses_bwd_v3,
       nvte_ck_is_v3_atomic_fp32,
-      nvte_ck_is_v3_spec,
       nvte_ck_how_v3_bf16_cvt,
       stream));
 }


### PR DESCRIPTION
# Description

Upgrade the CK version to latest ck_tile/fa_bwd_v3
This also contains the commit for v3 multi-threading module load fix

Fixes https://github.com/ROCm/frameworks-internal/issues/11194

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

CK version upgrade

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
