### PR TITLE
[ROCm] integrate ck varlen feature with THD layout into TE

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -657,25 +657,48 @@ model_configs_layout_thd = {
 }
 
 
+# ROCm fused attn does not use cudnn, return high numbers to avoid tests filtering out
 @pytest.mark.skipif(get_cudnn_version() < (9, 0, 0), reason="cuDNN 9.0.0+ is required.")
 @pytest.mark.skipif(
+    (not IS_HIP_EXTENSION) and
     get_device_compute_capability() < (9, 0), reason="THD is only supported on Hopper+."
 )
 @pytest.mark.parametrize("dtype", param_types_lean)
 @pytest.mark.parametrize("model_configs", [model_configs_layout_thd])
 @pytest.mark.parametrize("model", model_configs_layout_thd.keys())
 @pytest.mark.parametrize("qkv_layout", qkv_layouts_thd)
-def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout):
+@pytest.mark.parametrize("pad_between_seqs", [False, True])
+def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout, pad_between_seqs):
     """Test DotProductAttention module with different QKV layouts"""
-    pad_between_seqs = True
+    if (pad_between_seqs==False and get_cudnn_version() < (9, 3, 0)):
+        pytest.skip("cuDNN 9.3.0+ is required to run pad_between_seqs = False");
     test_dot_product_attention(
         dtype, model_configs, model, False, True, qkv_layout, False, pad_between_seqs
     )
-    if get_cudnn_version() >= (9, 3, 0):
-        # cuDNN 9.3.0+ is required to run pad_between_seqs = False/True in the same run
-        pad_between_seqs = False
+
+# ROCm specific pytests, not in upstream NVTE repo
+@pytest.mark.parametrize("dtype", param_types_lean)
+@pytest.mark.parametrize("model_configs", [model_configs_layout_thd])
+@pytest.mark.parametrize("model", model_configs_layout_thd.keys())
+@pytest.mark.parametrize("qkv_layout", qkv_layouts_thd)
+def test_dpa_qkv_layout_thd_mqa_gqa(dtype, model_configs, model, qkv_layout):
+    if (not IS_HIP_EXTENSION):
+        pytest.skip("ROCm specific pytests.");
+
+    def find_factors(x):
+        f = []
+        for i in range(2, x + 1):
+            if x % i == 0:
+                f.append(i)
+        return f
+
+    config = model_configs[model]
+    num_querys_per_gqa_group = find_factors(config.num_heads)
+
+    for num_q_per_gqa_group in num_querys_per_gqa_group:
+        config.num_gqa_groups = config.num_heads // num_q_per_gqa_group
         test_dot_product_attention(
-            dtype, model_configs, model, False, True, qkv_layout, False, pad_between_seqs
+            dtype, model_configs, model, False, True, qkv_layout, False, False
         )
 
 

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -676,15 +676,12 @@ def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout, pad_between
         dtype, model_configs, model, False, True, qkv_layout, False, pad_between_seqs
     )
 
-# ROCm specific pytests, not in upstream NVTE repo
+@pytest.mark.skipif(not IS_HIP_EXTENSION, reason="ROCm TE specific pytests.")
 @pytest.mark.parametrize("dtype", param_types_lean)
 @pytest.mark.parametrize("model_configs", [model_configs_layout_thd])
 @pytest.mark.parametrize("model", model_configs_layout_thd.keys())
 @pytest.mark.parametrize("qkv_layout", qkv_layouts_thd)
 def test_dpa_qkv_layout_thd_mqa_gqa(dtype, model_configs, model, qkv_layout):
-    if (not IS_HIP_EXTENSION):
-        pytest.skip("ROCm specific pytests.");
-
     def find_factors(x):
         f = []
         for i in range(2, x + 1):

--- a/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
+++ b/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
@@ -123,7 +123,7 @@ model_configs_fused_attn = {
 @pytest.mark.parametrize("cp_comm_type", ["p2p", "all_gather", "a2a", "a2a+p2p"])
 def test_cp_with_fused_attention(dtype, model, qkv_format, cp_comm_type):
     if IS_HIP_EXTENSION and qkv_format == "thd":
-        pytest.skip("THD format has not been supported on ROCm yet!")
+        pytest.skip("THD format in CP has not been supported on ROCm yet!")
     if qkv_format == "thd" and get_device_compute_capability() < (9, 0):
         pytest.skip("THD format is only supported on sm90+!")
     if cp_comm_type == "all_gather" and get_cudnn_version() < (9, 3, 0):

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1824,36 +1824,29 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
         attn_input_format="bshd",
     )
 
-    #TODO: release after rocm fused attn support var seq len features
-    if not IS_HIP_EXTENSION:
-        torch.manual_seed(0)
-        block_thd = TransformerLayer(
-            config.hidden_size,
-            4 * config.hidden_size,
-            config.num_attention_heads,
-            layernorm_epsilon=config.eps,
-            init_method=init_method,
-            output_layer_init_method=output_layer_init_method,
-            hidden_dropout=0,
-            attention_dropout=0,
-            kv_channels=config.embed,
-            params_dtype=dtype,
-            apply_residual_connection_post_layernorm=False,
-            output_layernorm=False,
-            device="cuda",
-            attn_input_format="thd",
-            self_attn_mask_type="padding_causal",
-        )
+    torch.manual_seed(0)
+    block_thd = TransformerLayer(
+        config.hidden_size,
+        4 * config.hidden_size,
+        config.num_attention_heads,
+        layernorm_epsilon=config.eps,
+        init_method=init_method,
+        output_layer_init_method=output_layer_init_method,
+        hidden_dropout=0,
+        attention_dropout=0,
+        kv_channels=config.embed,
+        params_dtype=dtype,
+        apply_residual_connection_post_layernorm=False,
+        output_layernorm=False,
+        device="cuda",
+        attn_input_format="thd",
+        self_attn_mask_type="padding_causal",
+    )
 
-        for (n1, p1), (n2, p2), (n3, p3) in zip(
-            block_bshd.named_parameters(), block_sbhd.named_parameters(), block_thd.named_parameters()
-        ):
-            assert torch.all(torch.eq(p1, p2) & torch.eq(p1, p3)), f"{n1}, {n2} and {n3} not identical"
-    else:
-        for (n1, p1), (n2, p2) in zip(
-            block_bshd.named_parameters(), block_sbhd.named_parameters()
-        ):
-            assert torch.all(torch.eq(p1, p2)), f"{n1} and {n2} not identical"
+    for (n1, p1), (n2, p2), (n3, p3) in zip(
+        block_bshd.named_parameters(), block_sbhd.named_parameters(), block_thd.named_parameters()
+    ):
+        assert torch.all(torch.eq(p1, p2) & torch.eq(p1, p3)), f"{n1}, {n2} and {n3} not identical"
 
     x_sbhd = torch.randn(
         (config.seq_len, bs, config.hidden_size),
@@ -1896,25 +1889,23 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             y_sbhd.transpose(0, 1).contiguous(),
         )
 
-    # TODO: wait for rocm fused attn support var seqlen
-    if not IS_HIP_EXTENSION:
-        # THD is not supported in float32 and on GPUs older than Ampere, skip the test here
-        if dtype != torch.float32 and sm_80plus:
-            # To make sure forward is also identical (just in case some module decides
-            # to act fancy)
-            torch.manual_seed(0)
-            y_thd = block_thd(
-                x_thd,
-                cu_seqlens_q=x_thd_cumsum,
-                cu_seqlens_kv=x_thd_cumsum,
-                max_seqlen_q=config.seq_len,
-                max_seqlen_kv=config.seq_len,
-            )
+    # THD is not supported in float32 and on GPUs older than Ampere, skip the test here
+    if dtype != torch.float32 and (IS_HIP_EXTENSION or sm_80plus):
+        # To make sure forward is also identical (just in case some module decides
+        # to act fancy)
+        torch.manual_seed(0)
+        y_thd = block_thd(
+            x_thd,
+            cu_seqlens_q=x_thd_cumsum,
+            cu_seqlens_kv=x_thd_cumsum,
+            max_seqlen_q=config.seq_len,
+            max_seqlen_kv=config.seq_len,
+        )
 
-            torch.testing.assert_close(
-                y_bshd,
-                y_thd.reshape(bs, config.seq_len, config.hidden_size).contiguous(),
-            )
+        torch.testing.assert_close(
+            y_bshd,
+            y_thd.reshape(bs, config.seq_len, config.hidden_size).contiguous(),
+        )
 
 
 @pytest.mark.parametrize("dtype", param_types)

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1890,8 +1890,10 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
         )
 
     # in ROCm TE, THD only supported with ck backend
-    if IS_HIP_EXTENSION and os.getenv("NVTE_FUSED_ATTN_CK", "1") == "0":
-        return 
+    if IS_HIP_EXTENSION:
+        _, _, use_ck = rocm_attn_backend()
+        if not use_ck:
+            return 
     # THD is not supported in float32 and on GPUs older than Ampere, skip the test here
     if dtype != torch.float32 and (IS_HIP_EXTENSION or sm_80plus):
         # To make sure forward is also identical (just in case some module decides

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1889,6 +1889,9 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
             y_sbhd.transpose(0, 1).contiguous(),
         )
 
