### PR TITLE
[ROCm] hotfix for THD in TE CK: avoid reading total_seqlen_q and total_seqlen_kv directly on host

### DIFF
--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -17,21 +17,19 @@
 
 namespace ck_fused_attn{
 
-// convert the softmax lse from [b, h, s_q] into shape [h, total_seqlen_q]
+// convert the softmax lse from [b, h, s_q] into shape [h, b*s_q] (with effective data in first total_q places)
 __global__ void softmax_lse_to_thd(
   uint64_t b, uint64_t h, uint64_t s_q,
   const int32_t* cu_seqlen_q,
   const float* lse,
   float* lse_thd){
 
-  int32_t total_seqlen_q = cu_seqlen_q[b];
-  
   for(uint64_t bh_idx = blockIdx.x*blockDim.x + threadIdx.x; bh_idx < b*h; bh_idx += blockDim.x * gridDim.x){
     uint64_t b_idx = bh_idx/h;
     uint64_t h_idx = bh_idx%h;
     // loop over a given batch and head idx
     for(uint64_t s_idx = cu_seqlen_q[b_idx]; s_idx < cu_seqlen_q[b_idx + 1]; s_idx++){
-      lse_thd[h_idx * total_seqlen_q + s_idx] = lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]];
+      lse_thd[h_idx * b*s_q + s_idx] = lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]];
     }
   }
 }
