### PR TITLE
[ROCm] enable hdim=64 and packed qkv layout for ck bwd v3 kernels

### DIFF
--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -63,10 +63,14 @@ run_test_config() {
     run 1 test_fused_attn.py
     run_default_fa 1 test_helper.py
     run_default_fa 1 test_layer.py #it effectevly always uses unfused attention
+    NVTE_CK_USES_BWD_V3=1 run_default_fa 1 test_layer.py #it effectevly always uses unfused attention
     if [ $_fus_attn = "$_DEFAULT_FUSED_ATTN" ]; then
         run 1 test_praxis_layers.py
     else
         run 3 test_praxis_layers.py
+    fi
+    if [ $_fus_attn = "ck" ]
+        NVTE_CK_USES_BWD_V3=1 run 1 test_fused_attn.py
     fi
     run_default_fa 1 test_sharding.py
     run_default_fa 1 test_softmax.py
@@ -78,6 +82,9 @@ run_test_config_mgpu() {
     #TODO: remove the flag when switch to a newer JAX that has a fix
     export XLA_FLAGS="--xla_gpu_enable_dot_strength_reduction=false --xla_gpu_enable_command_buffer=CUSTOM_CALL"
     run 3 test_distributed_fused_attn.py
+    if [ $_fus_attn = "ck" ]
+        NVTE_CK_USES_BWD_V3=1 run 3 test_distributed_fused_attn.py
+    fi
     run_default_fa 3 test_distributed_layernorm.py
     run_default_fa 3 test_distributed_layernorm_mlp.py
     run_default_fa 3 test_distributed_softmax.py

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -64,6 +64,8 @@ run_test_config(){
         run_default_fa 1 triton_kernels/test_cast_transpose_triton.py
         run_default_fa 1 triton_kernels/test_rmsnorm_triton.py
         NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 run_default_fa 3 test_numerics.py
+        NVTE_CK_USES_BWD_V3=1 run_default_fa 1 fused_attn/test_fused_attn.py
+        NVTE_CK_USES_BWD_V3=1 run_default_fa 3 test_numerics.py
     fi
 }
 
@@ -75,6 +77,7 @@ run_test_config_mgpu(){
         run 3 test_fused_optimizer.py
         run 3 test_fusible_ops_distributed.py
         run 3 fused_attn/test_fused_attn_with_cp.py
+        NVTE_CK_USES_BWD_V3=1 run 3 fused_attn/test_fused_attn_with_cp.py
         run 3 distributed/test_numerics.py
     fi
 }

--- a/transformer_engine/common/ck_fused_attn/CMakeLists.txt
+++ b/transformer_engine/common/ck_fused_attn/CMakeLists.txt
@@ -24,7 +24,7 @@ execute_process(
 #bwd kernels list
 execute_process(
   COMMAND python3 ${__CK_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py
-  --api bwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/bwd_blob_list.txt --receipt 3
+  --api bwd --list_blobs ${CMAKE_CURRENT_BINARY_DIR}/gen_src/bwd_blob_list.txt --receipt 5
 )
 
 file(STRINGS ${CMAKE_CURRENT_BINARY_DIR}/gen_src/fwd_blob_list.txt FMHA_FWD_GEN_BLOBS)
@@ -39,7 +39,7 @@ execute_process(
 # generate the actual bwd kernel cpp files
 execute_process(
   COMMAND python3 ${__CK_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py
-  --api bwd --output_dir ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp --receipt 3
+  --api bwd --output_dir ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp --receipt 5
 )
 
 set(ck_fused_attn_SOURCES)

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -555,13 +555,7 @@ void fused_attn_ck_bwd_impl(
   }
   // bwd v3 is optional by enabling the following envs
   // default values follows the ck example setting
-  // TODO: release SBHD format once CK support it
-  bool nvte_ck_uses_bwd_v3 = getenv<int>("NVTE_CK_USES_BWD_V3", 0) and (nvte_get_qkv_format(layout)!=NVTE_QKV_Format::NVTE_SBHD);
-  if(nvte_log_ck_config){
-    if(getenv<int>("NVTE_CK_USES_BWD_V3", 0) and (nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_SBHD)){
-      std::cout<<"Disable CK BWD v3 since SBHD format not supported"<<std::endl;
-    }
-  }
+  bool nvte_ck_uses_bwd_v3 = getenv<int>("NVTE_CK_USES_BWD_V3", 0);
   bool nvte_ck_is_v3_atomic_fp32 = getenv<int>("NVTE_CK_IS_V3_ATOMIC_FP32", 1);
   int nvte_ck_how_v3_bf16_cvt = getenv<int>("NVTE_CK_HOW_V3_BF16_CVT", 1);
 


### PR DESCRIPTION
# Description

Enable hdim=64 for bwd v3 kernels

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