+    # in ROCm TE, THD only supported with ck backend
+    if IS_HIP_EXTENSION and os.getenv("NVTE_FUSED_ATTN_CK", "1") == "0":
+        return 
     # THD is not supported in float32 and on GPUs older than Ampere, skip the test here
     if dtype != torch.float32 and (IS_HIP_EXTENSION or sm_80plus):
         # To make sure forward is also identical (just in case some module decides

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -15,14 +15,14 @@
 namespace ck_fused_attn{
 
 // input qkv dtypes
-enum DType {
+enum class DType {
   kFloat16    = 0,  /*!< 16-bit float (E5M10) */
   kBFloat16   = 1,  /*!< 16-bit bfloat (E8M7) */
   kNumTypes         /*!< Number of supported types */
 };
 
 // keep sync with mask_enum in mask.hpp
-enum MaskType {
+enum class MaskType {
   no_mask = 0,
   mask_top_left = 1,
   mask_bottom_right = 2,
@@ -30,7 +30,7 @@ enum MaskType {
 };
 
 // keep sync with bias_enum in bias.hpp
-enum BiasType{
+enum class BiasType{
   no_bias          = 0,
   elementwise_bias = 1,
   alibi            = 2,
@@ -60,7 +60,28 @@ hipError_t ck_attn_fwd(
   void* lse_ptr, 
   hipStream_t stream);
 
-  
+hipError_t ck_attn_varlen_fwd(
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  const void* q_ptr, 
+  uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  bool is_training,
+  float scaling_factor,
+  float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* o_ptr, 
+  uint64_t stride_h_o, uint64_t stride_s_o,
+  void* lse_thd_ptr,
+  void* lse_ptr, 
+  hipStream_t stream);
+
 hipError_t ck_attn_bwd(  
   DType dtype,
   uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
@@ -95,11 +116,45 @@ hipError_t ck_attn_bwd(
   uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
   void* dbias_expanded_ptr,
   void* dbias_ptr,
-  void* workspace_ptr,
+  void* lse_workspace_ptr,
   bool deterministic,
   bool uses_bwd_v3,
   bool is_v3_atomic_fp32,
   int how_v3_bf16_cvt,
+  hipStream_t stream);
+
+hipError_t ck_attn_varlen_bwd(  
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  const void* q_ptr, 
+  uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  const void* o_ptr, 
+  uint64_t stride_h_o, uint64_t stride_s_o,
+  const void* lse_ptr, 
+  const void* do_ptr, 
+  uint64_t stride_h_do, uint64_t stride_s_do,
+  float scaling_factor, float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* dq_ptr, 
+  uint64_t stride_h_dq, uint64_t stride_s_dq,
+  void* dq_acc_ptr,
+  void* dk_expanded_ptr,
+  void* dv_expanded_ptr,
+  uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
+  void* dk_ptr, 
+  uint64_t stride_h_dk, uint64_t stride_s_dk,
+  void* dv_ptr, 
+  uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* lse_workspace_ptr,
+  void* lse_thd_ptr,
+  bool deterministic,
   hipStream_t stream);
 
 }//namespace ck_fused_attn

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -17,6 +17,25 @@
 
 namespace ck_fused_attn{
 
+// convert the softmax lse from [b, h, s_q] into shape [h, total_seqlen_q]
+__global__ void softmax_lse_to_thd(
+  uint64_t b, uint64_t h, uint64_t s_q,
+  const int32_t* cu_seqlen_q,
+  const float* lse,
+  float* lse_thd){
+
+  int32_t total_seqlen_q = cu_seqlen_q[b];
+  
+  for(uint64_t bh_idx = blockIdx.x*blockDim.x + threadIdx.x; bh_idx < b*h; bh_idx += blockDim.x * gridDim.x){
+    uint64_t b_idx = bh_idx/h;
+    uint64_t h_idx = bh_idx%h;
+    // loop over a given batch and head idx
+    for(uint64_t s_idx = cu_seqlen_q[b_idx]; s_idx < cu_seqlen_q[b_idx + 1]; s_idx++){
+      lse_thd[h_idx * total_seqlen_q + s_idx] = lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]];
+    }
+  }
+}
+
 // define dk_dv_reduce function only for fp16 and bf16 types
 template<typename DataType>
 __global__ void dk_dv_reduce(
@@ -43,6 +62,56 @@ __global__ void dk_dv_reduce(
   assert(hdim_dix<d);
   uint64_t read_idx = batch_idx*stride_b_dkv_expanded + head_k_idx*head_idx_offset*stride_h_dkv_expanded + seqlen_idx*stride_s_dkv_expanded + hdim_idx;
   uint64_t write_idx = batch_idx*stride_b_dkv + head_k_idx*stride_h_dkv + seqlen_idx* stride_s_dkv + hdim_idx;
+  
+  for(uint64_t ii = 0; ii < head_idx_offset; ii++){
+    // bf16 requires special casting in CK
+    if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+      sum_dk += ck_tile::bf16_to_float(dk_expanded[read_idx]);
+      sum_dv += ck_tile::bf16_to_float(dv_expanded[read_idx]);
+    }else{
+      sum_dk += dk_expanded[read_idx];
+      sum_dv += dv_expanded[read_idx];
+    }
+    read_idx += stride_h_dkv_expanded;
+  }
+
+  // bf16 requires special casting in CK
+  if constexpr (std::is_same_v<DataType, ck_tile::bf16_t>){
+    dk[write_idx] = ck_tile::float_to_bf16(sum_dk);
+    dv[write_idx] = ck_tile::float_to_bf16(sum_dv);
+  }else{
+    dk[write_idx] = sum_dk;
+    dv[write_idx] = sum_dv;
+  }
+}
+
+// define dk_dv_reduce function in THD layout only for fp16 and bf16 types
+template<typename DataType>
+__global__ void dk_dv_reduce_thd(
+  uint64_t h, uint64_t hg, uint64_t d, int32_t total_seqlen_kv,
+  const DataType *dk_expanded,
+  const DataType *dv_expanded,
+  uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
+  DataType *dk,
+  DataType *dv,
+  //k,v, dk, dv guaranteed to have the same stride
+  uint64_t stride_h_dkv, uint64_t stride_s_dkv){
+  
+  uint64_t seqlen_idx = blockIdx.x;
+  uint64_t head_k_idx = blockIdx.y;
+  uint64_t hdim_idx = threadIdx.x;
+  
+  // h guaranteed to be multiples of hg
+  uint64_t head_idx_offset = h / hg;
+
+  float sum_dk = 0.0f;
+  float sum_dv = 0.0f;
+
+  assert(hdim_dix<d);
+  assert(seqlen_idx < total_seqlen_kv);
+
+  uint64_t read_idx = head_k_idx*head_idx_offset*stride_h_dkv_expanded + seqlen_idx*stride_s_dkv_expanded + hdim_idx;
+  uint64_t write_idx = head_k_idx*stride_h_dkv + seqlen_idx* stride_s_dkv + hdim_idx;
   
   for(uint64_t ii = 0; ii < head_idx_offset; ii++){
     // bf16 requires special casting in CK
@@ -156,271 +225,14 @@ __global__ void dbias_reduce_b1ss(
   }
 }
 
-#define CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, type, ...)   \
-switch (dtype) {                                            \
-  case DType::kFloat16: {                                   \
-    using type = ck_tile::half_t;                           \
-    __VA_ARGS__;                                            \
-    break;                                                  \
-  }                                                         \
-  case DType::kBFloat16: {                                  \
-    using type = ck_tile::bf16_t;                           \
-    __VA_ARGS__;                                            \
-    break;                                                  \
-  }                                                         \
-  default:                                                  \
-    throw std::runtime_error("Invalid type for 16 bit..");  \
-}
+// print the fmha_traits and args passed into ck apis
+void log_bwd_config(const char* func_name, const fmha_bwd_traits& fmha_traits, const fmha_bwd_args& fmha_args){
 
-hipError_t ck_attn_bwd(  
-  DType dtype,
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
-  const void* q_ptr, 
-  uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
-  const void* k_ptr, 
-  uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
-  const void* v_ptr, 
-  uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
-  const void* bias_ptr,
-  const void* alibi_slope_ptr,
-  const void* o_ptr, 
-  uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
-  const void* lse_ptr, 
-  const void* do_ptr, 
-  uint64_t stride_b_do, uint64_t stride_h_do, uint64_t stride_s_do,
-  float scaling_factor, float dropout_probability,
-  void* philox_seed_ptr, void* philox_offset_ptr,
-  BiasType attn_bias_type,
-  MaskType attn_mask_type,
-  int64_t window_size_left, int64_t window_size_right,
-  void* dq_ptr, 
-  uint64_t stride_b_dq, uint64_t stride_h_dq, uint64_t stride_s_dq,
-  void* dq_acc_ptr,
-  void* dk_expanded_ptr,
-  void* dv_expanded_ptr,
-  uint64_t stride_b_dkv_expanded, uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
-  void* dk_ptr, 
-  uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
-  void* dv_ptr, 
-  uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
-  void* dbias_expanded_ptr,
-  void* dbias_ptr,
-  void* workspace_ptr,
-  bool deterministic,
-  bool uses_bwd_v3,
-  bool is_v3_atomic_fp32,
-  int how_v3_bf16_cvt,
-  hipStream_t stream){
-
-  bool has_dropout = (dropout_probability > 0.f);
-  bool has_dbias = dbias_ptr!=nullptr;
-  bool is_mqa_gqa = (h > hg);
-
-  /* CK input parameters */
-  ck_tile::index_t batch = b;
-  ck_tile::index_t seqlen_q = s_q;
-  ck_tile::index_t nhead = h;
-  ck_tile::index_t hdim_q = d;
-  ck_tile::index_t seqlen_k = s_kv;
-  ck_tile::index_t nhead_k = hg;
-  ck_tile::index_t hdim_v = d;
-  ck_tile::index_t max_seqlen_q = s_q;
-  ck_tile::index_t max_seqlen_k = s_kv;
-  float scale_s = scaling_factor;
-  float p_drop = dropout_probability;
-  float p_undrop = 1.0 - p_drop;
-  bool is_group_mode = false;
-  bool s_randval = false;
-
-  bias_enum bias_type;
-  BiasShape bias_shape; 
-  if (attn_bias_type==BiasType::no_bias){
-    bias_type = bias_enum::no_bias;
-  }else if (attn_bias_type==BiasType::elementwise_bias){
-    bias_type = bias_enum::elementwise_bias;
-    bias_shape = get_bias_shape(b, h, bias_b, bias_h);
-  }else if (attn_bias_type==BiasType::alibi){
-    bias_type = bias_enum::alibi;
-  }else{
-    //TODO: better error out system
-    throw std::runtime_error("Invalid bias_type in ck_fused_attn.");
-  }
-
-  mask_enum mask_type;
-  ck_tile::index_t left, right;
-  if (attn_mask_type == MaskType::no_mask){
-    mask_type = mask_enum::no_mask;
-  }else if(attn_mask_type == MaskType::mask_top_left){
-    mask_type = mask_enum::mask_top_left;
-  }else if(attn_mask_type == MaskType::mask_bottom_right){
-    mask_type = mask_enum::mask_bottom_right;
-  }else{
-    mask_type = mask_enum::window_generic;
-  }
-  left = window_size_left;
-  right = window_size_right;
- 
   bool ck_fused_attn_log_config = false;
   if (const char* env_p = std::getenv("CK_FUSED_ATTN_LOG_CONFIG") ) {
     if (env_p != nullptr && std::string(env_p) == "1")
       ck_fused_attn_log_config = true;
-  } 
-  // print kernel name on verbose mode
-  ck_tile::stream_config stream_config{stream, false, ck_fused_attn_log_config};
-
-  ck_tile::index_t shape_seqlen_q = seqlen_q;
-  ck_tile::index_t shape_seqlen_k = seqlen_k;
-
-  std::string data_type_str;
-  if(dtype==DType::kFloat16){
-    data_type_str = "fp16";
-  }else if(dtype==DType::kBFloat16){
-    data_type_str = "bf16";
-  }else{
-    //TODO: better error out system
-    throw std::runtime_error("Invalid dtype in ck_fused_attn.");
   }
-
-  auto fmha_traits =
-    fmha_bwd_traits{hdim_q,    hdim_v,    data_type_str, is_group_mode,
-                    mask_type, bias_type, has_dbias,     has_dropout, 
-                    s_randval, deterministic, 
-                    uses_bwd_v3, // use_bwd_v3
-                    is_v3_atomic_fp32, // is_v3_atomic_fp32
-                    how_v3_bf16_cvt //how_v3_bf16_cvt 0:RTNE; 1:RTNA; 2:RTZ
-                    };
-
-  auto fmha_args = [&]() {
-    // setup stride_* arguments
-    const ck_tile::index_t stride_q = stride_s_q;
-    const ck_tile::index_t stride_k = stride_s_k;
-    const ck_tile::index_t stride_v = stride_s_v;
-    // bias of shape (bias_b, bias_h, s_q, s_kv)
-    const ck_tile::index_t stride_bias = max_seqlen_k;
-    const ck_tile::index_t stride_o = stride_s_o;
-    const ck_tile::index_t stride_randval = max_seqlen_k;
-    const ck_tile::index_t stride_do = stride_s_do;
-    const ck_tile::index_t stride_dq = stride_s_dq;
-    const ck_tile::index_t stride_dk = stride_s_dk;
-    const ck_tile::index_t stride_dv = stride_s_dv;
-    const ck_tile::index_t stride_dkv_expanded = stride_s_dkv_expanded;
-    const ck_tile::index_t stride_dq_acc = d; //dq_acc of shape (nsplits, B, H, S, D)
-    // dbias is of the same shape as bias
-    // but ck only take dbias with BHSS
-    const ck_tile::index_t stride_dbias = max_seqlen_k;
-    // setup nhead_stride_* arguments
-    const ck_tile::index_t nhead_stride_q = stride_h_q;
-    const ck_tile::index_t nhead_stride_k = stride_h_k;
-    const ck_tile::index_t nhead_stride_v = stride_h_v;
-    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
-    const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
-    const ck_tile::index_t nhead_stride_o = stride_h_o;
-    const ck_tile::index_t nhead_stride_randval =
-        shape_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t nhead_stride_do = stride_h_do;
-    const ck_tile::index_t nhead_stride_lsed = max_seqlen_q;
-    const ck_tile::index_t nhead_stride_dq = stride_h_dq;
-    const ck_tile::index_t nhead_stride_dk = stride_h_dk;
-    const ck_tile::index_t nhead_stride_dv = stride_h_dv;
-    const ck_tile::index_t nhead_stride_dkv_expanded = stride_h_dkv_expanded;
-    // dbias can only be of BHSS
-    const ck_tile::index_t nhead_stride_dbias = max_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t nhead_stride_dq_acc = s_q*d; //dq_acc of shape (nsplits, B, H, S, D)
-    // setup batch_stride_* arguments
-    const ck_tile::index_t batch_stride_q = stride_b_q;
-    const ck_tile::index_t batch_stride_k = stride_b_k;
-    const ck_tile::index_t batch_stride_v = stride_b_v;
-    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
-    // for B1SS and BHSS, batch stride for bias are both bias_h x s_q x s_kv (bias_h==1 for B1SS and bias_h == h for BHSS)
-    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: bias_h* max_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t batch_stride_o = stride_b_o;
-    const ck_tile::index_t batch_stride_randval =
-        nhead * shape_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t batch_stride_do = stride_b_do;
-    const ck_tile::index_t batch_stride_lsed = nhead * max_seqlen_q;
-    const ck_tile::index_t batch_stride_dq = stride_b_dq;
-    const ck_tile::index_t batch_stride_dk = stride_b_dk;
-    const ck_tile::index_t batch_stride_dv = stride_b_dv;
-    const ck_tile::index_t batch_stride_dkv_expanded = stride_b_dkv_expanded;
-    // for dbias, use h since h can be different from bias_h
-    const ck_tile::index_t batch_stride_dbias = h* max_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t batch_stride_dq_acc = h*s_q*d; //dq_acc of shape (nsplits, B, H, S, D)
-    const ck_tile::index_t split_stride_dq_acc = b * h * s_q * d;
-
-    return fmha_bwd_args{q_ptr,
-                         k_ptr,
-                         v_ptr,
-                         bias_type==bias_enum::no_bias? nullptr : (bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr),
-                         o_ptr,
-                         lse_ptr,
-                         do_ptr,
-                         workspace_ptr,
-                         nullptr,
-                         dq_ptr,
-                         is_mqa_gqa? dk_expanded_ptr:dk_ptr,
-                         is_mqa_gqa? dv_expanded_ptr:dv_ptr,
-                         has_dbias? (bias_shape==BiasShape::kBHSS ? dbias_ptr: dbias_expanded_ptr): nullptr,
-                         dq_acc_ptr, //dq_acc_buf
-                         nullptr,//cu_seqlen_q
-                         nullptr,//cu_seqlen_kv
-                         nullptr, /* seqlen_k_ptr */
-                         shape_seqlen_q,
-                         shape_seqlen_k,
-                         batch,
-                         max_seqlen_q,
-                         max_seqlen_k,
-                         hdim_q,
-                         hdim_v,
-                         nhead,
-                         nhead_k,
-                         scale_s,
-                         stride_q,
-                         stride_k,
-                         stride_v,
-                         bias_type==bias_enum::alibi? 0: stride_bias,
-                         stride_o,
-                         stride_randval,
-                         stride_do,
-                         stride_dq_acc,//stride_dq_acc
-                         stride_dq,//stride_dq
-                         is_mqa_gqa? stride_dkv_expanded:stride_dk,
-                         is_mqa_gqa? stride_dkv_expanded:stride_dv,
-                         stride_dbias,
-                         nhead_stride_q,
-                         nhead_stride_k,
-                         nhead_stride_v,
-                         nhead_stride_bias,
-                         nhead_stride_o,
-                         nhead_stride_randval,
-                         nhead_stride_do,
-                         nhead_stride_lsed,
-                         nhead_stride_dq_acc, //nhead_stride_dq_acc
-                         nhead_stride_dq,
-                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dk,
-                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dv,
-                         nhead_stride_dbias,
-                         batch_stride_q,
-                         batch_stride_k,
-                         batch_stride_v,
-                         batch_stride_bias,
-                         batch_stride_o,
-                         batch_stride_randval,
-                         batch_stride_do,
-                         batch_stride_lsed,
-                         batch_stride_dq_acc, //batch_stride_dq_acc
-                         batch_stride_dq,
-                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dk,
-                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dv,
-                         batch_stride_dbias,
-                         split_stride_dq_acc,
-                         left,
-                         right,
-                         static_cast<ck_tile::index_t>(mask_type),
-                         p_drop,
-                         p_undrop,
-                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
-  }();
-
   if (ck_fused_attn_log_config) {
     std::cout<<std::endl<<"run ck fmha_bwd: "<<std::endl;
     // fmha_traits debug
@@ -513,6 +325,242 @@ hipError_t ck_attn_bwd(
     std::cout<<"dropout_seed_ptr: "<<std::get<0>(std::get<std::pair<const void*, const void*>>(fmha_args.drop_seed_offset))<<std::endl;
     std::cout<<"dropout_offset_ptr: "<<std::get<1>(std::get<std::pair<const void*, const void*>>(fmha_args.drop_seed_offset))<<std::endl;
   }
+
+}
+hipError_t ck_attn_bwd(  
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
+  const void* q_ptr, 
+  uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* bias_ptr,
+  const void* alibi_slope_ptr,
+  const void* o_ptr, 
+  uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
+  const void* lse_ptr, 
+  const void* do_ptr, 
+  uint64_t stride_b_do, uint64_t stride_h_do, uint64_t stride_s_do,
+  float scaling_factor, float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  BiasType attn_bias_type,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* dq_ptr, 
+  uint64_t stride_b_dq, uint64_t stride_h_dq, uint64_t stride_s_dq,
+  void* dq_acc_ptr,
+  void* dk_expanded_ptr,
+  void* dv_expanded_ptr,
+  uint64_t stride_b_dkv_expanded, uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
+  void* dk_ptr, 
+  uint64_t stride_b_dk, uint64_t stride_h_dk, uint64_t stride_s_dk,
+  void* dv_ptr, 
+  uint64_t stride_b_dv, uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* dbias_expanded_ptr,
+  void* dbias_ptr,
+  void* lse_workspace_ptr,
+  bool deterministic,
+  bool uses_bwd_v3,
+  bool is_v3_atomic_fp32,
+  int how_v3_bf16_cvt,
+  hipStream_t stream){
+
+  bool has_dropout = (dropout_probability > 0.f);
+  bool has_dbias = dbias_ptr!=nullptr;
+  bool is_mqa_gqa = (h > hg);
+
+  /* CK input parameters */
+  ck_tile::index_t batch = b;
+  ck_tile::index_t seqlen_q = s_q;
+  ck_tile::index_t nhead = h;
+  ck_tile::index_t hdim_q = d;
+  ck_tile::index_t seqlen_k = s_kv;
+  ck_tile::index_t nhead_k = hg;
+  ck_tile::index_t hdim_v = d;
+  ck_tile::index_t max_seqlen_q = s_q;
+  ck_tile::index_t max_seqlen_k = s_kv;
+  float scale_s = scaling_factor;
+  float p_drop = dropout_probability;
+  float p_undrop = 1.0 - p_drop;
+  bool is_group_mode = false;
+  bool s_randval = false;
+
+  bias_enum bias_type;
+  BiasShape bias_shape; 
+  std::tie(bias_type, bias_shape) = get_ck_bias_type_shape(attn_bias_type, b, h, bias_b, bias_h);
+
+  mask_enum mask_type;
+  ck_tile::index_t left, right;
+  if (attn_mask_type == MaskType::no_mask){
+    mask_type = mask_enum::no_mask;
+  }else if(attn_mask_type == MaskType::mask_top_left){
+    mask_type = mask_enum::mask_top_left;
+  }else if(attn_mask_type == MaskType::mask_bottom_right){
+    mask_type = mask_enum::mask_bottom_right;
+  }else{
+    mask_type = mask_enum::window_generic;
+  }
+  left = window_size_left;
+  right = window_size_right;
+ 
+  bool ck_fused_attn_log_config = false;
+  if (const char* env_p = std::getenv("CK_FUSED_ATTN_LOG_CONFIG") ) {
+    if (env_p != nullptr && std::string(env_p) == "1")
+      ck_fused_attn_log_config = true;
+  } 
+  // print kernel name on verbose mode
+  ck_tile::stream_config stream_config{stream, false, ck_fused_attn_log_config};
+
+  ck_tile::index_t shape_seqlen_q = seqlen_q;
+  ck_tile::index_t shape_seqlen_k = seqlen_k;
+
+  std::string data_type_str = get_data_type_str(dtype);
+
+  auto fmha_traits =
+    fmha_bwd_traits{hdim_q,    hdim_v,    data_type_str, is_group_mode,
+                    mask_type, bias_type, has_dbias,     has_dropout, 
+                    s_randval, deterministic, 
+                    uses_bwd_v3, // use_bwd_v3
+                    is_v3_atomic_fp32, // is_v3_atomic_fp32
+                    how_v3_bf16_cvt //how_v3_bf16_cvt 0:RTNE; 1:RTNA; 2:RTZ
+                    };
+
+  auto fmha_args = [&]() {
+    // setup stride_* arguments
+    const ck_tile::index_t stride_q = stride_s_q;
+    const ck_tile::index_t stride_k = stride_s_k;
+    const ck_tile::index_t stride_v = stride_s_v;
+    // bias of shape (bias_b, bias_h, s_q, s_kv)
+    const ck_tile::index_t stride_bias = max_seqlen_k;
+    const ck_tile::index_t stride_o = stride_s_o;
+    const ck_tile::index_t stride_randval = max_seqlen_k;
+    const ck_tile::index_t stride_do = stride_s_do;
+    const ck_tile::index_t stride_dq = stride_s_dq;
+    const ck_tile::index_t stride_dk = stride_s_dk;
+    const ck_tile::index_t stride_dv = stride_s_dv;
+    const ck_tile::index_t stride_dkv_expanded = stride_s_dkv_expanded;
+    const ck_tile::index_t stride_dq_acc = d; //dq_acc of shape (nsplits, B, H, S, D)
+    // dbias is of the same shape as bias
+    // but ck only take dbias with BHSS
+    const ck_tile::index_t stride_dbias = max_seqlen_k;
+    // setup nhead_stride_* arguments
+    const ck_tile::index_t nhead_stride_q = stride_h_q;
+    const ck_tile::index_t nhead_stride_k = stride_h_k;
+    const ck_tile::index_t nhead_stride_v = stride_h_v;
+    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
+    const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
+    const ck_tile::index_t nhead_stride_o = stride_h_o;
+    const ck_tile::index_t nhead_stride_randval =
+        shape_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t nhead_stride_do = stride_h_do;
+    const ck_tile::index_t nhead_stride_lsed = max_seqlen_q;
+    const ck_tile::index_t nhead_stride_dq = stride_h_dq;
+    const ck_tile::index_t nhead_stride_dk = stride_h_dk;
+    const ck_tile::index_t nhead_stride_dv = stride_h_dv;
+    const ck_tile::index_t nhead_stride_dkv_expanded = stride_h_dkv_expanded;
+    // dbias can only be of BHSS
+    const ck_tile::index_t nhead_stride_dbias = max_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t nhead_stride_dq_acc = s_q*d; //dq_acc of shape (nsplits, B, H, S, D)
+    // setup batch_stride_* arguments
+    const ck_tile::index_t batch_stride_q = stride_b_q;
+    const ck_tile::index_t batch_stride_k = stride_b_k;
+    const ck_tile::index_t batch_stride_v = stride_b_v;
+    // bias input can be of different shapes (11SS, 1HSS, B1SS, and BHSS), but dbias must be of BHSS
+    // for B1SS and BHSS, batch stride for bias are both bias_h x s_q x s_kv (bias_h==1 for B1SS and bias_h == h for BHSS)
+    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: bias_h* max_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t batch_stride_o = stride_b_o;
+    const ck_tile::index_t batch_stride_randval =
+        nhead * shape_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t batch_stride_do = stride_b_do;
+    const ck_tile::index_t batch_stride_lsed = nhead * max_seqlen_q;
+    const ck_tile::index_t batch_stride_dq = stride_b_dq;
+    const ck_tile::index_t batch_stride_dk = stride_b_dk;
+    const ck_tile::index_t batch_stride_dv = stride_b_dv;
+    const ck_tile::index_t batch_stride_dkv_expanded = stride_b_dkv_expanded;
+    // for dbias, use h since h can be different from bias_h
+    const ck_tile::index_t batch_stride_dbias = h* max_seqlen_q * max_seqlen_k;
+    const ck_tile::index_t batch_stride_dq_acc = h*s_q*d; //dq_acc of shape (nsplits, B, H, S, D)
+    const ck_tile::index_t split_stride_dq_acc = b * h * s_q * d;
+
+    return fmha_bwd_args{q_ptr,
+                         k_ptr,
+                         v_ptr,
+                         bias_type==bias_enum::no_bias? nullptr : (bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr),
+                         o_ptr,
+                         lse_ptr,
+                         do_ptr,
+                         lse_workspace_ptr,
+                         nullptr,
+                         dq_ptr,
+                         is_mqa_gqa? dk_expanded_ptr:dk_ptr,
+                         is_mqa_gqa? dv_expanded_ptr:dv_ptr,
+                         has_dbias? (bias_shape==BiasShape::kBHSS ? dbias_ptr: dbias_expanded_ptr): nullptr,
+                         dq_acc_ptr, //dq_acc_buf
+                         nullptr,//cu_seqlen_q
+                         nullptr,//cu_seqlen_kv
+                         nullptr, /* seqlen_k_ptr */
+                         shape_seqlen_q,
+                         shape_seqlen_k,
+                         batch,
+                         max_seqlen_q,
+                         max_seqlen_k,
+                         hdim_q,
+                         hdim_v,
+                         nhead,
+                         nhead_k,
+                         scale_s,
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         bias_type==bias_enum::alibi? 0: stride_bias,
+                         stride_o,
+                         stride_randval,
+                         stride_do,
+                         stride_dq_acc,//stride_dq_acc
+                         stride_dq,//stride_dq
+                         is_mqa_gqa? stride_dkv_expanded:stride_dk,
+                         is_mqa_gqa? stride_dkv_expanded:stride_dv,
+                         stride_dbias,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         nhead_stride_bias,
+                         nhead_stride_o,
+                         nhead_stride_randval,
+                         nhead_stride_do,
+                         nhead_stride_lsed,
+                         nhead_stride_dq_acc, //nhead_stride_dq_acc
+                         nhead_stride_dq,
+                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dk,
+                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dv,
+                         nhead_stride_dbias,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         batch_stride_bias,
+                         batch_stride_o,
+                         batch_stride_randval,
+                         batch_stride_do,
+                         batch_stride_lsed,
+                         batch_stride_dq_acc, //batch_stride_dq_acc
+                         batch_stride_dq,
+                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dk,
+                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dv,
+                         batch_stride_dbias,
+                         split_stride_dq_acc,
+                         left,
+                         right,
+                         static_cast<ck_tile::index_t>(mask_type),
+                         p_drop,
+                         p_undrop,
+                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
+  }();
+
+  // print ck traits and args when needed
+  log_bwd_config(__FUNCTION__, fmha_traits, fmha_args); 
+
   float average_runtime = fmha_bwd(fmha_traits, fmha_args, stream_config);
   if(average_runtime < 0){
     //TODO: better error out system
@@ -588,6 +636,264 @@ hipError_t ck_attn_bwd(
           static_cast<CK_TILE_TYPE*>(dbias_expanded_ptr),
           static_cast<CK_TILE_TYPE*>(dbias_ptr));); 
     }
+  }
+  return hipSuccess;
+}
+
+hipError_t ck_attn_varlen_bwd(  
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  const void* q_ptr, 
+  uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  const void* o_ptr, 
+  uint64_t stride_h_o, uint64_t stride_s_o,
+  const void* lse_ptr, 
+  const void* do_ptr, 
+  uint64_t stride_h_do, uint64_t stride_s_do,
+  float scaling_factor, float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* dq_ptr, 
+  uint64_t stride_h_dq, uint64_t stride_s_dq,
+  void* dq_acc_ptr,
+  void* dk_expanded_ptr,
+  void* dv_expanded_ptr,
+  uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
+  void* dk_ptr, 
+  uint64_t stride_h_dk, uint64_t stride_s_dk,
+  void* dv_ptr, 
+  uint64_t stride_h_dv, uint64_t stride_s_dv,
+  void* lse_workspace_ptr,
+  void* lse_thd_ptr,
+  bool deterministic,
+  hipStream_t stream){
+
+  bool has_dropout = (dropout_probability > 0.f);
+  bool has_dbias = false;
+  bool is_mqa_gqa = (h > hg);
+
+  /* CK input parameters */
+  ck_tile::index_t batch = b;
+  ck_tile::index_t nhead = h;
+  ck_tile::index_t hdim_q = d;
+  ck_tile::index_t nhead_k = hg;
+  ck_tile::index_t hdim_v = d;
+  ck_tile::index_t max_seqlen_q = s_q;
+  ck_tile::index_t max_seqlen_k = s_kv;
+  ck_tile::index_t total_seqlen_q = *(static_cast<const int32_t *>(cu_seqlen_q_ptr) + b);
+  ck_tile::index_t total_seqlen_kv = *(static_cast<const int32_t *>(cu_seqlen_kv_ptr) + b);
+  float scale_s = scaling_factor;
+  float p_drop = dropout_probability;
+  float p_undrop = 1.0 - p_drop;
+  bool is_group_mode = true;
+  bool s_randval = false;
+
+  // convert the softmax_lse from shape [b, h, s_q] into THD
+  if(lse_thd_ptr!=lse_ptr){
+    assert((lse_thd_ptr!=nullptr) && (lse_ptr!=nullptr));
+    constexpr int THREADS_PER_BLOCK = 1024;
+    dim3 block(THREADS_PER_BLOCK);
+    dim3 grid(ceil(1.0 * b * h/THREADS_PER_BLOCK));
+    hipLaunchKernelGGL(
+      softmax_lse_to_thd, grid, block, 0, stream,
+      b, h, s_q, static_cast<const int32_t*>(cu_seqlen_q_ptr),
+      static_cast<const float*>(lse_ptr),
+      static_cast<float*>(lse_thd_ptr));
+  }
+
+  // THD does not work with bias
+
+  mask_enum mask_type = get_ck_mask_type(attn_mask_type);
+
+  ck_tile::index_t left, right;
+  left = window_size_left;
+  right = window_size_right;
+ 
+  bool ck_fused_attn_log_config = false;
+  if (const char* env_p = std::getenv("CK_FUSED_ATTN_LOG_CONFIG") ) {
+    if (env_p != nullptr && std::string(env_p) == "1")
+      ck_fused_attn_log_config = true;
+  } 
+  // print kernel name on verbose mode
+  ck_tile::stream_config stream_config{stream, false, ck_fused_attn_log_config};
+
+  std::string data_type_str = get_data_type_str(dtype);
+
+  auto fmha_traits =
+    fmha_bwd_traits{hdim_q,    hdim_v,    data_type_str, is_group_mode,
+                    mask_type, bias_enum::no_bias, has_dbias,     has_dropout, 
+                    s_randval, deterministic, 
+                    false, // use_bwd_v3
+                    true, // is_v3_atomic_fp32
+                    1 //how_v3_bf16_cvt 0:RTNE; 1:RTNA; 2:RTZ
+                    };
+
+  auto fmha_args = [&]() {
+    // setup stride_* arguments
+    const ck_tile::index_t stride_q = stride_s_q;
+    const ck_tile::index_t stride_k = stride_s_k;
+    const ck_tile::index_t stride_v = stride_s_v;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t stride_bias = 0;
+    const ck_tile::index_t stride_o = stride_s_o;
+    const ck_tile::index_t stride_randval = max_seqlen_k;
+    const ck_tile::index_t stride_do = stride_s_do;
+    const ck_tile::index_t stride_dq = stride_s_dq;
+    const ck_tile::index_t stride_dk = stride_s_dk;
+    const ck_tile::index_t stride_dv = stride_s_dv;
+    const ck_tile::index_t stride_dkv_expanded = stride_s_dkv_expanded;
+    const ck_tile::index_t stride_dq_acc = h*d; //dq_acc of shape (nsplits, T, H, D)
+    // bias not used in THD qkv layout
+    const ck_tile::index_t stride_dbias = 0;
+    // setup nhead_stride_* arguments
+    const ck_tile::index_t nhead_stride_q = stride_h_q;
+    const ck_tile::index_t nhead_stride_k = stride_h_k;
+    const ck_tile::index_t nhead_stride_v = stride_h_v;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t nhead_stride_bias = 0;
+    const ck_tile::index_t nhead_stride_o = stride_h_o;
+    const ck_tile::index_t nhead_stride_randval = 0;
+    const ck_tile::index_t nhead_stride_do = stride_h_do;
+    // lsed and lse of shape [h, total_seqlen_q]
+    const ck_tile::index_t nhead_stride_lsed = total_seqlen_q;
+    const ck_tile::index_t nhead_stride_dq = stride_h_dq;
+    const ck_tile::index_t nhead_stride_dk = stride_h_dk;
+    const ck_tile::index_t nhead_stride_dv = stride_h_dv;
+    const ck_tile::index_t nhead_stride_dkv_expanded = stride_h_dkv_expanded;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t nhead_stride_dbias = 0;
+    const ck_tile::index_t nhead_stride_dq_acc = d; //dq_acc of shape (nsplits, T, H, D)
+    // setup batch_stride_* arguments
+    const ck_tile::index_t batch_stride_q = 0;
+    const ck_tile::index_t batch_stride_k = 0;
+    const ck_tile::index_t batch_stride_v = 0;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t batch_stride_bias = 0;
+    const ck_tile::index_t batch_stride_o = 0;
+    const ck_tile::index_t batch_stride_randval = 0;
+    const ck_tile::index_t batch_stride_do = 0;
+    const ck_tile::index_t batch_stride_lsed = 0;
+    const ck_tile::index_t batch_stride_dq = 0;
+    const ck_tile::index_t batch_stride_dk = 0;
+    const ck_tile::index_t batch_stride_dv = 0;
+    const ck_tile::index_t batch_stride_dkv_expanded = 0;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t batch_stride_dbias = 0;
+    const ck_tile::index_t batch_stride_dq_acc = 0; //dq_acc of shape (nsplits, T, H, D)
+    const ck_tile::index_t split_stride_dq_acc = total_seqlen_q*h*d;
+
+    return fmha_bwd_args{q_ptr,
+                         k_ptr,
+                         v_ptr,
+                         nullptr,
+                         o_ptr,
+                         lse_thd_ptr,
+                         do_ptr,
+                         lse_workspace_ptr,
+                         nullptr,
+                         dq_ptr,
+                         is_mqa_gqa? dk_expanded_ptr:dk_ptr,
+                         is_mqa_gqa? dv_expanded_ptr:dv_ptr,
+                         nullptr,
+                         dq_acc_ptr, //dq_acc_buf
+                         cu_seqlen_q_ptr,//cu_seqlen_q
+                         cu_seqlen_kv_ptr,//cu_seqlen_kv
+                         nullptr, /* seqlen_k_ptr */
+                         total_seqlen_q,
+                         total_seqlen_kv,
+                         batch,
+                         max_seqlen_q,
+                         max_seqlen_k,
+                         hdim_q,
+                         hdim_v,
+                         nhead,
+                         nhead_k,
+                         scale_s,
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         stride_bias,
+                         stride_o,
+                         stride_randval,
+                         stride_do,
+                         stride_dq_acc,//stride_dq_acc
+                         stride_dq,//stride_dq
+                         is_mqa_gqa? stride_dkv_expanded:stride_dk,
+                         is_mqa_gqa? stride_dkv_expanded:stride_dv,
+                         stride_dbias,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         nhead_stride_bias,
+                         nhead_stride_o,
+                         nhead_stride_randval,
+                         nhead_stride_do,
+                         nhead_stride_lsed,
+                         nhead_stride_dq_acc, //nhead_stride_dq_acc
+                         nhead_stride_dq,
+                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dk,
+                         is_mqa_gqa? nhead_stride_dkv_expanded:nhead_stride_dv,
+                         nhead_stride_dbias,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         batch_stride_bias,
+                         batch_stride_o,
+                         batch_stride_randval,
+                         batch_stride_do,
+                         batch_stride_lsed,
+                         batch_stride_dq_acc, //batch_stride_dq_acc
+                         batch_stride_dq,
+                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dk,
+                         is_mqa_gqa? batch_stride_dkv_expanded:batch_stride_dv,
+                         batch_stride_dbias,
+                         split_stride_dq_acc,
+                         left,
+                         right,
+                         static_cast<ck_tile::index_t>(mask_type),
+                         p_drop,
+                         p_undrop,
+                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
+  }();
+
+  // print ck traits and args when needed
+  log_bwd_config(__FUNCTION__, fmha_traits, fmha_args); 
+
+  float average_runtime = fmha_bwd(fmha_traits, fmha_args, stream_config);
+  if(average_runtime < 0){
+    //TODO: better error out system
+    throw std::runtime_error("fused attn configs not supported in ck_fused_attn bwd pass.");
+  }
+  if(is_mqa_gqa){
+    dim3 grid(total_seqlen_kv, hg);
+    dim3 block(d);
+    if (ck_fused_attn_log_config){
+      std::cout<<std::endl<<"run dk_dv_reduce_thd: "<<std::endl;
+      std::cout<<"dk_expanded_ptr: "<<dk_expanded_ptr<<std::endl;
+      std::cout<<"dv_expanded_ptr: "<<dv_expanded_ptr<<std::endl;
+      std::cout<<"stride_h_dkv_expanded: "<<stride_h_dkv_expanded<<std::endl;
+      std::cout<<"stride_s_dkv_expanded: "<<stride_s_dkv_expanded<<std::endl;
+      std::cout<<"dk_ptr: "<<dk_ptr<<std::endl;
+      std::cout<<"dv_ptr: "<<dv_ptr<<std::endl;
+      std::cout<<"stride_h_dk: "<<stride_h_dk<<std::endl;
+      std::cout<<"stride_s_dk: "<<stride_s_dk<<std::endl;
+    }
+    CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
+      hipLaunchKernelGGL(
+        dk_dv_reduce_thd<CK_TILE_TYPE>, grid, block, 0, stream,
+        h, hg, d, total_seqlen_kv,
+        static_cast<CK_TILE_TYPE*>(dk_expanded_ptr),
+        static_cast<CK_TILE_TYPE*>(dv_expanded_ptr),
+        stride_h_dkv_expanded, stride_s_dkv_expanded,
+        static_cast<CK_TILE_TYPE*>(dk_ptr),
+        static_cast<CK_TILE_TYPE*>(dv_ptr),
+        stride_h_dk, stride_s_dk););
   }
   return hipSuccess;
 }

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/
@@ -17,183 +17,34 @@
 
 namespace ck_fused_attn{
 
-hipError_t ck_attn_fwd(
-  DType dtype,
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
-  const void* q_ptr, 
-  uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
-  const void* k_ptr, 
-  uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
-  const void* v_ptr, 
-  uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
-  const void* bias_ptr,
-  const void* alibi_slope_ptr,
-  bool is_training,
-  float scaling_factor,
-  float dropout_probability,
-  void* philox_seed_ptr, void* philox_offset_ptr,
-  BiasType attn_bias_type,
-  MaskType attn_mask_type,
-  int64_t window_size_left, int64_t window_size_right,
-  void* o_ptr, 
-  uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
-  void* lse_ptr, 
-  hipStream_t stream){
+// cuda kernel to convert softmax lse from [h, total_seqlen_q] to [b, h, s_q]
+__global__ void softmax_lse_from_thd(
+  uint64_t b, uint64_t h, uint64_t s_q,
+  const int32_t* cu_seqlen_q,
+  const float* lse_thd,
+  float* lse){
 
-  bool has_dropout = (is_training && dropout_probability > 0.f);
-  bool has_lse = (lse_ptr != nullptr);
-
-  /* CK input parameters */
-  ck_tile::index_t batch = b;
-  ck_tile::index_t seqlen_q = s_q;
-  ck_tile::index_t nhead = h;
-  ck_tile::index_t hdim_q = d;
-  ck_tile::index_t seqlen_k = s_kv;
-  ck_tile::index_t nhead_k = hg;
-  ck_tile::index_t hdim_v = d;
-  ck_tile::index_t max_seqlen_q = s_q;
-  ck_tile::index_t max_seqlen_k = s_kv;
-  float scale_s = scaling_factor;
-  float scale_p = 1.f;
-  float scale_o = 1.f;
-  float p_drop = dropout_probability;
-  bool is_group_mode = false;
-  bool is_v_rowmajor = true;
-  bool do_fp8_static_quant = false;
-
-  bias_enum bias_type;
-  BiasShape bias_shape; 
-  if (attn_bias_type==BiasType::no_bias){
-    bias_type = bias_enum::no_bias;
-  }else if (attn_bias_type==BiasType::elementwise_bias){
-    bias_type = bias_enum::elementwise_bias;
-    bias_shape = get_bias_shape(b, h, bias_b, bias_h);
-  }else if (attn_bias_type==BiasType::alibi){
-    bias_type = bias_enum::alibi;
-  }else{
-    //TODO: better error out system
-    throw std::runtime_error("Invalid bias_type in ck_fused_attn.");
-  }
-
-  mask_enum mask_type;
-  ck_tile::index_t left, right;
-  if (attn_mask_type == MaskType::no_mask){
-    mask_type = mask_enum::no_mask;
-  }else if(attn_mask_type == MaskType::mask_top_left){
-    mask_type = mask_enum::mask_top_left;
-  }else if(attn_mask_type == MaskType::mask_bottom_right){
-    mask_type = mask_enum::mask_bottom_right;
-  }else{
-    mask_type = mask_enum::window_generic;
-  }
-  left = window_size_left;
-  right = window_size_right;
+  int32_t total_seqlen_q = cu_seqlen_q[b];
   
-  ck_tile::stream_config stream_config{stream};
-
-  ck_tile::index_t shape_seqlen_q = seqlen_q;
-  ck_tile::index_t shape_seqlen_k = seqlen_k;
-
-  std::string data_type_str;
-  if(dtype==DType::kFloat16){
-    data_type_str = "fp16";
-  }else if(dtype==DType::kBFloat16){
-    data_type_str = "bf16";
-  }else{
-    //TODO: better error out system
-    throw std::runtime_error("Invalid dtype in ck_fused_attn.");
+  for(uint64_t bh_idx = blockIdx.x*blockDim.x + threadIdx.x; bh_idx < b*h; bh_idx += blockDim.x * gridDim.x){
+    uint64_t b_idx = bh_idx/h;
+    uint64_t h_idx = bh_idx%h;
+    // loop over a given batch and head idx
+    for(uint64_t s_idx = cu_seqlen_q[b_idx]; s_idx < cu_seqlen_q[b_idx + 1]; s_idx++){
+      lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]] = lse_thd[h_idx * total_seqlen_q + s_idx];
+    }
   }
+}
 
-  auto fmha_traits = fmha_fwd_traits{
-    hdim_q,    hdim_v,    data_type_str, is_group_mode, is_v_rowmajor,
-    mask_type, bias_type, has_lse,       has_dropout,   do_fp8_static_quant};
-
-  auto fmha_args = [&]() {
-    // setup stride_* arguments
-    const ck_tile::index_t stride_q = stride_s_q;
-    const ck_tile::index_t stride_k = stride_s_k;
-    const ck_tile::index_t stride_v = stride_s_v;
-    // bias is of shape [b, h , s_q, s_kv]
-    const ck_tile::index_t stride_bias = max_seqlen_k;
-    const ck_tile::index_t stride_randval = max_seqlen_k;
-    const ck_tile::index_t stride_o = stride_s_o;
-    // setup nhead_stride_* arguments
-    const ck_tile::index_t nhead_stride_q = stride_h_q;
-    const ck_tile::index_t nhead_stride_k = stride_h_k;
-    const ck_tile::index_t nhead_stride_v = stride_h_v;
-    const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
-    //TODO: randval never used, can we remove it
-    const ck_tile::index_t nhead_stride_randval =
-        shape_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t nhead_stride_lse = shape_seqlen_q;
-    const ck_tile::index_t nhead_stride_o = stride_h_o;
-    // setup batch_stride_* arguments
-    const ck_tile::index_t batch_stride_q = stride_b_q;
-    const ck_tile::index_t batch_stride_k = stride_b_k;
-    const ck_tile::index_t batch_stride_v = stride_b_v;
-    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: (bias_shape==BiasShape::kBHSS? bias_h* max_seqlen_q * max_seqlen_k: max_seqlen_q*max_seqlen_k);
-    //TODO: randval never used, can we remove it
-    const ck_tile::index_t batch_stride_randval =
-        nhead * shape_seqlen_q * max_seqlen_k;
-    const ck_tile::index_t batch_stride_lse = nhead * shape_seqlen_q;
-    const ck_tile::index_t batch_stride_o = stride_b_o;
-
-    return fmha_fwd_args{q_ptr,
-                         k_ptr,
-                         v_ptr,
-                         bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr,
-                         nullptr,//rand_val_ptr
-                         lse_ptr,
-                         o_ptr,
-                         nullptr,//cu_seqlen_q
-                         nullptr,//cu_seqlen_kv
-                         nullptr, /* seqlen_k_ptr */
-                         shape_seqlen_q,
-                         shape_seqlen_k,
-                         batch,
-                         max_seqlen_q,
-                         hdim_q,
-                         hdim_v,
-                         nhead,
-                         nhead_k,
-                         scale_s,
-                         scale_p,
-                         scale_o,
-                         stride_q,
-                         stride_k,
-                         stride_v,
-                         bias_type==bias_enum::alibi? 0: stride_bias, // upstream TE only requires standard (vanilla) alibi slopes
-                         stride_randval,
-                         stride_o,
-                         nhead_stride_q,
-                         nhead_stride_k,
-                         nhead_stride_v,
-                         nhead_stride_bias,
-                         nhead_stride_randval,
-                         nhead_stride_lse,
-                         nhead_stride_o,
-                         batch_stride_q,
-                         batch_stride_k,
-                         batch_stride_v,
-                         batch_stride_bias,
-                         batch_stride_randval,
-                         batch_stride_lse,
-                         batch_stride_o,
-                         left,
-                         right,
-                         static_cast<ck_tile::index_t>(mask_type),
-                         p_drop,
-                         false,
-                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
-  }();
-  
+// print the fmha traits and args when calling ck apis
+void log_fwd_config(const char* func_name, const fmha_fwd_traits& fmha_traits, const fmha_fwd_args& fmha_args){
   bool ck_fused_attn_log_config = false;
   if (const char* env_p = std::getenv("CK_FUSED_ATTN_LOG_CONFIG") ) {
     if (env_p != nullptr && std::string(env_p) == "1")
       ck_fused_attn_log_config = true;
   }
   if (ck_fused_attn_log_config) {
-    std::cout<<std::endl<<"run ck fmha_fwd: "<<std::endl;
+    std::cout<<std::endl<<func_name<<std::endl;
 
     // debug fmha_traits
     std::cout<<"fmha_traits: "<<std::endl;
@@ -260,6 +111,150 @@ hipError_t ck_attn_fwd(
     std::cout<<"dropout_seed_ptr: "<<std::get<0>(std::get<std::pair<const void*, const void*>>(fmha_args.drop_seed_offset))<<std::endl;
     std::cout<<"dropout_offset_ptr: "<<std::get<1>(std::get<std::pair<const void*, const void*>>(fmha_args.drop_seed_offset))<<std::endl;
   }
+}
+
+hipError_t ck_attn_fwd(
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
+  const void* q_ptr, 
+  uint64_t stride_b_q, uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_b_k, uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_b_v, uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* bias_ptr,
+  const void* alibi_slope_ptr,
+  bool is_training,
+  float scaling_factor,
+  float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  BiasType attn_bias_type,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* o_ptr, 
+  uint64_t stride_b_o, uint64_t stride_h_o, uint64_t stride_s_o,
+  void* lse_ptr, 
+  hipStream_t stream){
+
+  bool has_dropout = (is_training && dropout_probability > 0.f);
+  bool has_lse = (lse_ptr != nullptr);
+
+  /* CK input parameters */
+  ck_tile::index_t batch = b;
+  ck_tile::index_t nhead = h;
+  ck_tile::index_t hdim_q = d;
+  ck_tile::index_t nhead_k = hg;
+  ck_tile::index_t hdim_v = d;
+  ck_tile::index_t max_seqlen_q = s_q;
+  ck_tile::index_t max_seqlen_k = s_kv;
+  float scale_s = scaling_factor;
+  float scale_p = 1.f;
+  float scale_o = 1.f;
+  float p_drop = dropout_probability;
+  bool is_group_mode = false;
+  bool is_v_rowmajor = true;
+  bool do_fp8_static_quant = false;
+
+  bias_enum bias_type;
+  BiasShape bias_shape; 
+  std::tie(bias_type, bias_shape) = get_ck_bias_type_shape(attn_bias_type, b, h, bias_b, bias_h);
+
+  mask_enum mask_type = get_ck_mask_type(attn_mask_type);
+
+  ck_tile::index_t left, right;
+  left = window_size_left;
+  right = window_size_right;
+  
+  ck_tile::stream_config stream_config{stream};
+
+  std::string data_type_str = get_data_type_str(dtype);
+
+  auto fmha_traits = fmha_fwd_traits{
+    hdim_q,    hdim_v,    data_type_str, is_group_mode, is_v_rowmajor,
+    mask_type, bias_type, has_lse,       has_dropout,   do_fp8_static_quant};
+
+  auto fmha_args = [&]() {
+    // setup stride_* arguments
+    const ck_tile::index_t stride_q = stride_s_q;
+    const ck_tile::index_t stride_k = stride_s_k;
+    const ck_tile::index_t stride_v = stride_s_v;
+    // bias is of shape [b, h , s_q, s_kv]
+    const ck_tile::index_t stride_bias = max_seqlen_k;
+    const ck_tile::index_t stride_randval = max_seqlen_k;
+    const ck_tile::index_t stride_o = stride_s_o;
+    // setup nhead_stride_* arguments
+    const ck_tile::index_t nhead_stride_q = stride_h_q;
+    const ck_tile::index_t nhead_stride_k = stride_h_k;
+    const ck_tile::index_t nhead_stride_v = stride_h_v;
+    const ck_tile::index_t nhead_stride_bias = (bias_shape==BiasShape::k1HSS || bias_shape==BiasShape::kBHSS) ? max_seqlen_q * max_seqlen_k: 0;
+    //TODO: randval never used, can we remove it
+    const ck_tile::index_t nhead_stride_randval = 0;
+    // softmax_lse is of shape [b, h, s_q]
+    const ck_tile::index_t nhead_stride_lse = max_seqlen_q;
+    const ck_tile::index_t nhead_stride_o = stride_h_o;
+    // setup batch_stride_* arguments
+    const ck_tile::index_t batch_stride_q = stride_b_q;
+    const ck_tile::index_t batch_stride_k = stride_b_k;
+    const ck_tile::index_t batch_stride_v = stride_b_v;
+    const ck_tile::index_t batch_stride_bias = (bias_shape==BiasShape::k11SS || bias_shape==BiasShape::k1HSS) ? 0: (bias_shape==BiasShape::kBHSS? bias_h* max_seqlen_q * max_seqlen_k: max_seqlen_q*max_seqlen_k);
+    //TODO: randval never used, can we remove it
+    const ck_tile::index_t batch_stride_randval = 0;
+    // softmax_lse is of shape [b, h, s_q]
+    const ck_tile::index_t batch_stride_lse = nhead * max_seqlen_q;
+    const ck_tile::index_t batch_stride_o = stride_b_o;
+
+    return fmha_fwd_args{q_ptr,
+                         k_ptr,
+                         v_ptr,
+                         bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr,
+                         nullptr,//rand_val_ptr
+                         lse_ptr,
+                         o_ptr,
+                         nullptr,//cu_seqlen_q
+                         nullptr,//cu_seqlen_kv
+                         nullptr, /* seqlen_k_ptr */
+                         max_seqlen_q,
+                         max_seqlen_k,
+                         batch,
+                         max_seqlen_q,
+                         hdim_q,
+                         hdim_v,
+                         nhead,
+                         nhead_k,
+                         scale_s,
+                         scale_p,
+                         scale_o,
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         bias_type==bias_enum::alibi? 0: stride_bias, // upstream TE only requires standard (vanilla) alibi slopes
+                         stride_randval,
+                         stride_o,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         nhead_stride_bias,
+                         nhead_stride_randval,
+                         nhead_stride_lse,
+                         nhead_stride_o,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         batch_stride_bias,
+                         batch_stride_randval,
+                         batch_stride_lse,
+                         batch_stride_o,
+                         left,
+                         right,
+                         static_cast<ck_tile::index_t>(mask_type),
+                         p_drop,
+                         false,
+                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
+  }();
+  
+  // print ck traits and args when needed
+  log_fwd_config(__FUNCTION__, fmha_traits, fmha_args); 
+
   float average_runtime = fmha_fwd(fmha_traits, fmha_args, stream_config);
   if(average_runtime < 0){
     //TODO: better error out system
@@ -267,4 +262,169 @@ hipError_t ck_attn_fwd(
   }
   return hipSuccess;
 }
+
+hipError_t ck_attn_varlen_fwd(
+  DType dtype,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d,
+  const void* q_ptr, 
+  uint64_t stride_h_q, uint64_t stride_s_q,
+  const void* k_ptr, 
+  uint64_t stride_h_k, uint64_t stride_s_k,
+  const void* v_ptr, 
+  uint64_t stride_h_v, uint64_t stride_s_v,
+  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  bool is_training,
+  float scaling_factor,
+  float dropout_probability,
+  void* philox_seed_ptr, void* philox_offset_ptr,
+  MaskType attn_mask_type,
+  int64_t window_size_left, int64_t window_size_right,
+  void* o_ptr, 
+  uint64_t stride_h_o, uint64_t stride_s_o,
+  void* lse_thd_ptr,
+  void* lse_ptr, 
+  hipStream_t stream){
+
+  bool has_dropout = (is_training && dropout_probability > 0.f);
+  bool has_lse = (lse_ptr != nullptr);
+
+  /* CK input parameters */
+  ck_tile::index_t batch = b;
+  ck_tile::index_t nhead = h;
+  ck_tile::index_t hdim_q = d;
+  ck_tile::index_t nhead_k = hg;
+  ck_tile::index_t hdim_v = d;
+  ck_tile::index_t max_seqlen_q = s_q;
+  ck_tile::index_t total_seqlen_q = *(static_cast<const int32_t *>(cu_seqlen_q_ptr) + b);
+  ck_tile::index_t total_seqlen_kv = *(static_cast<const int32_t *>(cu_seqlen_kv_ptr) + b);
+
+  float scale_s = scaling_factor;
+  float scale_p = 1.f;
+  float scale_o = 1.f;
+  float p_drop = dropout_probability;
+  bool is_group_mode = true;
+  bool is_v_rowmajor = true;
+  bool do_fp8_static_quant = false;
+
+  // THD does not work with bias
+
+  mask_enum mask_type = get_ck_mask_type(attn_mask_type);
+
+  ck_tile::index_t left, right;
+  left = window_size_left;
+  right = window_size_right;
+  
+  ck_tile::stream_config stream_config{stream};
+
+  std::string data_type_str = get_data_type_str(dtype);
+
+  auto fmha_traits = fmha_fwd_traits{
+    hdim_q,    hdim_v,    data_type_str, is_group_mode, is_v_rowmajor,
+    mask_type, bias_enum::no_bias, has_lse,       has_dropout,   do_fp8_static_quant};
+
+  auto fmha_args = [&]() {
+    // setup stride_* arguments
+    const ck_tile::index_t stride_q = stride_s_q;
+    const ck_tile::index_t stride_k = stride_s_k;
+    const ck_tile::index_t stride_v = stride_s_v;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t stride_bias = 0;
+    // randval not used
+    const ck_tile::index_t stride_randval = 0;
+    const ck_tile::index_t stride_o = stride_s_o;
+    // setup nhead_stride_* arguments
+    const ck_tile::index_t nhead_stride_q = stride_h_q;
+    const ck_tile::index_t nhead_stride_k = stride_h_k;
+    const ck_tile::index_t nhead_stride_v = stride_h_v;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t nhead_stride_bias = 0;
+    //TODO: randval never used, can we remove it
+    const ck_tile::index_t nhead_stride_randval = 0;
+    // CK group mode requires softmax_lse be of shape [h, total_s_q]
+    const ck_tile::index_t nhead_stride_lse = total_seqlen_q;
+    const ck_tile::index_t nhead_stride_o = stride_h_o;
+    // setup batch_stride_* arguments
+    const ck_tile::index_t batch_stride_q = 0;
+    const ck_tile::index_t batch_stride_k = 0;
+    const ck_tile::index_t batch_stride_v = 0;
+    // bias not used in THD qkv layout
+    const ck_tile::index_t batch_stride_bias = 0;
+    //TODO: randval never used, can we remove it
+    const ck_tile::index_t batch_stride_randval = 0;
+    const ck_tile::index_t batch_stride_lse = 0;
+    const ck_tile::index_t batch_stride_o = 0;
+
+    return fmha_fwd_args{q_ptr,
+                         k_ptr,
+                         v_ptr,
+                         nullptr,//bias_ptr
+                         nullptr,//rand_val_ptr
+                         lse_thd_ptr,
+                         o_ptr,
+                         cu_seqlen_q_ptr,//cu_seqlen_q
+                         cu_seqlen_kv_ptr,//cu_seqlen_kv
+                         nullptr, /* seqlen_k_ptr */
+                         total_seqlen_q,
+                         total_seqlen_kv,
+                         batch,
+                         max_seqlen_q,
+                         hdim_q,
+                         hdim_v,
+                         nhead,
+                         nhead_k,
+                         scale_s,
+                         scale_p,
+                         scale_o,
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         stride_bias,
+                         stride_randval,
+                         stride_o,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         nhead_stride_bias,
+                         nhead_stride_randval,
+                         nhead_stride_lse,
+                         nhead_stride_o,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         batch_stride_bias,
+                         batch_stride_randval,
+                         batch_stride_lse,
+                         batch_stride_o,
+                         left,
+                         right,
+                         static_cast<ck_tile::index_t>(mask_type),
+                         p_drop,
+                         false,
+                         std::pair<const void*, const void*>{philox_seed_ptr, philox_offset_ptr}};
+  }();
+
+  // print ck traits and args when needed
+  log_fwd_config(__FUNCTION__, fmha_traits, fmha_args); 
+
+  float average_runtime = fmha_fwd(fmha_traits, fmha_args, stream_config);
+  if(average_runtime < 0){
+    //TODO: better error out system
+    throw std::runtime_error("fused attn configs not supported in ck_fused_attn fwd pass.");
+  }
+
+  // convert softmax_lse from [h, total_seqlen_q] to [b, h, s_q]
+  if(lse_thd_ptr!=lse_ptr){
+    assert((lse_thd_ptr!=nullptr) && (lse_ptr!=nullptr));
+    constexpr int THREADS_PER_BLOCK = 1024;
+    dim3 block(THREADS_PER_BLOCK);
+    dim3 grid(ceil(1.0 * b * h/THREADS_PER_BLOCK));
+    hipLaunchKernelGGL(
+      softmax_lse_from_thd, grid, block, 0, stream,
+      b, h, s_q, static_cast<const int32_t*>(cu_seqlen_q_ptr),
+      static_cast<const float*>(lse_thd_ptr),
+      static_cast<float*>(lse_ptr));
+  }
+  return hipSuccess;
+}
+
 }//namespace ck_fused_attn

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -1,12 +1,30 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/
 
+#include<utility>
 #include "ck_fused_attn_utils.hpp"
+#include "ck_fused_attn/ck_fused_attn.hpp"
+#include "mask.hpp"
+#include "bias.hpp"
 
 namespace ck_fused_attn{
+
+std::string get_data_type_str(DType dtype){
+  std::string data_type_str;
+  if(dtype==DType::kFloat16){
+    data_type_str = "fp16";
+  }else if(dtype==DType::kBFloat16){
+    data_type_str = "bf16";
+  }else{
+    //TODO: better error out system
+    throw std::runtime_error("Invalid dtype in ck_fused_attn.");
+  }
+  return data_type_str;
+}
+
 BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h){
   //identify BHSS with high priority to include scenaiors when b=1 and h=1
   //reduce the chance of dbias_expand_ptr usage
@@ -24,6 +42,40 @@ BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_
     throw std::runtime_error("Invalid bias_shape in ck_fused_attn.");
   }
   return BiasShape::kNumBiasShapes;
+}
+
+//get ck_tile bias_type and CK_FUSED_ATTN bias_shape
+std::pair<bias_enum, BiasShape> get_ck_bias_type_shape(BiasType attn_bias_type, uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h){
+  bias_enum bias_type;
+  BiasShape bias_shape; 
+  if (attn_bias_type==BiasType::no_bias){
+    bias_type = bias_enum::no_bias;
+  }else if (attn_bias_type==BiasType::elementwise_bias){
+    bias_type = bias_enum::elementwise_bias;
+    bias_shape = get_bias_shape(b, h, bias_b, bias_h);
+  }else if (attn_bias_type==BiasType::alibi){
+    bias_type = bias_enum::alibi;
+  }else{
+    //TODO: better error out system
+    throw std::runtime_error("Invalid bias_type in ck_fused_attn.");
+  }
+  return std::make_pair(bias_type, bias_shape); 
+}
+
+//CK_FUSED_ATTN MaskType to ck_tile mask enum
+mask_enum get_ck_mask_type(MaskType attn_mask_type){
+  mask_enum mask_type;
+  if (attn_mask_type == MaskType::no_mask){
+    mask_type = mask_enum::no_mask;
+  }else if(attn_mask_type == MaskType::mask_top_left){
+    mask_type = mask_enum::mask_top_left;
+  }else if(attn_mask_type == MaskType::mask_bottom_right){
+    mask_type = mask_enum::mask_bottom_right;
+  }else{
+    mask_type = mask_enum::window_generic;
+  }
+
+  return mask_type;
 }
 
 }//namespace ck_fused_attn

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/
@@ -7,13 +7,34 @@
 #ifndef CK_FUSED_ATTN_UTILS_H
 #define CK_FUSED_ATTN_UTILS_H
 
-#include <iostream>
+#include<iostream>
 #include<cstdint>
+
+//forward declaration for ck_tile enum
+enum class mask_enum;
+//forward declaration for ck_tile enum
+enum class bias_enum;
 
 namespace ck_fused_attn{
 
+#define CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, type, ...)   \
+switch (dtype) {                                            \
+  case DType::kFloat16: {                                   \
+    using type = ck_tile::half_t;                           \
+    __VA_ARGS__;                                            \
+    break;                                                  \
+  }                                                         \
+  case DType::kBFloat16: {                                  \
+    using type = ck_tile::bf16_t;                           \
+    __VA_ARGS__;                                            \
+    break;                                                  \
+  }                                                         \
+  default:                                                  \
+    throw std::runtime_error("Invalid type for 16 bit..");  \
+}
+
 // element-wise bias shape
-enum BiasShape{
+enum class BiasShape{
   k11SS = 0,
   k1HSS = 1,
   kB1SS = 2,
@@ -21,7 +42,19 @@ enum BiasShape{
   kNumBiasShapes  /*!< Number of supported bias shapes */
 };
 
+//forward declaration of ck_fused_attn::DType
+enum class DType ;
+//forward declaration of ck_fused_attn::MaskType
+enum class MaskType;
+//forward declaration of ck_fused_attn::BiasType
+enum class BiasType;
+
+std::string get_data_type_str(DType dtype);
 BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+std::pair<bias_enum, BiasShape> get_ck_bias_type_shape(BiasType attn_bias_type, uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+
+mask_enum get_ck_mask_type(MaskType attn_mask_type);
+
 
 }//namespace ck_fused_attn
 #endif // CK_FUSED_ATTN_UTILS_H

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -81,10 +81,10 @@ bool is_ck_backend_supported(
 
   const int device_id = cuda::current_device();
   const std::string sm_arch_name_ = cuda::sm_arch_name(device_id);
-  //only MI300X supported
+  //only gfx942 supported
   if(!(sm_arch_name_.find("gfx942")!=std::string::npos)){
     if(nvte_log_ck_config){
-      std::cout<<"only MI300X is supported"<<std::endl;
+      std::cout<<"only gfx942 is supported"<<std::endl;
     }
     return false;
   }

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -18,6 +18,7 @@ namespace transformer_engine {
 namespace fused_attn_rocm {
 
 // check the fused attn config to see whether it's ck backend supported
+// single filtering followed by joint filtering
 bool is_ck_backend_supported(
   NVTEDType q_dtype,
   NVTEDType kv_dtype,
@@ -34,12 +35,16 @@ bool is_ck_backend_supported(
 
 #ifdef USE_FUSED_ATTN_CK
 
+  // debug info setting
   bool nvte_log_ck_config = false;
   if (const char* env_p = std::getenv("NVTE_LOG_CK_CONFIG") ) {
     if (env_p != nullptr && std::string(env_p) == "1")
       nvte_log_ck_config = true;
   }
+  
+  // single filters
 
+  // filter based on head_dim
   //TODO: release after CK support support Multi-latent attention
   if(head_dim_qk != head_dim_v){
     if(nvte_log_ck_config){
@@ -47,7 +52,8 @@ bool is_ck_backend_supported(
     }
     return false;
   }
-
+  
+  // filter based on num_heads and num_gqa_groups
   if(num_gqa_groups == 0 || num_attn_heads%num_gqa_groups != 0){
     if(nvte_log_ck_config){
       std::cout<<"Num of attention heads must be divisible by num of gqa groups"<<std::endl;
@@ -55,42 +61,20 @@ bool is_ck_backend_supported(
     return false;
   }
 
-  //swa filter
-  if(attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK || attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK){
-    // causal mask window must be with causal top left or causal bottom right mask type
-    if (!((window_size_left ==-1 || window_size_left >=0) && window_size_right ==0 )){
-      if(nvte_log_ck_config){
-        std::cout<<"When mask contains causal, window size should be (-1, 0) or (>=0, 0)"<<std::endl;
-      }
-      return false;
-    }
-  }else if(attn_mask_type==NVTE_Mask_Type::NVTE_NO_MASK){
-    // no mask must be with either (-1, -1) or (>=0, >=0)
-    if (!((window_size_left == -1 && window_size_right == -1)||(window_size_left >= 0 && window_size_right >= 0))){
-      if(nvte_log_ck_config){
-        std::cout<<"When no mask, window size should be (-1, -1) or (>=0, >=0)"<<std::endl;
-      }
-      return false;
-    }
-  }
-
-  bool is_mqa_gqa = num_attn_heads > num_gqa_groups;
-  NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
-
-  bool is_qkvpacked = layout_group==NVTE_QKV_Layout_Group::NVTE_3HD ||layout_group==NVTE_QKV_Layout_Group::NVTE_H3D;
-
-  // MQA/GQA does not work with qkvpacked layout
-  if(is_mqa_gqa && is_qkvpacked){
+  // filter based on data type
+  // Q and KV must have the same data type, in fp16 or bf16
+  if((q_dtype!=kv_dtype) || !((q_dtype==NVTEDType::kNVTEFloat16) || (q_dtype == NVTEDType::kNVTEBFloat16))){
     if(nvte_log_ck_config){
-      std::cout<<"When no mask, window size should be (-1, -1) or (>=0, >=0)"<<std::endl;
+      std::cout<<"q, k, v data type has to be fp16 or bf16"<<std::endl;
     }
     return false;
   }
-  
-  // qkvpacked layout requires seq length to be the same
-  if(is_qkvpacked && max_seqlen_q!=max_seqlen_kv){
+
+  // filter based on bias type
+  // CK does not support pre_scale bias
+  if(!(bias_type == NVTE_Bias_Type::NVTE_NO_BIAS || bias_type == NVTE_Bias_Type::NVTE_ALIBI || bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS)){
     if(nvte_log_ck_config){
-      std::cout<<"qkv packed layout requires seqlen_q==seqlen_kv"<<std::endl;
+      std::cout<<"CK fused attn does not support pre_scale bias"<<std::endl;
     }
     return false;
   }
@@ -104,44 +88,72 @@ bool is_ck_backend_supported(
     }
     return false;
   }
-  
-  // Q and KV must have the same data type, in fp16 or bf16
-  if((q_dtype!=kv_dtype) || !((q_dtype==NVTEDType::kNVTEFloat16) || (q_dtype == NVTEDType::kNVTEBFloat16))){
+
+  // joint filters
+
+  // joint filter based on sliding window and attn_mask
+  bool is_causal = (attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
+                    attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK||
+                    attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK||
+                    attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK);
+  if(is_causal){
+    // causal mask window must be with causal top left or causal bottom right mask type
+    if (!((window_size_left ==-1 || window_size_left >=0) && window_size_right ==0 )){
+      if(nvte_log_ck_config){
+        std::cout<<"When mask contains causal, window size should be (-1, 0) or (>=0, 0)"<<std::endl;
+      }
+      return false;
+    }
+  }else if(attn_mask_type==NVTE_Mask_Type::NVTE_NO_MASK || attn_mask_type==NVTE_Mask_Type::NVTE_PADDING_MASK){
+    // no mask must be with either (-1, -1) or (>=0, >=0)
+    if (!((window_size_left == -1 && window_size_right == -1)||(window_size_left >= 0 && window_size_right >= 0))){
+      if(nvte_log_ck_config){
+        std::cout<<"When no mask, window size should be (-1, -1) or (>=0, >=0)"<<std::endl;
+      }
+      return false;
+    }
+  }
+
+  // joint filter that MQA/GQA does not work with qkvpacked layout
+  NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
+  bool is_qkvpacked = layout_group==NVTE_QKV_Layout_Group::NVTE_3HD ||layout_group==NVTE_QKV_Layout_Group::NVTE_H3D;
+  bool is_mqa_gqa = num_attn_heads > num_gqa_groups;
+  if(is_mqa_gqa && is_qkvpacked){
     if(nvte_log_ck_config){
-      std::cout<<"q, k, v data type has to be fp16 or bf16"<<std::endl;
+      std::cout<<"MQA/GQA cannot work with qkvpacked layout"<<std::endl;
     }
     return false;
   }
   
-  //Only BSHD, SBHD style layouts supported
-  NVTE_QKV_Format qkv_format = nvte_get_qkv_format(qkv_layout);
-  if(!(qkv_format == NVTE_QKV_Format::NVTE_SBHD||
-    qkv_format == NVTE_QKV_Format::NVTE_BSHD)){
+  // joint filter that qkvpacked layout requires seq length to be the same
+  if(is_qkvpacked && max_seqlen_q!=max_seqlen_kv){
     if(nvte_log_ck_config){
-      std::cout<<"qkv format can only be BSHD or SBHD"<<std::endl;
-    }
-    return false;
-  }
-  
-  // CK does not support pre_scale bias
-  if(!(bias_type == NVTE_Bias_Type::NVTE_NO_BIAS || bias_type == NVTE_Bias_Type::NVTE_ALIBI || bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS)){
-    if(nvte_log_ck_config){
-      std::cout<<"CK fused attn does not support pre_scale bias"<<std::endl;
+      std::cout<<"qkv packed layout requires seqlen_q==seqlen_kv"<<std::endl;
     }
     return false;
   }
 
-  // Only no mask and causal (top left) and causal bottom right mask supported
-  // TODO: support padding mask in CK
-  if(!(attn_mask_type == NVTE_Mask_Type::NVTE_NO_MASK ||
-    attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
-    attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK)){
+  // joint filter that THD layout should imply padding mask  
+  NVTE_QKV_Format qkv_format = nvte_get_qkv_format(qkv_layout);
+  bool is_ragged = qkv_format==NVTE_QKV_Format::NVTE_THD;
+  // in CK, currently padding equals thd since BSHD padding not supported
+  bool is_padding = (attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_MASK || 
+                     attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||
+                     attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK);
+  if(is_ragged != is_padding){
     if(nvte_log_ck_config){
-      std::cout<<"CK fused attn only support no_mask, causal_mask, causal_bottom_right_mask"<<std::endl;
+      std::cout<<"THD layout must be with padding mask in CK for now"<<std::endl;
     }
     return false;
-  } 
+  }
   
+  // joint filter that THD/padding does not work with ALIBI bias or post_scale_bias
+  if(is_padding && (bias_type==NVTE_Bias_Type::NVTE_POST_SCALE_BIAS || bias_type==NVTE_Bias_Type::NVTE_ALIBI)){
+    if(nvte_log_ck_config){
+      std::cout<<"padding mask cannot work with post_scale_bias or alibi"<<std::endl;
+    }
+    return false;
+  }
   return true;
 #else
   NVTE_ERROR("CK fused attn backend not compiled.");
@@ -176,7 +188,7 @@ ck_fused_attn::BiasType nvte_to_ck_bias_type(NVTE_Bias_Type t_bias_type){
 
 // set the ck mask type based on nvte mask type and window size table above
 ck_fused_attn::MaskType set_ck_mask(NVTE_Mask_Type nvte_mask_type, int64_t nvte_window_size_left, int64_t nvte_window_size_right){
-  if (nvte_mask_type==NVTE_Mask_Type::NVTE_NO_MASK){
+  if (nvte_mask_type==NVTE_Mask_Type::NVTE_NO_MASK || nvte_mask_type==NVTE_Mask_Type::NVTE_PADDING_MASK){
     // window size in NVTE_NO_Mask can be (-1, -1) and (>=0, >=0)
     if(nvte_window_size_left==-1 && nvte_window_size_right==-1){
       // (-1, -1)
@@ -185,10 +197,10 @@ ck_fused_attn::MaskType set_ck_mask(NVTE_Mask_Type nvte_mask_type, int64_t nvte_
       // (>=0, >=0)
       return ck_fused_attn::MaskType::mask_top_left;
     }
-  }else if (nvte_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK){
+  }else if (nvte_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK || nvte_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK){
     // nvte causal mask can map to (-1, 0) or (>=0, 0)
     return ck_fused_attn::MaskType::mask_top_left;
-  }else if (nvte_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK){
+  }else if (nvte_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK || nvte_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK){
     return ck_fused_attn::MaskType::mask_bottom_right;
   }
   return ck_fused_attn::MaskType::window_generic;
@@ -220,7 +232,7 @@ void fused_attn_ck_fwd_impl(
   void *devPtrQ, void *devPtrK, void *devPtrV, void* devPtrBias,
   void *devPtrSoftmaxAux, void *devPtrO,
   void* devPtrDropoutSeed, void* devPtrDropoutOffset,
-  //void* devPtrCuSeqlensQ, void* devPtrCuSeqlensKV,
+  void* devPtrCuSeqlensQ, void* devPtrCuSeqlensKV,
   ck_fused_attn::DType dtype,
   void *workspace, 
   size_t *workspace_size,
@@ -233,11 +245,16 @@ void fused_attn_ck_fwd_impl(
   }
   // Exit to request upper level API to allocate memory if needed
   // Currently ck fused attn does not need workspace in fwd pass
+  bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD; 
   if(workspace==nullptr){
     *workspace_size = 0;
     // ck requires an alibi slope array even if in standard (vanilla) mode
     if(bias_type == NVTE_Bias_Type::NVTE_ALIBI){
       (*workspace_size)+= h*sizeof(float);
+    }
+    // softmax_lse buffer needed for THD qkv_layout
+    if(is_ragged){
+      (*workspace_size)+= b*h*s_q*sizeof(float);
     }
 
     if (nvte_log_ck_config) {
@@ -269,19 +286,40 @@ void fused_attn_ck_fwd_impl(
     //assign standard alibi slope
     hipLaunchKernelGGL(generate_alibi_slope, grid, block, 0, stream, h, static_cast<float*>(devPtrAlibiSlope));
   }
-  
+  // First b*h*sq*sizeof(float) in workspace are for lse in THD layout
+  void* devPtrSoftmaxLSETHD = nullptr;
+  if(is_ragged){
+    devPtrSoftmaxLSETHD = workspace;
+  }
   if (nvte_log_ck_config) {
     std::cout<<std::endl<<"attn_fwd(ck): ";
-    std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
-    std::cout<<"q_stride: ("<<q_stride[0]<<", "<<q_stride[1]<<", "<<q_stride[2]<<", "<<q_stride[3]<<"), ";
-    std::cout<<"kv_shape: ("<<b<<", "<<hg<<", "<<s_kv<<", "<<d<<"), ";
-    std::cout<<"k_stride: ("<<k_stride[0]<<", "<<k_stride[1]<<", "<<k_stride[2]<<", "<<k_stride[3]<<"), ";
-    std::cout<<"v_stride: ("<<v_stride[0]<<", "<<v_stride[1]<<", "<<v_stride[2]<<", "<<v_stride[3]<<"), ";
+    std::cout<<"layout: "<<layout<<", ";
+    if(is_ragged){
+      // THD
+      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
+      int32_t total_kv = *(static_cast<const int32_t *>(devPtrCuSeqlensKV) + b);
+      std::cout<<"q_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"q_stride: ("<<q_stride[2]<<", "<<q_stride[1]<<", "<<q_stride[3]<<"), ";
+      std::cout<<"kv_shape: ("<<total_kv<<", "<<hg<<", "<<d<<"), ";
+      std::cout<<"k_stride: ("<<k_stride[2]<<", "<<k_stride[1]<<", "<<k_stride[3]<<"), ";
+      std::cout<<"v_stride: ("<<v_stride[2]<<", "<<v_stride[1]<<", "<<v_stride[3]<<"), ";
+
+      std::cout<<"o_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"o_stride: ("<<o_stride[2]<<", "<<o_stride[1]<<", "<<o_stride[3]<<"), ";
+    }else{
+      // non-THD
+      std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
+      std::cout<<"q_stride: ("<<q_stride[0]<<", "<<q_stride[1]<<", "<<q_stride[2]<<", "<<q_stride[3]<<"), ";
+      std::cout<<"kv_shape: ("<<b<<", "<<hg<<", "<<s_kv<<", "<<d<<"), ";
+      std::cout<<"k_stride: ("<<k_stride[0]<<", "<<k_stride[1]<<", "<<k_stride[2]<<", "<<k_stride[3]<<"), ";
+      std::cout<<"v_stride: ("<<v_stride[0]<<", "<<v_stride[1]<<", "<<v_stride[2]<<", "<<v_stride[3]<<"), ";
+ 
+      std::cout<<"o_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
+      std::cout<<"o_stride: ("<<o_stride[0]<<", "<<o_stride[1]<<", "<<o_stride[2]<<", "<<o_stride[3]<<"), ";
+    }
     std::cout<<"scaling_factor: "<<scaling_factor<<", ";
     std::cout<<"M_shape: ("<<b*h<<", "<<s_q<<"), ";
     std::cout<<"M_stride: ("<<s_q<<", "<<1<<"), ";
-    std::cout<<"o_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
-    std::cout<<"o_stride: ("<<o_stride[0]<<", "<<o_stride[1]<<", "<<o_stride[2]<<", "<<o_stride[3]<<"), ";
     std::cout<<"is_training: "<<is_training<<", ";
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed_ptr: "<<devPtrDropoutSeed<<", philox_offset_ptr: "<<devPtrDropoutOffset<<", ";
@@ -290,28 +328,53 @@ void fused_attn_ck_fwd_impl(
     std::cout<<"mask_type: "<<mask_type<<std::endl;
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
   }
-  using ck_fused_attn::ck_attn_fwd;
-  NVTE_CHECK_CUDA(
-    ck_attn_fwd(
-      dtype,
-      b, h, hg, s_q, s_kv, d, bias_b, bias_h,
-      devPtrQ, 
-      q_stride[0], q_stride[1], q_stride[2],
-      devPtrK, 
-      k_stride[0], k_stride[1], k_stride[2],
-      devPtrV, 
-      v_stride[0], v_stride[1], v_stride[2],
-      devPtrBias,
-      devPtrAlibiSlope,
-      is_training, scaling_factor, dropout_probability,
-      devPtrDropoutSeed, devPtrDropoutOffset,
-      nvte_to_ck_bias_type(bias_type),
-      set_ck_mask(mask_type, window_size_left, window_size_right),
-      window_size_left, window_size_right,
-      devPtrO,
-      o_stride[0], o_stride[1], o_stride[2],
-      devPtrSoftmaxAux,
-      stream));
+  if(is_ragged){
+    using ck_fused_attn::ck_attn_varlen_fwd;
+    NVTE_CHECK_CUDA(
+      ck_attn_varlen_fwd(
+        dtype,
+        b, h, hg, s_q, s_kv, d,
+        devPtrQ, 
+        q_stride[1], q_stride[2],
+        devPtrK, 
+        k_stride[1], k_stride[2],
+        devPtrV, 
+        v_stride[1], v_stride[2],
+        devPtrCuSeqlensQ, devPtrCuSeqlensKV, 
+        is_training, scaling_factor, dropout_probability,
+        devPtrDropoutSeed, devPtrDropoutOffset,
+        set_ck_mask(mask_type, window_size_left, window_size_right),
+        window_size_left, window_size_right,
+        devPtrO,
+        o_stride[1], o_stride[2],
+        devPtrSoftmaxLSETHD,
+        devPtrSoftmaxAux,
+        stream));
+    // softmax_lse will be fixed from [total_seqlen_q, h] to [b, h, s] in ck_fused_attn
+  }else{
+    using ck_fused_attn::ck_attn_fwd;
+    NVTE_CHECK_CUDA(
+      ck_attn_fwd(
+        dtype,
+        b, h, hg, s_q, s_kv, d, bias_b, bias_h,
+        devPtrQ, 
+        q_stride[0], q_stride[1], q_stride[2],
+        devPtrK, 
+        k_stride[0], k_stride[1], k_stride[2],
+        devPtrV, 
+        v_stride[0], v_stride[1], v_stride[2],
+        devPtrBias,
+        devPtrAlibiSlope,
+        is_training, scaling_factor, dropout_probability,
+        devPtrDropoutSeed, devPtrDropoutOffset,
+        nvte_to_ck_bias_type(bias_type),
+        set_ck_mask(mask_type, window_size_left, window_size_right),
+        window_size_left, window_size_right,
+        devPtrO,
+        o_stride[0], o_stride[1], o_stride[2],
+        devPtrSoftmaxAux,
+        stream));
+  }
 }
 
 size_t ck_dtype_size(ck_fused_attn::DType t_dtype){
@@ -340,6 +403,7 @@ void fused_attn_ck_bwd_impl(
   void* devPtrdBias,
   void* devPtrDropoutSeed, 
   void* devPtrDropoutOffset,
+  void* devPtrCuSeqlensQ, void* devPtrCuSeqlensKV,
   ck_fused_attn::DType dtype,
   void *workspace,
   size_t *workspace_size,
@@ -355,6 +419,8 @@ void fused_attn_ck_bwd_impl(
 
   size_t kN0 = (d <= 128)? 128:64;
   size_t nsplits = deterministic? ceil(1.0*s_kv/kN0):1; 
+
+  bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD; 
   // Exit to request upper level API to allocate memory if needed
   if(workspace==nullptr){
     size_t workspace_size_lse = b*h*s_q*sizeof(float);
@@ -373,6 +439,10 @@ void fused_attn_ck_bwd_impl(
       //ck requires a buffer dbias_expanded of size BHSS if bias is not BHSS
       (*workspace_size) += b*h*s_q*s_kv*ck_dtype_size(dtype);
     }
+    if(is_ragged){
+      // transform the input softmax_lse of shape [b, h, s] into [h, total_s]
+      (*workspace_size)+= b*h*s_q*sizeof(float);
+    }
     if (nvte_log_ck_config) {
       std::cout<<std::endl<<"attn_bwd(ck) requested workspace of size "<<*workspace_size<<std::endl;
     }
@@ -384,10 +454,21 @@ void fused_attn_ck_bwd_impl(
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(layout);
   if((layout_group == NVTE_QKV_Layout_Group::NVTE_3HD) or (layout_group == NVTE_QKV_Layout_Group::NVTE_H3D)){
     // just memset all dq, dk, dv
-    (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d*3, stream);
+    if(is_ragged){
+      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
+      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*h*total_q*d*3, stream);
+
+    }else{
+      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d*3, stream);
+    }
   }else{
     // HD_2HD, HD_H2D, HD_HD_HD can just memset dq itself
-    (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d, stream);
+    if(is_ragged){
+      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
+      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*h*total_q*d, stream);
+    }else{
+      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d, stream);
+    }
   }
   std::array<uint64_t, 4> q_stride;
   std::array<uint64_t, 4> k_stride;
@@ -472,6 +553,15 @@ void fused_attn_ck_bwd_impl(
     }
   }
   
+  void* devPtrSoftmaxLSETHD = nullptr;
+  if(is_ragged){
+    if(is_mqa_gqa){
+      devPtrSoftmaxLSETHD = static_cast<void *>(static_cast<int8_t*>(dk_expanded_ptr) + 2*b*h*s_kv*d*ck_dtype_size(dtype));
+    }else{
+      // devPtrSoftmaxLSETHD at the end of dq_acc_ptr if no mqa/gqa temp buffer needed
+      devPtrSoftmaxLSETHD = static_cast<void *>(static_cast<int8_t*>(dq_acc_ptr) + nsplits*b*h*s_q*d*sizeof(float));
+    }
+  }
   // bwd v3 is optional by enabling the following envs
   // default values follows the ck example setting
   bool nvte_ck_uses_bwd_v3 = getenv<int>("NVTE_CK_USES_BWD_V3", 0);
@@ -480,16 +570,33 @@ void fused_attn_ck_bwd_impl(
 
   if (nvte_log_ck_config) {
     std::cout<<std::endl<<"attn_bwd(ck): ";
-    std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
-    std::cout<<"q_stride: ("<<q_stride[0]<<", "<<q_stride[1]<<", "<<q_stride[2]<<", "<<q_stride[3]<<"), ";
-    std::cout<<"kv_shape: ("<<b<<", "<<hg<<", "<<s_kv<<", "<<d<<"), ";
-    std::cout<<"k_stride: ("<<k_stride[0]<<", "<<k_stride[1]<<", "<<k_stride[2]<<", "<<k_stride[3]<<"), ";
-    std::cout<<"v_stride: ("<<v_stride[0]<<", "<<v_stride[1]<<", "<<v_stride[2]<<", "<<v_stride[3]<<"), ";
+    std::cout<<"layout: "<<layout<<", ";
+    if(is_ragged){
+      // THD
+      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
+      int32_t total_kv = *(static_cast<const int32_t *>(devPtrCuSeqlensKV) + b);
+      std::cout<<"q_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"q_stride: ("<<q_stride[2]<<", "<<q_stride[1]<<", "<<q_stride[3]<<"), ";
+      std::cout<<"kv_shape: ("<<total_kv<<", "<<hg<<", "<<d<<"), ";
+      std::cout<<"k_stride: ("<<k_stride[2]<<", "<<k_stride[1]<<", "<<k_stride[3]<<"), ";
+      std::cout<<"v_stride: ("<<v_stride[2]<<", "<<v_stride[1]<<", "<<v_stride[3]<<"), ";
+
+      std::cout<<"o_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"o_stride: ("<<o_stride[2]<<", "<<o_stride[1]<<", "<<o_stride[3]<<"), ";
+    }else{
+      // non-THD
+      std::cout<<"q_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
+      std::cout<<"q_stride: ("<<q_stride[0]<<", "<<q_stride[1]<<", "<<q_stride[2]<<", "<<q_stride[3]<<"), ";
+      std::cout<<"kv_shape: ("<<b<<", "<<hg<<", "<<s_kv<<", "<<d<<"), ";
+      std::cout<<"k_stride: ("<<k_stride[0]<<", "<<k_stride[1]<<", "<<k_stride[2]<<", "<<k_stride[3]<<"), ";
+      std::cout<<"v_stride: ("<<v_stride[0]<<", "<<v_stride[1]<<", "<<v_stride[2]<<", "<<v_stride[3]<<"), ";
+
+      std::cout<<"o_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
+      std::cout<<"o_stride: ("<<o_stride[0]<<", "<<o_stride[1]<<", "<<o_stride[2]<<", "<<o_stride[3]<<"), ";
+    }
     std::cout<<"scaling_factor: "<<scaling_factor<<", ";
     std::cout<<"M_shape: ("<<b*h<<", "<<s_q<<"), ";
     std::cout<<"M_stride: ("<<s_q<<", "<<1<<"), ";
-    std::cout<<"o_shape: ("<<b<<", "<<h<<", "<<s_q<<", "<<d<<"), ";
-    std::cout<<"o_stride: ("<<o_stride[0]<<", "<<o_stride[1]<<", "<<o_stride[2]<<", "<<o_stride[3]<<"), ";
     std::cout<<"dropout_p: "<<dropout_probability<<", ";
     std::cout<<"philox_seed_ptr: "<<devPtrDropoutSeed<<", philox_offset_ptr: "<<devPtrDropoutOffset<<", ";
     std::cout<<"bias_type: "<<bias_type<<std::endl;
@@ -498,47 +605,86 @@ void fused_attn_ck_bwd_impl(
     std::cout<<"window_size: ("<<window_size_left<<", "<<window_size_right<<")"<<std::endl;
     std::cout<<"deterministic: "<<deterministic<<std::endl;
   }
-  using ck_fused_attn::ck_attn_bwd;
-  NVTE_CHECK_CUDA(
-    ck_attn_bwd(
-      dtype,
-      b, h, hg, s_q, s_kv, d, bias_b, bias_h,
-      devPtrQ,
-      q_stride[0], q_stride[1], q_stride[2],
-      devPtrK,
-      k_stride[0], k_stride[1], k_stride[2],
-      devPtrV,
-      v_stride[0], v_stride[1], v_stride[2],
-      devPtrBias,
-      devPtrAlibiSlope,
-      devPtrO,
-      o_stride[0], o_stride[1], o_stride[2],
-      devPtrSoftmaxAux,
-      devPtrdO,
-      o_stride[0], o_stride[1], o_stride[2], //dO and O share the same stride
-      scaling_factor, dropout_probability,
-      devPtrDropoutSeed, devPtrDropoutOffset,
-      nvte_to_ck_bias_type(bias_type),
-      set_ck_mask(mask_type, window_size_left, window_size_right),
-      window_size_left, window_size_right,
-      devPtrdQ,
-      q_stride[0], q_stride[1], q_stride[2], //dQ and Q share the same stride
-      dq_acc_ptr, 
-      dk_expanded_ptr,
-      dv_expanded_ptr,
-      dkv_expanded_stride[0], dkv_expanded_stride[1], dkv_expanded_stride[2], //dK and K share the same stride
-      devPtrdK,
-      k_stride[0], k_stride[1], k_stride[2], //dK and K share the same stride
-      devPtrdV,
-      v_stride[0], v_stride[1], v_stride[2], //dV and V share the same stride
-      dbias_expanded_ptr,
-      devPtrdBias,
-      workspace,
-      deterministic,
-      nvte_ck_uses_bwd_v3,
-      nvte_ck_is_v3_atomic_fp32,
-      nvte_ck_how_v3_bf16_cvt,
-      stream));
+  if(is_ragged){
+    using ck_fused_attn::ck_attn_varlen_bwd;
+    NVTE_CHECK_CUDA(
+      ck_attn_varlen_bwd(
+        dtype,
+        b, h, hg, s_q, s_kv, d,
+        devPtrQ,
+        q_stride[1], q_stride[2],
+        devPtrK,
+        k_stride[1], k_stride[2],
+        devPtrV,
+        v_stride[1], v_stride[2],
+        devPtrCuSeqlensQ, devPtrCuSeqlensKV, 
+        devPtrO,
+        o_stride[1], o_stride[2],
+        devPtrSoftmaxAux,
+        devPtrdO,
+        o_stride[1], o_stride[2], //dO and O share the same stride
+        scaling_factor, dropout_probability,
+        devPtrDropoutSeed, devPtrDropoutOffset,
+        set_ck_mask(mask_type, window_size_left, window_size_right),
+        window_size_left, window_size_right,
+        devPtrdQ,
+        q_stride[1], q_stride[2], //dQ and Q share the same stride
+        dq_acc_ptr, 
+        dk_expanded_ptr,
+        dv_expanded_ptr,
+        dkv_expanded_stride[1], dkv_expanded_stride[2], //dK and K share the same stride
+        devPtrdK,
+        k_stride[1], k_stride[2], //dK and K share the same stride
+        devPtrdV,
+        v_stride[1], v_stride[2], //dV and V share the same stride
+        workspace, // softmax_lsed
+        devPtrSoftmaxLSETHD,
+        deterministic,
+        // bwd_v3 not supported for THD
+        stream));
+  }else{
+    using ck_fused_attn::ck_attn_bwd;
+    NVTE_CHECK_CUDA(
+      ck_attn_bwd(
+        dtype,
+        b, h, hg, s_q, s_kv, d, bias_b, bias_h,
+        devPtrQ,
+        q_stride[0], q_stride[1], q_stride[2],
+        devPtrK,
+        k_stride[0], k_stride[1], k_stride[2],
+        devPtrV,
+        v_stride[0], v_stride[1], v_stride[2],
+        devPtrBias,
+        devPtrAlibiSlope,
+        devPtrO,
+        o_stride[0], o_stride[1], o_stride[2],
+        devPtrSoftmaxAux,
+        devPtrdO,
+        o_stride[0], o_stride[1], o_stride[2], //dO and O share the same stride
+        scaling_factor, dropout_probability,
+        devPtrDropoutSeed, devPtrDropoutOffset,
+        nvte_to_ck_bias_type(bias_type),
+        set_ck_mask(mask_type, window_size_left, window_size_right),
+        window_size_left, window_size_right,
+        devPtrdQ,
+        q_stride[0], q_stride[1], q_stride[2], //dQ and Q share the same stride
+        dq_acc_ptr, 
+        dk_expanded_ptr,
+        dv_expanded_ptr,
+        dkv_expanded_stride[0], dkv_expanded_stride[1], dkv_expanded_stride[2], //dK and K share the same stride
+        devPtrdK,
+        k_stride[0], k_stride[1], k_stride[2], //dK and K share the same stride
+        devPtrdV,
+        v_stride[0], v_stride[1], v_stride[2], //dV and V share the same stride
+        dbias_expanded_ptr,
+        devPtrdBias,
+        workspace,
+        deterministic,
+        nvte_ck_uses_bwd_v3,
+        nvte_ck_is_v3_atomic_fp32,
+        nvte_ck_how_v3_bf16_cvt,
+        stream));
+  }
 }
 #endif // USE_FUSED_ATTN_CK
 }  // namespace fused_attn_rocm
@@ -581,6 +727,7 @@ void fused_attn_ck_fwd_qkvpacked(
   }
   void *devPtrO = output_O->data.dptr;
   void *devPtrS = nullptr;
+  void *devPtrCuSeqlens = input_cu_seqlens->data.dptr;
 
   if (Aux_CTX_Tensors->size == 0) {
     if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
@@ -636,6 +783,7 @@ void fused_attn_ck_fwd_qkvpacked(
     devPtrS, devPtrO,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlens, devPtrCuSeqlens,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -708,7 +856,8 @@ void fused_attn_ck_bwd_qkvpacked(
   void *devPtrdQ = static_cast<void *>(devPtrdQKV);
   void *devPtrdK = static_cast<void *>(static_cast<int8_t *>(devPtrdQKV) + stride);
   void *devPtrdV = static_cast<void *>(static_cast<int8_t *>(devPtrdQKV) + 2 * stride);
-  
+
+  void *devPtrCuSeqlens = input_cu_seqlens->data.dptr; 
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
@@ -724,6 +873,7 @@ void fused_attn_ck_bwd_qkvpacked(
     devPtrdO, devPtrdBias,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlens, devPtrCuSeqlens,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -785,6 +935,8 @@ void fused_attn_ck_fwd_kvpacked(
   }
   void *devPtrO = output_O->data.dptr;
   void *devPtrS = nullptr;
+  void *devPtrCuSeqlensQ = input_cu_seqlens_q->data.dptr;
+  void *devPtrCuSeqlensKV = input_cu_seqlens_kv->data.dptr;
 
   if (Aux_CTX_Tensors->size == 0) {
     if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
@@ -840,6 +992,7 @@ void fused_attn_ck_fwd_kvpacked(
     devPtrS, devPtrO,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlensQ, devPtrCuSeqlensKV,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -913,6 +1066,8 @@ void fused_attn_ck_bwd_kvpacked(
 
   void *devPtrSoftmaxStats = output_S->data.dptr;
 
+  void *devPtrCuSeqlensQ = input_cu_seqlens_q->data.dptr;
+  void *devPtrCuSeqlensKV = input_cu_seqlens_kv->data.dptr;
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
@@ -928,6 +1083,7 @@ void fused_attn_ck_bwd_kvpacked(
     devPtrdO, devPtrdBias,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlensQ, devPtrCuSeqlensKV, 
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -980,6 +1136,9 @@ void fused_attn_ck_fwd(
     bias_b = input_Bias->data.shape[0];
     bias_h = input_Bias->data.shape[1];
   }
+
+  void *devPtrCuSeqlensQ = input_cu_seqlens_q->data.dptr;
+  void *devPtrCuSeqlensKV = input_cu_seqlens_kv->data.dptr;
 
   if (Aux_CTX_Tensors->size == 0) {
     if ((bias_type != NVTE_NO_BIAS) && (bias_type != NVTE_ALIBI)) {
@@ -1034,6 +1193,7 @@ void fused_attn_ck_fwd(
     devPtrS, devPtrO,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlensQ, devPtrCuSeqlensKV,
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,
@@ -1096,6 +1256,9 @@ void fused_attn_ck_bwd(
   void *devPtrdV = output_dV->data.dptr;
   void *devPtrSoftmaxStats = output_S->data.dptr;
 
+  void *devPtrCuSeqlensQ = input_cu_seqlens_q->data.dptr;
+  void *devPtrCuSeqlensKV = input_cu_seqlens_kv->data.dptr;
+
   size_t workspace_size = 0;
 
   fused_attn_ck_bwd_impl(
@@ -1111,6 +1274,7 @@ void fused_attn_ck_bwd(
     devPtrdO, devPtrdBias,
     rng_state->data.dptr, 
     reinterpret_cast<void *>(reinterpret_cast<uint64_t *>(rng_state->data.dptr) + 1),
+    devPtrCuSeqlensQ, devPtrCuSeqlensKV, 
     nvte_to_ck_dtype(QKV_type),
     workspace->data.dptr,
     &workspace_size,

--- a/transformer_engine/common/fused_attn_rocm/utils.cpp
+++ b/transformer_engine/common/fused_attn_rocm/utils.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
  *
  * License for AMD contributions = MIT. See LICENSE for more information
  ************************************************************************/
@@ -42,7 +42,7 @@ void generateMatrixStrides(
             uint64_t s_q, uint64_t s_kv,
             uint64_t d, uint64_t* stride,
             NVTE_QKV_Layout layout, NVTE_QKV_Matrix matrix) {
-    // AOTriton internally takes BHSD for implementation
+    // CK/AOTriton internally takes BHSD for implementation
     constexpr int batch_dim_idx   = 0;
     constexpr int head_dim_idx    = 1;
     constexpr int seqlen_dim_idx  = 2;

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -114,6 +114,9 @@ class FusedAttnHelper:
 
     def get_fused_attn_backend(self):
         """Get the fused attention kernel backend"""
+        # temporary hack to disable thd in rocm fused attn as no pad_between_sequence
+        if self.qkv_layout in [NVTE_QKV_Layout.NVTE_T3HD, NVTE_QKV_Layout.NVTE_THD_T2HD, NVTE_QKV_Layout.NVTE_THD_THD_THD]:
+            return NVTE_Fused_Attn_Backend.NVTE_No_Backend
         return transformer_engine_jax.get_fused_attn_backend(
             jax_dtype_to_te_dtype(self.q_dtype),
             jax_dtype_to_te_dtype(self.kv_dtype),

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -521,11 +521,12 @@ def get_attention_backend(
                     "padding between sequences, i.e. [a, a, PAD, b, b, b, PAD, c, PAD]"
                 )
             use_flash_attention = False
-        # TODO: rocm fused attention does not integrate var seqlen features
-        if IS_HIP_EXTENSION and use_fused_attention:
-            logger.debug("Disabling ROCm FusedAttention for qkv_format = thd")
+        if IS_HIP_EXTENSION and use_fused_attention and pad_between_seqs:
+            logger.debug(
+                "Disabling rocm fused attn for qkv_format = thd when there is "
+                "padding between sequences, i.e. [a, a, PAD, b, b, b, PAD, c, PAD]"
+            )
             use_fused_attention = False
-
     # Filter: Dropout
     if attention_dropout != 0.0 and use_flash_attention and _use_flash_attn_3:
         logger.debug("Disabling FlashAttention 3 for dropout")


### PR DESCRIPTION
# Description

Integrate the CK THD layout without padding between sequence into ROCM fused attn. 

Currently only the pytorch side can run since JAX THD layout requires padding between sequences

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes
Including softmax lse shape conversion kernels

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