@@ -88,7 +86,8 @@ __global__ void dk_dv_reduce(
 // define dk_dv_reduce function in THD layout only for fp16 and bf16 types
 template<typename DataType>
 __global__ void dk_dv_reduce_thd(
-  uint64_t h, uint64_t hg, uint64_t d, int32_t total_seqlen_kv,
+  uint64_t b, uint64_t h, uint64_t hg, uint64_t d, 
+  const int32_t* cu_seqlen_kv_ptr,
   const DataType *dk_expanded,
   const DataType *dv_expanded,
   uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
@@ -96,19 +95,25 @@ __global__ void dk_dv_reduce_thd(
   DataType *dv,
   //k,v, dk, dv guaranteed to have the same stride
   uint64_t stride_h_dkv, uint64_t stride_s_dkv){
-  
+
+  int32_t total_seqlen_kv = *(cu_seqlen_kv_ptr + b);
+
   uint64_t seqlen_idx = blockIdx.x;
   uint64_t head_k_idx = blockIdx.y;
   uint64_t hdim_idx = threadIdx.x;
   
+  assert(hdim_dix<d);
+
+  if(seqlen_idx>=total_seqlen_kv){
+    return;
+  }
+
   // h guaranteed to be multiples of hg
   uint64_t head_idx_offset = h / hg;
 
   float sum_dk = 0.0f;
   float sum_dv = 0.0f;
 
-  assert(hdim_dix<d);
-  assert(seqlen_idx < total_seqlen_kv);
 
   uint64_t read_idx = head_k_idx*head_idx_offset*stride_h_dkv_expanded + seqlen_idx*stride_s_dkv_expanded + hdim_idx;
   uint64_t write_idx = head_k_idx*stride_h_dkv + seqlen_idx* stride_s_dkv + hdim_idx;
@@ -686,8 +691,6 @@ hipError_t ck_attn_varlen_bwd(
   ck_tile::index_t hdim_v = d;
   ck_tile::index_t max_seqlen_q = s_q;
   ck_tile::index_t max_seqlen_k = s_kv;
-  ck_tile::index_t total_seqlen_q = *(static_cast<const int32_t *>(cu_seqlen_q_ptr) + b);
-  ck_tile::index_t total_seqlen_kv = *(static_cast<const int32_t *>(cu_seqlen_kv_ptr) + b);
   float scale_s = scaling_factor;
   float p_drop = dropout_probability;
   float p_undrop = 1.0 - p_drop;
@@ -760,8 +763,8 @@ hipError_t ck_attn_varlen_bwd(
     const ck_tile::index_t nhead_stride_o = stride_h_o;
     const ck_tile::index_t nhead_stride_randval = 0;
     const ck_tile::index_t nhead_stride_do = stride_h_do;
-    // lsed and lse of shape [h, total_seqlen_q]
-    const ck_tile::index_t nhead_stride_lsed = total_seqlen_q;
+    // lsed and lse of shape [h, b*s_q] with effective data in first total_seqlen_q places
+    const ck_tile::index_t nhead_stride_lsed = batch*max_seqlen_q;
     const ck_tile::index_t nhead_stride_dq = stride_h_dq;
     const ck_tile::index_t nhead_stride_dk = stride_h_dk;
     const ck_tile::index_t nhead_stride_dv = stride_h_dv;
@@ -786,7 +789,7 @@ hipError_t ck_attn_varlen_bwd(
     // bias not used in THD qkv layout
     const ck_tile::index_t batch_stride_dbias = 0;
     const ck_tile::index_t batch_stride_dq_acc = 0; //dq_acc of shape (nsplits, T, H, D)
-    const ck_tile::index_t split_stride_dq_acc = total_seqlen_q*h*d;
+    const ck_tile::index_t split_stride_dq_acc = batch*max_seqlen_q*h*d;
 
     return fmha_bwd_args{q_ptr,
                          k_ptr,
@@ -805,8 +808,8 @@ hipError_t ck_attn_varlen_bwd(
                          cu_seqlen_q_ptr,//cu_seqlen_q
                          cu_seqlen_kv_ptr,//cu_seqlen_kv
                          nullptr, /* seqlen_k_ptr */
-                         total_seqlen_q,
-                         total_seqlen_kv,
+                         0, //seqlen_q, unused in group mode
+                         0, //seqlen_kv, unused in group mode
                          batch,
                          max_seqlen_q,
                          max_seqlen_k,
@@ -871,7 +874,7 @@ hipError_t ck_attn_varlen_bwd(
     throw std::runtime_error("fused attn configs not supported in ck_fused_attn bwd pass.");
   }
   if(is_mqa_gqa){
-    dim3 grid(total_seqlen_kv, hg);
+    dim3 grid(b*s_kv, hg);
     dim3 block(d);
     if (ck_fused_attn_log_config){
       std::cout<<std::endl<<"run dk_dv_reduce_thd: "<<std::endl;
@@ -887,7 +890,8 @@ hipError_t ck_attn_varlen_bwd(
     CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
       hipLaunchKernelGGL(
         dk_dv_reduce_thd<CK_TILE_TYPE>, grid, block, 0, stream,
-        h, hg, d, total_seqlen_kv,
+        b, h, hg, d, 
+        static_cast<const int32_t*>(cu_seqlen_kv_ptr),
         static_cast<CK_TILE_TYPE*>(dk_expanded_ptr),
         static_cast<CK_TILE_TYPE*>(dv_expanded_ptr),
         stride_h_dkv_expanded, stride_s_dkv_expanded,

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -86,8 +86,8 @@ __global__ void dk_dv_reduce(
 // define dk_dv_reduce function in THD layout only for fp16 and bf16 types
 template<typename DataType>
 __global__ void dk_dv_reduce_thd(
-  uint64_t b, uint64_t h, uint64_t hg, uint64_t d, 
-  const int32_t* cu_seqlen_kv_ptr,
+  uint64_t h, uint64_t hg, uint64_t d, 
+  const int32_t* total_seqlen_kv_ptr,
   const DataType *dk_expanded,
   const DataType *dv_expanded,
   uint64_t stride_h_dkv_expanded, uint64_t stride_s_dkv_expanded,
@@ -96,15 +96,13 @@ __global__ void dk_dv_reduce_thd(
   //k,v, dk, dv guaranteed to have the same stride
   uint64_t stride_h_dkv, uint64_t stride_s_dkv){
 
-  int32_t total_seqlen_kv = *(cu_seqlen_kv_ptr + b);
-
   uint64_t seqlen_idx = blockIdx.x;
   uint64_t head_k_idx = blockIdx.y;
   uint64_t hdim_idx = threadIdx.x;
   
   assert(hdim_dix<d);
 
-  if(seqlen_idx>=total_seqlen_kv){
+  if(seqlen_idx >= *total_seqlen_kv_ptr){
     return;
   }
 
@@ -890,8 +888,8 @@ hipError_t ck_attn_varlen_bwd(
     CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, CK_TILE_TYPE,
       hipLaunchKernelGGL(
         dk_dv_reduce_thd<CK_TILE_TYPE>, grid, block, 0, stream,
-        b, h, hg, d, 
-        static_cast<const int32_t*>(cu_seqlen_kv_ptr),
+        h, hg, d, 
+        static_cast<const int32_t*>(cu_seqlen_kv_ptr)+b,
         static_cast<CK_TILE_TYPE*>(dk_expanded_ptr),
         static_cast<CK_TILE_TYPE*>(dv_expanded_ptr),
         stride_h_dkv_expanded, stride_s_dkv_expanded,

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
@@ -17,21 +17,19 @@
 
 namespace ck_fused_attn{
 
-// cuda kernel to convert softmax lse from [h, total_seqlen_q] to [b, h, s_q]
+// cuda kernel to convert softmax lse from [h, b*s_q] (with effective data in first total_q places) to [b, h, s_q]
 __global__ void softmax_lse_from_thd(
   uint64_t b, uint64_t h, uint64_t s_q,
   const int32_t* cu_seqlen_q,
   const float* lse_thd,
   float* lse){
 
-  int32_t total_seqlen_q = cu_seqlen_q[b];
-  
   for(uint64_t bh_idx = blockIdx.x*blockDim.x + threadIdx.x; bh_idx < b*h; bh_idx += blockDim.x * gridDim.x){
     uint64_t b_idx = bh_idx/h;
     uint64_t h_idx = bh_idx%h;
     // loop over a given batch and head idx
     for(uint64_t s_idx = cu_seqlen_q[b_idx]; s_idx < cu_seqlen_q[b_idx + 1]; s_idx++){
-      lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]] = lse_thd[h_idx * total_seqlen_q + s_idx];
+      lse[bh_idx * s_q + s_idx - cu_seqlen_q[b_idx]] = lse_thd[h_idx * b*s_q + s_idx];
     }
   }
 }
@@ -295,8 +293,6 @@ hipError_t ck_attn_varlen_fwd(
   ck_tile::index_t nhead_k = hg;
   ck_tile::index_t hdim_v = d;
   ck_tile::index_t max_seqlen_q = s_q;
-  ck_tile::index_t total_seqlen_q = *(static_cast<const int32_t *>(cu_seqlen_q_ptr) + b);
-  ck_tile::index_t total_seqlen_kv = *(static_cast<const int32_t *>(cu_seqlen_kv_ptr) + b);
 
   float scale_s = scaling_factor;
   float scale_p = 1.f;
@@ -340,8 +336,8 @@ hipError_t ck_attn_varlen_fwd(
     const ck_tile::index_t nhead_stride_bias = 0;
     //TODO: randval never used, can we remove it
     const ck_tile::index_t nhead_stride_randval = 0;
-    // CK group mode requires softmax_lse be of shape [h, total_s_q]
-    const ck_tile::index_t nhead_stride_lse = total_seqlen_q;
+    // In CK group mode, softmax_lse can be of shape [h, b*s_q] with effective data in first total_seqlen_q places
+    const ck_tile::index_t nhead_stride_lse = batch*max_seqlen_q;
     const ck_tile::index_t nhead_stride_o = stride_h_o;
     // setup batch_stride_* arguments
     const ck_tile::index_t batch_stride_q = 0;
@@ -364,8 +360,8 @@ hipError_t ck_attn_varlen_fwd(
                          cu_seqlen_q_ptr,//cu_seqlen_q
                          cu_seqlen_kv_ptr,//cu_seqlen_kv
                          nullptr, /* seqlen_k_ptr */
-                         total_seqlen_q,
-                         total_seqlen_kv,
+                         0, //seqlen_q, unused in group mode
+                         0, //seqlen_kv, unused in group mode
                          batch,
                          max_seqlen_q,
                          hdim_q,
@@ -412,7 +408,7 @@ hipError_t ck_attn_varlen_fwd(
     throw std::runtime_error("fused attn configs not supported in ck_fused_attn fwd pass.");
   }
 
-  // convert softmax_lse from [h, total_seqlen_q] to [b, h, s_q]
+  // convert softmax_lse from [h, b*max_seqlen_q] (effective data in first total_q places) to [b, h, s_q]
   if(lse_thd_ptr!=lse_ptr){
     assert((lse_thd_ptr!=nullptr) && (lse_ptr!=nullptr));
     constexpr int THREADS_PER_BLOCK = 1024;

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -1067,11 +1067,9 @@ void fused_attn_ck_bwd_kvpacked(
   size_t workspace_size = 0;
 
   // extract the qkv and o storage bytes to clear qkv buffer
-  size_t q_storage_bytes = 0;
-  size_t kv_storage_bytes = 0;
   // b from cu_seqlen is not the actual storage batch for pad_between_seq case
-  q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
-  kv_storage_bytes = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t kv_storage_bytes = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
   // ensure k ,v are of the same storage size
   assert(kv_storage_bytes%2==0);
 
@@ -1268,13 +1266,10 @@ void fused_attn_ck_bwd(
   size_t workspace_size = 0;
 
   // extract the qkv and o storage bytes to clear dq buffer
-  size_t q_storage_bytes = 0;
-  size_t k_storage_bytes = 0;
-  size_t v_storage_bytes = 0;
   // b from cu_seqlen is not the actual storage batch for pad_between_seqs case
-  q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
-  k_storage_bytes = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
-  v_storage_bytes = std::accumulate((input_V->data).shape.begin(), (input_V->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t k_storage_bytes = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t v_storage_bytes = std::accumulate((input_V->data).shape.begin(), (input_V->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
 
   fused_attn_ck_bwd_impl(
     b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <string>
+#include <numeric> // Required for std::accumulate
 #ifdef USE_FUSED_ATTN_CK
 #include <ck_fused_attn/ck_fused_attn.hpp>
 #endif // USE_FUSED_ATTN_CK
@@ -296,15 +297,13 @@ void fused_attn_ck_fwd_impl(
     std::cout<<"layout: "<<layout<<", ";
     if(is_ragged){
       // THD
-      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
-      int32_t total_kv = *(static_cast<const int32_t *>(devPtrCuSeqlensKV) + b);
-      std::cout<<"q_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"q_shape: ("<<b*s_q<<", "<<h<<", "<<d<<"), ";
       std::cout<<"q_stride: ("<<q_stride[2]<<", "<<q_stride[1]<<", "<<q_stride[3]<<"), ";
-      std::cout<<"kv_shape: ("<<total_kv<<", "<<hg<<", "<<d<<"), ";
+      std::cout<<"kv_shape: ("<<b*s_kv<<", "<<hg<<", "<<d<<"), ";
       std::cout<<"k_stride: ("<<k_stride[2]<<", "<<k_stride[1]<<", "<<k_stride[3]<<"), ";
       std::cout<<"v_stride: ("<<v_stride[2]<<", "<<v_stride[1]<<", "<<v_stride[3]<<"), ";
 
-      std::cout<<"o_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"o_shape: ("<<b*s_q<<", "<<h<<", "<<d<<"), ";
       std::cout<<"o_stride: ("<<o_stride[2]<<", "<<o_stride[1]<<", "<<o_stride[3]<<"), ";
     }else{
       // non-THD
@@ -350,7 +349,7 @@ void fused_attn_ck_fwd_impl(
         devPtrSoftmaxLSETHD,
         devPtrSoftmaxAux,
         stream));
-    // softmax_lse will be fixed from [total_seqlen_q, h] to [b, h, s] in ck_fused_attn
+    // softmax_lse will be fixed from [h, b*s_q] to [b, h, s] in ck_fused_attn
   }else{
     using ck_fused_attn::ck_attn_fwd;
     NVTE_CHECK_CUDA(
@@ -391,6 +390,7 @@ size_t ck_dtype_size(ck_fused_attn::DType t_dtype){
 
 void fused_attn_ck_bwd_impl(
   uint64_t b, uint64_t h, uint64_t hg, uint64_t s_q, uint64_t s_kv, uint64_t d, uint64_t bias_b, uint64_t bias_h,
+  size_t q_storage_bytes, size_t k_storage_bytes, size_t v_storage_bytes,
   float scaling_factor, float dropout_probability, 
   NVTE_QKV_Layout layout,
   NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
@@ -440,7 +440,7 @@ void fused_attn_ck_bwd_impl(
       (*workspace_size) += b*h*s_q*s_kv*ck_dtype_size(dtype);
     }
     if(is_ragged){
-      // transform the input softmax_lse of shape [b, h, s] into [h, total_s]
+      // transform the input softmax_lse of shape [b, h, s] into [h, b*s_q]
       (*workspace_size)+= b*h*s_q*sizeof(float);
     }
     if (nvte_log_ck_config) {
@@ -454,21 +454,12 @@ void fused_attn_ck_bwd_impl(
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(layout);
   if((layout_group == NVTE_QKV_Layout_Group::NVTE_3HD) or (layout_group == NVTE_QKV_Layout_Group::NVTE_H3D)){
     // just memset all dq, dk, dv
-    if(is_ragged){
-      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
-      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*h*total_q*d*3, stream);
-
-    }else{
-      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d*3, stream);
-    }
+    // dq, dk, dv is of same shape as q, k, v
+    NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdQ, 0, q_storage_bytes + k_storage_bytes + v_storage_bytes, stream));
   }else{
     // HD_2HD, HD_H2D, HD_HD_HD can just memset dq itself
-    if(is_ragged){
-      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
-      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*h*total_q*d, stream);
-    }else{
-      (void)cudaMemsetAsync(devPtrdQ, 0, ck_dtype_size(dtype)*b*h*s_q*d, stream);
-    }
+    // dq is of the same shape as q
+    NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdQ, 0, q_storage_bytes, stream));
   }
   std::array<uint64_t, 4> q_stride;
   std::array<uint64_t, 4> k_stride;
@@ -573,15 +564,13 @@ void fused_attn_ck_bwd_impl(
     std::cout<<"layout: "<<layout<<", ";
     if(is_ragged){
       // THD
-      int32_t total_q = *(static_cast<const int32_t *>(devPtrCuSeqlensQ) + b);
-      int32_t total_kv = *(static_cast<const int32_t *>(devPtrCuSeqlensKV) + b);
-      std::cout<<"q_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"q_shape: ("<<b*s_q<<", "<<h<<", "<<d<<"), ";
       std::cout<<"q_stride: ("<<q_stride[2]<<", "<<q_stride[1]<<", "<<q_stride[3]<<"), ";
-      std::cout<<"kv_shape: ("<<total_kv<<", "<<hg<<", "<<d<<"), ";
+      std::cout<<"kv_shape: ("<<b*s_kv<<", "<<hg<<", "<<d<<"), ";
       std::cout<<"k_stride: ("<<k_stride[2]<<", "<<k_stride[1]<<", "<<k_stride[3]<<"), ";
       std::cout<<"v_stride: ("<<v_stride[2]<<", "<<v_stride[1]<<", "<<v_stride[3]<<"), ";
 
-      std::cout<<"o_shape: ("<<total_q<<", "<<h<<", "<<d<<"), ";
+      std::cout<<"o_shape: ("<<b*s_q<<", "<<h<<", "<<d<<"), ";
       std::cout<<"o_stride: ("<<o_stride[2]<<", "<<o_stride[1]<<", "<<o_stride[3]<<"), ";
     }else{
       // non-THD
@@ -860,8 +849,16 @@ void fused_attn_ck_bwd_qkvpacked(
   void *devPtrCuSeqlens = input_cu_seqlens->data.dptr; 
   size_t workspace_size = 0;
 
+  // extract the qkv and o storage bytes to clear dq buffer
+  size_t qkv_storage_bytes = 0;
+  qkv_storage_bytes = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  // ensure q, k ,v are of the same storage size
+  assert(qkv_storage_bytes%3==0);
+  // in qkvpacked layouts, o is of the same shape as q shape
+  // dqkv has the same shape as qkv
   fused_attn_ck_bwd_impl(
     b, h, h, max_seqlen, max_seqlen, d, bias_b, bias_h,
+    qkv_storage_bytes/3, qkv_storage_bytes/3, qkv_storage_bytes/3,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
@@ -1070,8 +1067,18 @@ void fused_attn_ck_bwd_kvpacked(
   void *devPtrCuSeqlensKV = input_cu_seqlens_kv->data.dptr;
   size_t workspace_size = 0;
 
+  // extract the qkv and o storage bytes to clear qkv buffer
+  size_t q_storage_bytes = 0;
+  size_t kv_storage_bytes = 0;
+  // b from cu_seqlen is not the actual storage batch for pad_between_seq case
+  q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  kv_storage_bytes = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  // ensure k ,v are of the same storage size
+  assert(kv_storage_bytes%2==0);
+
   fused_attn_ck_bwd_impl(
     b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
+    q_storage_bytes, kv_storage_bytes/2, kv_storage_bytes/2,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,
@@ -1261,8 +1268,18 @@ void fused_attn_ck_bwd(
 
   size_t workspace_size = 0;
 
+  // extract the qkv and o storage bytes to clear dq buffer
+  size_t q_storage_bytes = 0;
+  size_t k_storage_bytes = 0;
+  size_t v_storage_bytes = 0;
+  // b from cu_seqlen is not the actual storage batch for pad_between_seqs case
+  q_storage_bytes = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  k_storage_bytes = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  v_storage_bytes = std::accumulate((input_V->data).shape.begin(), (input_V->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+
   fused_attn_ck_bwd_impl(
     b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, bias_b, bias_h,
+    q_storage_bytes, k_storage_bytes, v_storage_bytes,
     attn_scale, dropout, 
     qkv_layout,
     bias_type, attn_mask_type,

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -850,8 +850,7 @@ void fused_attn_ck_bwd_qkvpacked(
   size_t workspace_size = 0;
 
   // extract the qkv and o storage bytes to clear dq buffer
-  size_t qkv_storage_bytes = 0;
-  qkv_storage_bytes = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
+  size_t qkv_storage_bytes = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), 1, std::multiplies<size_t>())*nvte_dtype_size(QKV_type);
   // ensure q, k ,v are of the same storage size
   assert(qkv_storage_bytes%3==0);
   // in qkvpacked layouts, o is of the same shape as q shape


### PR DESCRIPTION
# Description

Only read cu_seqlen on device. Also introduce q, k, v storage bytes to clean dq buffer for thd and non-thd case.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
