### PR TITLE
[ROCm] integrating rmsnorm_bwd triton kernels into TE

### DIFF
--- a/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 import os
 
-from transformer_engine.pytorch.triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_fp8_noalloc_triton, te_rmsnorm_fwd_noalloc_triton, te_rmsnorm_fwd_inf_triton
+from transformer_engine.pytorch.triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_fp8_noalloc_triton, te_rmsnorm_fwd_noalloc_triton, te_rmsnorm_fwd_inf_triton, te_rmsnorm_bwd_triton
 from transformer_engine.pytorch import cpp_extensions as tex
 
 def get_te_dtype(dtype):
@@ -62,7 +62,7 @@ all_boolean = [True, False]
 #TODO add fp8/bf8 once fp8 triton kernels are available
 @pytest.mark.parametrize("out_dtype", test_dtypes)
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
-def test_rmsnorm_fwd_fp8_noalloc_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
+def test_rmsnorm_fwd_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
     if sizeof(in_dtype) < sizeof(out_dtype):
         pytest.skip("size of input dtype < size of output dtype")
     if (in_dtype==torch.float16 and out_dtype==torch.bfloat16) or (in_dtype==torch.bfloat16 and out_dtype==torch.float16):
@@ -70,14 +70,21 @@ def test_rmsnorm_fwd_fp8_noalloc_triton(M, N, in_dtype, out_dtype, zero_centered
     ## Uniform distribution between [-2.0, 1.0]
     input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
     input_tensor = input_tensor.to(in_dtype)
+    # in hipfied kernel cpp test, weight type == input_type
     gamma_tensor = torch.rand(N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
     gamma_tensor = gamma_tensor.to(in_dtype)
+    dz_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
+    # in hipfied kernel cpp test, dz is of weight type
+    dz_tensor = dz_tensor.to(in_dtype)
 
     epsilon = 1e-5
     # run the triton path
+    # in hipfied kernel cpp test, z is of out_type
     ln_out_triton = torch.empty(M, N, dtype=out_dtype, device='cuda')
     ln_out_triton, rsigma_triton = te_rmsnorm_fwd_fp8_noalloc_triton(input_tensor, gamma_tensor, epsilon, ln_out_triton, out_dtype, zero_centered_gamma)
+
     # run the reference hipified kernel path
+    # dummy fp8 meta 
     scale_tensor = torch.empty(0, dtype=torch.float32, device='cuda')
     amax_tensor = torch.zeros(0, dtype=torch.float32, device='cuda')
     scale_inv_tensor = torch.empty(0, dtype=torch.float32, device='cuda')
@@ -86,9 +93,18 @@ def test_rmsnorm_fwd_fp8_noalloc_triton(M, N, in_dtype, out_dtype, zero_centered
     ln_out_hipified = torch.empty(M, N, dtype=out_dtype, device='cuda')
     ln_out_hipified, rsigma_hipified = tex.rmsnorm_fwd_fp8_noalloc(input_tensor, gamma_tensor, epsilon, scale_tensor, ln_out_hipified, amax_tensor, scale_inv_tensor, get_te_dtype(out_dtype), fwd_ln_sm_margin, zero_centered_gamma)
     atol, rtol = get_tolerances(out_dtype)
-    assert torch.allclose(ln_out_triton, ln_out_hipified, atol=atol, rtol=rtol), 'ln_out does not match'
+    assert torch.allclose(ln_out_triton, ln_out_hipified, atol=1e-8, rtol=rtol), 'ln_out does not match'
     # rsigma is of type fp32
     assert torch.allclose(rsigma_triton, rsigma_hipified, atol=1e-6, rtol=5e-5), 'rsigma does not match'
+    
+    dx_triton, dgamma_triton = te_rmsnorm_bwd_triton(dz_tensor, input_tensor, rsigma_triton, gamma_tensor, zero_centered_gamma)
+    dx_hipified, dgamma_hipified = tex.rmsnorm_bwd(dz_tensor, input_tensor, rsigma_hipified, gamma_tensor, fwd_ln_sm_margin, zero_centered_gamma)
+
+    atol_bwd = 5e-6
+    rtol_bwd = 1e-4
+    torch.testing.assert_close(dx_triton, dx_hipified, atol=atol_bwd, rtol=rtol_bwd)
+    torch.testing.assert_close(dgamma_triton, dgamma_hipified, atol=atol_bwd, rtol=rtol_bwd)
+
 
 @pytest.mark.parametrize("M, N", test_shapes)
 @pytest.mark.parametrize("in_dtype", test_dtypes)

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -11,12 +11,15 @@ from dataclasses import dataclass
 import os
 
 import torch
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 from .. import cpp_extensions as tex
 from ..export import is_in_onnx_export_mode
 from ..fp8 import get_fp8_te_dtype
 from ..utils import get_default_init_method
-from ..triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_noalloc_triton, te_rmsnorm_fwd_inf_triton
+
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_noalloc_triton, te_rmsnorm_fwd_inf_triton, te_rmsnorm_bwd_triton
 
 def _get_normalization_func(
     normalization: str, fp8_output: bool, is_grad_enabled: bool, forward: bool
@@ -33,7 +36,7 @@ def _get_normalization_func(
     }
     bwd_normalization_funcs = {
         "LayerNorm": tex.layernorm_bwd,
-        "RMSNorm": tex.rmsnorm_bwd,
+        "RMSNorm": te_rmsnorm_bwd_triton if (IS_HIP_EXTENSION and bool( int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')) )) else tex.rmsnorm_bwd,
     }
 
     if forward:
@@ -101,12 +104,12 @@ def _apply_normalization(
     else:
         use_rmsnorm_triton = bool( int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')) )
         if is_grad_enabled:
-            if use_rmsnorm_triton and normalization == "RMSNorm":
+            if IS_HIP_EXTENSION and use_rmsnorm_triton and normalization == "RMSNorm":
                 output = te_rmsnorm_fwd_noalloc_triton(*inputs, ln_out, eps, zero_centered_gamma)
             else:
                 output = normalization_func(*inputs, ln_out, eps, fwd_ln_sm_margin, zero_centered_gamma)
         else:
-            if use_rmsnorm_triton and normalization == "RMSNorm":
+            if IS_HIP_EXTENSION and use_rmsnorm_triton and normalization == "RMSNorm":
                 return (
                     te_rmsnorm_fwd_inf_triton(*inputs, eps, zero_centered_gamma),
                     None,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -10,6 +10,8 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import torch
 from torch.nn import init
 
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
+
 from .. import cpp_extensions as tex
 
 from .base import (
@@ -48,6 +50,9 @@ from ..float8_tensor import Float8Tensor
 from ..export import is_in_onnx_export_mode
 from ..tensor import QuantizedTensor
 from ..cpu_offload import is_cpu_offload_enabled
+
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.rmsnorm_triton import te_rmsnorm_bwd_triton
 
 __all__ = ["LayerNormLinear"]
 
@@ -697,14 +702,23 @@ class _LayerNormLinear(torch.autograd.Function):
                     ctx.zero_centered_gamma,
                 )
             elif ctx.normalization == "RMSNorm":
-                dgrad, dgamma = tex.rmsnorm_bwd(
-                    dgrad,
-                    inputmat,
-                    rsigma,
-                    ln_weight,
-                    ctx.bwd_ln_sm_margin,
-                    ctx.zero_centered_gamma,
-                )
+                if IS_HIP_EXTENSION and bool( int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')) ):
+                    dgrad, dgamma = te_rmsnorm_bwd_triton(
+                        dgrad,
+                        inputmat,
+                        rsigma,
+                        ln_weight,
+                        ctx.zero_centered_gamma,
+                    )
+                else:
+                    dgrad, dgamma = tex.rmsnorm_bwd(
+                        dgrad,
+                        inputmat,
+                        rsigma,
+                        ln_weight,
+                        ctx.bwd_ln_sm_margin,
+                        ctx.zero_centered_gamma,
+                    )
                 dbeta = None
             clear_tensor_data(mu)
             clear_tensor_data(rsigma)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -61,6 +61,9 @@ from ..float8_tensor import Float8Tensor
 from ._common import _apply_normalization
 from ..cpu_offload import is_cpu_offload_enabled
 
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.rmsnorm_triton import te_rmsnorm_bwd_triton
+
 __all__ = ["LayerNormMLP"]
 
 
@@ -1057,14 +1060,23 @@ class _LayerNormMLP(torch.autograd.Function):
                     ctx.zero_centered_gamma,
                 )
             elif ctx.normalization == "RMSNorm":
-                dgrad, dgamma = tex.rmsnorm_bwd(
-                    dgrad,
-                    inputmat,
-                    rsigma,
-                    ln_weight,
-                    ctx.bwd_ln_sm_margin,
-                    ctx.zero_centered_gamma,
-                )
+                if IS_HIP_EXTENSION and bool( int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')) ):
+                    dgrad, dgamma = te_rmsnorm_bwd_triton(
+                        dgrad,
+                        inputmat,
+                        rsigma,
+                        ln_weight,
+                        ctx.zero_centered_gamma,
+                    )
+                else:
+                    dgrad, dgamma = tex.rmsnorm_bwd(
+                        dgrad,
+                        inputmat,
+                        rsigma,
+                        ln_weight,
+                        ctx.bwd_ln_sm_margin,
+                        ctx.zero_centered_gamma,
+                    )
                 dbeta = None
             clear_tensor_data(mu)
             clear_tensor_data(rsigma)

--- a/transformer_engine/pytorch/module/rmsnorm.py
+++ b/transformer_engine/pytorch/module/rmsnorm.py
@@ -12,11 +12,13 @@ from typing import Union, Tuple, Optional
 import torch
 from torch.nn.parameter import Parameter
 from torch.nn import init
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 from .. import cpp_extensions as tex
 from ..jit import no_torch_dynamo
 from ..utils import cast_if_needed
-from ..triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_triton
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_triton, te_rmsnorm_fwd_inf_triton, te_rmsnorm_bwd_triton
 
 __all__ = ["RMSNorm"]
 
@@ -80,14 +82,23 @@ class _RMSNorm(torch.autograd.Function):
         inputmat, rmsnorm_weight, rsigma = ctx.saved_tensors
         grad_output = grad_output.contiguous()
         d_rmsnorm_out = grad_output.view(inputmat.shape)
-        dxmat, dgamma = tex.rmsnorm_bwd(
-            d_rmsnorm_out,
-            inputmat,
-            rsigma,
-            rmsnorm_weight,
-            ctx.bwd_rmsnorm_sm_margin,
-            ctx.zero_centered_gamma,
-        )
+        if IS_HIP_EXTENSION and bool( int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')) ):
+            dxmat, dgamma = te_rmsnorm_bwd_triton(
+                d_rmsnorm_out,
+                inputmat,
+                rsigma,
+                rmsnorm_weight,
+                ctx.zero_centered_gamma,
+            )
+        else:
+            dxmat, dgamma = tex.rmsnorm_bwd(
+                d_rmsnorm_out,
+                inputmat,
+                rsigma,
+                rmsnorm_weight,
+                ctx.bwd_rmsnorm_sm_margin,
+                ctx.zero_centered_gamma,
+            )
         return (
             dxmat.view(ctx.inp_shape),
             dgamma,

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm_triton.py
@@ -19,7 +19,7 @@ def get_autotune_config():
 
 @triton.autotune(configs=get_autotune_config(), key=['n_rows', 'n_cols'], use_cuda_graph=True)
 @triton.jit
-def _rmsnorm_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stride, output_row_stride, n_rows, n_cols, epsilon,
+def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stride, output_row_stride, n_rows, n_cols, epsilon,
                     ZERO_CENTERED_GAMMA: tl.constexpr, BLOCK_SIZE: tl.constexpr, USE_BLOCKED: tl.constexpr,
                     NUM_PRGMS: tl.constexpr):
     row_start = tl.program_id(0)
@@ -125,7 +125,7 @@ def te_rmsnorm_fwd_fp8_noalloc_triton(input, weight, eps, ln_out, otype, zero_ce
     grid = lambda meta: (NUM_PRGMS, )
     #encode the otype if ln_out is of different dtype
     ln_out = ln_out.view(otype)
-    _rmsnorm_triton[grid](ln_out, input, weight, rsigma, input.stride(0), ln_out.stride(0), M, N, eps, zero_centered_gamma, blk_size, USE_BLOCKED, NUM_PRGMS)
+    _rmsnorm_fwd_triton[grid](ln_out, input, weight, rsigma, input.stride(0), ln_out.stride(0), M, N, eps, zero_centered_gamma, blk_size, USE_BLOCKED, NUM_PRGMS)
 
     return ln_out, rsigma
 
@@ -148,3 +148,177 @@ def te_rmsnorm_fwd_triton(input, weight, eps, zero_centered_gamma):
     ln_out = torch.empty_like(input_)
     return te_rmsnorm_fwd_noalloc_triton(input_, weight_, ln_out, eps, zero_centered_gamma)
 
+@triton.jit
+def _rmsnorm_bwd_triton(grad_output_ptr, input_ptr, g_ptr, rsigma_ptr, dx_ptr, dg_ptr, input_row_stride, output_row_stride,
+                        n_rows, n_cols, ZERO_CENTERED_GAMMA: tl.constexpr, BLOCK_SIZE: tl.constexpr,
+                        USE_BLOCKED: tl.constexpr, NUM_PRGMS: tl.constexpr):
+    row_start = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    #   tl.assume(input_row_stride >= 0)
+    #   tl.assume(output_row_stride >= 0)
+    #   tl.assume(row_start >= 0)
+
+    if USE_BLOCKED:
+        for row_idx in tl.range(row_start, n_rows, NUM_PRGMS, num_stages=1):
+            row_input_ptr = input_ptr + row_idx * input_row_stride
+            row_grad_output_ptr = grad_output_ptr + row_idx * output_row_stride
+            row_dx_ptr = dx_ptr + row_idx * input_row_stride
+            row_dg_ptr = dg_ptr + row_idx * input_row_stride
+
+            # Compute gradients sum of all colums for each row
+            n_cols_blks = tl.cdiv(n_cols, BLOCK_SIZE) - 1
+            # older version of triton doesn't accept below init
+            # comment out for now to make it compatible with triton 3.1
+            # grad_sum: tl.float32 = 0.0
+            grad_sum = 0.0
+            for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
+                cols = blk_idx * BLOCK_SIZE + col_offsets
+                input_ptrs = row_input_ptr + cols
+                grad_output_ptrs = row_grad_output_ptr + cols
+
+                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+                grad_output_ptrs = tl.multiple_of(grad_output_ptrs, (16, ))
+
+                x = tl.load(input_ptrs).to(tl.float32)
+                grad_output = tl.load(grad_output_ptrs).to(tl.float32)
+                g_ptrs = g_ptr + cols
+                g = tl.load(g_ptrs).to(tl.float32)
+                if (ZERO_CENTERED_GAMMA):
+                    g += 1.
+                grad_sum += tl.sum(grad_output * x * g, axis=0)
+
+            # remainder for grad_sum:
+            cols = n_cols_blks * BLOCK_SIZE + col_offsets
+            mask = cols < n_cols
+            input_ptrs = row_input_ptr + cols
+            x = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            grad_output_ptrs = row_grad_output_ptr + cols
+            grad_output = tl.load(grad_output_ptrs, mask=mask, other=0.0).to(tl.float32)
+            g_ptrs = g_ptr + cols
+            g = tl.load(g_ptrs, mask=mask, other=0.0).to(tl.float32)
+            if (ZERO_CENTERED_GAMMA):
+                g += 1.
+            grad_sum += tl.sum(grad_output * x * g, axis=0)
+
+            # Load r_sigma
+            norm_factor = tl.load(rsigma_ptr + row_idx).to(tl.float32)
+
+            for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
+                cols = blk_idx * BLOCK_SIZE + col_offsets
+                input_ptrs = row_input_ptr + cols
+                grad_output_ptrs = row_grad_output_ptr + cols
+
+                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+                grad_output_ptrs = tl.multiple_of(grad_output_ptrs, (16, ))
+
+                x = tl.load(input_ptrs).to(tl.float32)
+                grad_output = tl.load(grad_output_ptrs).to(tl.float32)
+
+                g_ptrs = g_ptr + cols
+                g = tl.load(g_ptrs).to(tl.float32)
+                if (ZERO_CENTERED_GAMMA):
+                    g += 1.
+                grad_input = grad_output * norm_factor * g - (norm_factor * norm_factor * norm_factor) * x * (grad_sum /
+                                                                                                              n_cols)
+
+                dx_ptrs = row_dx_ptr + cols
+                tl.store(dx_ptrs, grad_input.to(dx_ptr.type.element_ty))
+
+                dg = grad_output * x * norm_factor
+                dg_ptrs = row_dg_ptr + cols
+                tl.store(dg_ptrs, dg.to(tl.float32))
+
+            # Handle remainder
+            cols = n_cols_blks * BLOCK_SIZE + col_offsets
+            mask = cols < n_cols
+
+            input_ptrs = row_input_ptr + cols
+            x = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            grad_output_ptrs = row_grad_output_ptr + cols
+            grad_output = tl.load(grad_output_ptrs, mask=mask, other=0.0).to(tl.float32)
+            g_ptrs = g_ptr + cols
+            g = tl.load(g_ptrs, mask=mask, other=0.0).to(tl.float32)
+            if (ZERO_CENTERED_GAMMA):
+                g += 1.
+            grad_input = grad_output * norm_factor * g - (norm_factor * norm_factor * norm_factor) * x * (grad_sum /
+                                                                                                          n_cols)
+
+            dx_ptrs = row_dx_ptr + cols
+            tl.store(dx_ptrs, grad_input.to(dx_ptr.type.element_ty), mask=mask)
+
+            dg = grad_output * x * norm_factor
+            dg_ptrs = row_dg_ptr + cols
+            tl.store(dg_ptrs, dg.to(tl.float32), mask=mask)
+
+    else:
+        mask = col_offsets < n_cols
+        for row_idx in tl.range(row_start, n_rows, NUM_PRGMS, num_stages=2):
+            input_ptrs = input_ptr + row_idx * input_row_stride + col_offsets
+            grad_output_ptrs = grad_output_ptr + row_idx * output_row_stride + col_offsets
+            dx_ptrs = dx_ptr + row_idx * input_row_stride + col_offsets
+            dg_ptrs = dg_ptr + row_idx * input_row_stride + col_offsets
+
+            input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+            grad_output_ptrs = tl.multiple_of(grad_output_ptrs, (16, ))
+            dx_ptrs = tl.multiple_of(dx_ptrs, (16, ))
+
+            x = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            grad_output = tl.load(grad_output_ptrs, mask=mask, other=0.0).to(tl.float32)
+            g = tl.load(g_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            if (ZERO_CENTERED_GAMMA):
+                g += 1.
+
+            norm_factor = tl.load(rsigma_ptr + row_idx).to(tl.float32)
+            grad_sum = tl.sum(grad_output * x * g, axis=0)
+
+            grad_input = grad_output * norm_factor * g - (norm_factor * norm_factor * norm_factor) * x * (grad_sum /
+                                                                                                          n_cols)
+            tl.store(dx_ptrs, grad_input.to(dx_ptr.type.element_ty), mask=mask)
+
+            dg = grad_output * x * norm_factor
+            tl.store(dg_ptrs, dg.to(tl.float32), mask=mask)
+
+@triton.jit
+def _rmsnorm_bwd_dg_reduce_triton(dg_in_ptr, dg_out_ptr, dg_in_stride, n_rows, n_cols, BLOCK_SIZE_M: tl.constexpr,
+                                  BLOCK_SIZE_N: tl.constexpr):
+    # we want parallelism in N direction
+    # if N is small, we will just use one CU,
+    # otherwise, it can be split by N/BLOCK_SIZE
+    pid = tl.program_id(0)
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for i in range(0, n_rows, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        mask = (rows[:, None] < n_rows) & (cols[None, :] < n_cols)
+        offs = rows[:, None] * n_cols + cols[None, :]
+        acc += tl.load(dg_in_ptr + offs, mask=mask, other=0.).to(tl.float32)
+
+    sum_dg = tl.sum(acc, axis=0)
+    tl.store(dg_out_ptr + cols, sum_dg.to(dg_out_ptr.type.element_ty), mask=cols < n_cols)
+
+# may take non-contiguous inputs
+# see rmsnorm_bwd in transformer_engine/pytorch/csrc/extensions/normalization.cu
+def te_rmsnorm_bwd_triton(dz, x, rsigma, gamma, zero_centered_gamma):
+    dz_ = dz.contiguous()
+    x_ = x.contiguous()
+    rsigma_ = rsigma.contiguous()
+    gamma_ = gamma.contiguous()
+
+    dx = torch.empty_like(x_)
+    dgamma = torch.empty_like(gamma_)
+    
+    M, N = x_.shape
+    dg_tmp = torch.zeros(M, N, device='cuda', dtype=torch.float32, requires_grad=False)
+
+    MAX_FUSED_SIZE = 65536 // x_.element_size()
+    blk_size = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
+    USE_BLOCKED = N > blk_size
+    NUM_PRGMS = min(M, get_num_sms())
+    grid_bwd = lambda meta: (NUM_PRGMS, )
+
+    _rmsnorm_bwd_triton[grid_bwd](dz_, x_, gamma_, rsigma_, dx, dg_tmp, x_.stride(0), dz_.stride(0), M, N, zero_centered_gamma, blk_size, USE_BLOCKED, NUM_PRGMS, num_warps = 8)
+
+    grid_reduce = lambda meta: [triton.cdiv(N, meta['BLOCK_SIZE_N'])]
+    _rmsnorm_bwd_dg_reduce_triton[grid_reduce](dg_tmp, dgamma, dg_tmp.stride(0), M, N, BLOCK_SIZE_M=128, BLOCK_SIZE_N=64)
+
+    return dx, dgamma


### PR DESCRIPTION
# Description

Integrate rmsnorm bwd triton kernels into TE

Fixes the issue that rmsnorm bwd takes a long time on certain machines

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
