### PR TITLE
[Fix] hipblaslt_gemm handle unsafe usage on multi stream scene

### DIFF
--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -60,12 +60,13 @@ namespace transformer_engine {
 
 #ifdef __HIP_PLATFORM_AMD__
 //Forward declaration. The implementation is in rocm_gemm.cu
+// stream_offset -1 means torch default stream.
 void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  const Tensor *inputBias, Tensor *outputPreGelu, int m, int n, int k, int lda,
                  int ldb, int ldd, bool transa, bool transb, bool grad,
                  void* workspace, size_t workspaceSize, bool accumulate, bool use_split_accumulator,
                  int math_sm_count, int m_split, int n_split, bool gemm_producer,
-                 const Tensor *inputCounter, hipStream_t stream);
+                 const Tensor *inputCounter, hipStream_t stream, int stream_offset = -1);
 #else // Use cublasLt
 void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  const Tensor *inputBias, Tensor *outputPreGelu, int m, int n, int k, int lda,
@@ -314,6 +315,77 @@ static void init_streams_and_events() {
 
 }  // namespace transformer_engine
 
+#ifdef __HIP_PLATFORM_AMD__
+// stream_offset = -1 means torch default stream
+void nvte_cublas_gemm_with_stream_offset(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
+                      NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
+                      NVTETensor workspace, bool accumulate, bool use_split_accumulator,
+                      int math_sm_count, cudaStream_t stream, int stream_offset) {
+  NVTE_API_CALL(nvte_cublas_gemm_with_stream_offset);
+
+  using namespace transformer_engine;
+  const Tensor *inputA = reinterpret_cast<const Tensor *>(A);
+  const Tensor *inputB = reinterpret_cast<const Tensor *>(B);
+  Tensor *outputD = reinterpret_cast<Tensor *>(D);
+  const Tensor *biasTensor = reinterpret_cast<const Tensor *>(bias);
+  Tensor *outputGelu = reinterpret_cast<Tensor *>(pre_gelu_out);
+  Tensor *wspace = reinterpret_cast<Tensor *>(workspace);
+
+  const int m = transa ? inputA->data.shape[0] : inputA->data.shape[1];
+  const int k = transa ? inputA->data.shape[1] : inputA->data.shape[0];
+  const int n = transb ? inputB->data.shape[1] : inputB->data.shape[0];
+  int lda, ldb, ldd;
+  if (transa && !transb) {  // TN
+    lda = k;
+    ldb = k;
+    ldd = m;
+  } else if (!transa && !transb) {  // NN
+    lda = m;
+    ldb = k;
+    ldd = m;
+  } else if (!transa && transb) {  // NT
+    lda = m;
+    ldb = n;
+    ldd = m;
+  } else {  // TT
+    NVTE_ERROR("TT layout not allowed.");
+  }
+
+  bool nvte_log_gemm_config = false;
+  if (const char* env_p = std::getenv("NVTE_LOG_GEMM_CONFIG") ) {
+    if (env_p != nullptr && std::string(env_p) == "1")
+      nvte_log_gemm_config = true;
+  }
+
+  if (nvte_log_gemm_config) {
+    float A_scale_inv, B_scale_inv;
+    (void)cudaMemcpy(&A_scale_inv, inputA->scale_inv.dptr, sizeof(float), cudaMemcpyDeviceToHost);
+    (void)cudaMemcpy(&B_scale_inv, inputB->scale_inv.dptr, sizeof(float), cudaMemcpyDeviceToHost);
+    std::cout << "m=" << m << " k=" << k << " n=" << n 
+        << " transa=" << (transa?"T":"N")
+        << " transb=" << (transb?"T":"N")
+        << " A_type=" << (int)inputA->data.dtype
+        << " B_type=" << (int)inputB->data.dtype
+        << " D_type=" << (int)outputD->data.dtype
+        << " bias_type=" << (int)biasTensor->data.dtype
+        << " grad=" << grad
+        << " bias=" << (biasTensor->data.dptr != nullptr)
+        << " gelu=" << (outputGelu->data.dptr != nullptr)
+        << " use_fp8=" << ( is_fp8_dtype(inputA->data.dtype) || is_fp8_dtype(inputB->data.dtype) )
+        << " A_scale_inverse = " <<  A_scale_inv
+        << " B_scale_inverse = " <<  B_scale_inv
+        << " accumulate=" << accumulate
+        << std::endl;
+  }
+
+  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
+              transa, transb,
+              grad,
+              wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
+              math_sm_count, 0, 0, false, nullptr, stream, stream_offset);
+}
+#endif // __HIP_PLATFORM_AMD__
+
 void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
                       NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
                       NVTETensor workspace, bool accumulate, bool use_split_accumulator,
@@ -459,9 +531,15 @@ void nvte_multi_stream_cublas_gemm(const NVTETensor *A, const NVTETensor *B, NVT
   }
 
   for (int i = 0; i < num_gemms; i++) {
+#ifdef __HIP_PLATFORM_AMD__
+    nvte_cublas_gemm_with_stream_offset(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
+                                        workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
+                                        compute_streams[i % num_streams], i % num_streams);
+#else
     nvte_cublas_gemm(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
                      workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
                      compute_streams[i % num_streams]);
+#endif // __HIP_PLATFORM_AMD__
   }
 
   // record events on compute streams

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -314,7 +314,7 @@ static void init_streams_and_events() {
 
 }  // namespace transformer_engine
 
-// -1 means the stream from outer rather than compute_streams
+// compute_stream_offset = -1 means the stream from outer rather than compute_streams
 static void cublas_gemm_ex(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
                            NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
                            NVTETensor workspace, bool accumulate, bool use_split_accumulator,

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -60,13 +60,12 @@ namespace transformer_engine {
 
 #ifdef __HIP_PLATFORM_AMD__
 //Forward declaration. The implementation is in rocm_gemm.cu
-// stream_offset -1 means torch default stream.
 void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  const Tensor *inputBias, Tensor *outputPreGelu, int m, int n, int k, int lda,
                  int ldb, int ldd, bool transa, bool transb, bool grad,
                  void* workspace, size_t workspaceSize, bool accumulate, bool use_split_accumulator,
                  int math_sm_count, int m_split, int n_split, bool gemm_producer,
-                 const Tensor *inputCounter, hipStream_t stream, int stream_offset = -1);
+                 const Tensor *inputCounter, hipStream_t stream, int compute_stream_offset = -1);
 #else // Use cublasLt
 void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  const Tensor *inputBias, Tensor *outputPreGelu, int m, int n, int k, int lda,
@@ -315,12 +314,11 @@ static void init_streams_and_events() {
 
 }  // namespace transformer_engine
 
-void nvte_cublas_gemm_ex(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
-                      NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
-                      NVTETensor workspace, bool accumulate, bool use_split_accumulator,
-                      int math_sm_count, cudaStream_t stream, int stream_offset = -1) {
-  NVTE_API_CALL(nvte_cublas_gemm_ex);
-
+// -1 means the stream from outer rather than compute_streams
+static void cublas_gemm_ex(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
+                           NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
+                           NVTETensor workspace, bool accumulate, bool use_split_accumulator,
+                           int math_sm_count, cudaStream_t stream, int compute_stream_offset = -1) {
   using namespace transformer_engine;
   const Tensor *inputA = reinterpret_cast<const Tensor *>(A);
   const Tensor *inputB = reinterpret_cast<const Tensor *>(B);
@@ -376,20 +374,19 @@ void nvte_cublas_gemm_ex(const NVTETensor A, const NVTETensor B, NVTETensor D, c
         << std::endl;
   }
 
+  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
 #ifdef __HIP_PLATFORM_AMD__
-  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
               transa, transb,
-              grad,
-              wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
-              math_sm_count, 0, 0, false, nullptr, stream, stream_offset);
 #else
-  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
-              transa, transb,
               (transa) ? CUBLAS_OP_T : CUBLAS_OP_N, (transb) ? CUBLAS_OP_T : CUBLAS_OP_N,
+#endif //__HIP_PLATFORM_AMD__
               grad,
               wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
-              math_sm_count, 0, 0, false, nullptr, stream);
+              math_sm_count, 0, 0, false, nullptr, stream
+#ifdef __HIP_PLATFORM_AMD__
+              ,compute_stream_offset
 #endif //__HIP_PLATFORM_AMD__
+            );
 }
 
 void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
@@ -398,12 +395,11 @@ void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, cons
                       int math_sm_count, cudaStream_t stream) {
   NVTE_API_CALL(nvte_cublas_gemm);
   
-  // stream_offset = -1 means torch default stream
-  nvte_cublas_gemm_ex(A, B, D, bias, pre_gelu_out, 
-                      transa, transb, 
-                      grad, 
-                      workspace, accumulate, use_split_accumulator, 
-                      math_sm_count, stream, -1);
+  cublas_gemm_ex(A, B, D, bias, pre_gelu_out, 
+                 transa, transb, 
+                 grad, 
+                 workspace, accumulate, use_split_accumulator, 
+                 math_sm_count, stream, -1);
 }
 
 void nvte_cublas_atomic_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D,
@@ -480,9 +476,9 @@ void nvte_multi_stream_cublas_gemm(const NVTETensor *A, const NVTETensor *B, NVT
   }
 
   for (int i = 0; i < num_gemms; i++) {
-    nvte_cublas_gemm_ex(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
-                     workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
-                     compute_streams[i % num_streams], i % num_streams);
+    cublas_gemm_ex(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
+                   workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
+                   compute_streams[i % num_streams], i % num_streams);
   }
 
   // record events on compute streams

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -315,13 +315,11 @@ static void init_streams_and_events() {
 
 }  // namespace transformer_engine
 
-#ifdef __HIP_PLATFORM_AMD__
-// stream_offset = -1 means torch default stream
-void nvte_cublas_gemm_with_stream_offset(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
+void nvte_cublas_gemm_ex(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
                       NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
                       NVTETensor workspace, bool accumulate, bool use_split_accumulator,
-                      int math_sm_count, cudaStream_t stream, int stream_offset) {
-  NVTE_API_CALL(nvte_cublas_gemm_with_stream_offset);
+                      int math_sm_count, cudaStream_t stream, int stream_offset = -1) {
+  NVTE_API_CALL(nvte_cublas_gemm_ex);
 
   using namespace transformer_engine;
   const Tensor *inputA = reinterpret_cast<const Tensor *>(A);
@@ -378,83 +376,34 @@ void nvte_cublas_gemm_with_stream_offset(const NVTETensor A, const NVTETensor B,
         << std::endl;
   }
 
+#ifdef __HIP_PLATFORM_AMD__
   cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
               transa, transb,
               grad,
               wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
               math_sm_count, 0, 0, false, nullptr, stream, stream_offset);
+#else
+  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
+              transa, transb,
+              (transa) ? CUBLAS_OP_T : CUBLAS_OP_N, (transb) ? CUBLAS_OP_T : CUBLAS_OP_N,
+              grad,
+              wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
+              math_sm_count, 0, 0, false, nullptr, stream);
+#endif //__HIP_PLATFORM_AMD__
 }
-#endif // __HIP_PLATFORM_AMD__
 
 void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, const NVTETensor bias,
                       NVTETensor pre_gelu_out, bool transa, bool transb, bool grad,
                       NVTETensor workspace, bool accumulate, bool use_split_accumulator,
                       int math_sm_count, cudaStream_t stream) {
   NVTE_API_CALL(nvte_cublas_gemm);
-  using namespace transformer_engine;
-  const Tensor *inputA = reinterpret_cast<const Tensor *>(A);
-  const Tensor *inputB = reinterpret_cast<const Tensor *>(B);
-  Tensor *outputD = reinterpret_cast<Tensor *>(D);
-  const Tensor *biasTensor = reinterpret_cast<const Tensor *>(bias);
-  Tensor *outputGelu = reinterpret_cast<Tensor *>(pre_gelu_out);
-  Tensor *wspace = reinterpret_cast<Tensor *>(workspace);
-
-  const int m = transa ? inputA->data.shape[0] : inputA->data.shape[1];
-  const int k = transa ? inputA->data.shape[1] : inputA->data.shape[0];
-  const int n = transb ? inputB->data.shape[1] : inputB->data.shape[0];
-  int lda, ldb, ldd;
-  if (transa && !transb) {  // TN
-    lda = k;
-    ldb = k;
-    ldd = m;
-  } else if (!transa && !transb) {  // NN
-    lda = m;
-    ldb = k;
-    ldd = m;
-  } else if (!transa && transb) {  // NT
-    lda = m;
-    ldb = n;
-    ldd = m;
-  } else {  // TT
-    NVTE_ERROR("TT layout not allowed.");
-  }
-
-  bool nvte_log_gemm_config = false;
-  if (const char* env_p = std::getenv("NVTE_LOG_GEMM_CONFIG") ) {
-    if (env_p != nullptr && std::string(env_p) == "1")
-      nvte_log_gemm_config = true;
-  }
-
-  if (nvte_log_gemm_config) {
-    float A_scale_inv, B_scale_inv;
-    (void)cudaMemcpy(&A_scale_inv, inputA->scale_inv.dptr, sizeof(float), cudaMemcpyDeviceToHost);
-    (void)cudaMemcpy(&B_scale_inv, inputB->scale_inv.dptr, sizeof(float), cudaMemcpyDeviceToHost);
-    std::cout << "m=" << m << " k=" << k << " n=" << n 
-        << " transa=" << (transa?"T":"N")
-        << " transb=" << (transb?"T":"N")
-        << " A_type=" << (int)inputA->data.dtype
-        << " B_type=" << (int)inputB->data.dtype
-        << " D_type=" << (int)outputD->data.dtype
-        << " bias_type=" << (int)biasTensor->data.dtype
-        << " grad=" << grad
-        << " bias=" << (biasTensor->data.dptr != nullptr)
-        << " gelu=" << (outputGelu->data.dptr != nullptr)
-        << " use_fp8=" << ( is_fp8_dtype(inputA->data.dtype) || is_fp8_dtype(inputB->data.dtype) )
-        << " A_scale_inverse = " <<  A_scale_inv
-        << " B_scale_inverse = " <<  B_scale_inv
-        << " accumulate=" << accumulate
-        << std::endl;
-  }
-
-  cublas_gemm(inputA, inputB, outputD,  biasTensor, outputGelu, m, n, k, lda, ldb, ldd,
-#ifdef __HIP_PLATFORM_AMD__
-              transa, transb,
-#else
-              (transa) ? CUBLAS_OP_T : CUBLAS_OP_N, (transb) ? CUBLAS_OP_T : CUBLAS_OP_N,
-#endif //__HIP_PLATFORM_AMD__
-              grad,
-              wspace->data.dptr, wspace->data.shape[0], accumulate, use_split_accumulator,
-              math_sm_count, 0, 0, false, nullptr, stream);
+  
+  // stream_offset = -1 means torch default stream
+  nvte_cublas_gemm_ex(A, B, D, bias, pre_gelu_out, 
+                      transa, transb, 
+                      grad, 
+                      workspace, accumulate, use_split_accumulator, 
+                      math_sm_count, stream, -1);
 }
 
 void nvte_cublas_atomic_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D,
@@ -531,15 +480,9 @@ void nvte_multi_stream_cublas_gemm(const NVTETensor *A, const NVTETensor *B, NVT
   }
 
   for (int i = 0; i < num_gemms; i++) {
-#ifdef __HIP_PLATFORM_AMD__
-    nvte_cublas_gemm_with_stream_offset(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
-                                        workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
-                                        compute_streams[i % num_streams], i % num_streams);
-#else
-    nvte_cublas_gemm(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
+    nvte_cublas_gemm_ex(A[i], B[i], D[i], bias[i], pre_gelu_out[i], transa, transb, grad,
                      workspace[i % num_streams], accumulate, use_split_accumulator, math_sm_count,
-                     compute_streams[i % num_streams]);
-#endif // __HIP_PLATFORM_AMD__
+                     compute_streams[i % num_streams], i % num_streams);
   }
 
   // record events on compute streams

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1802,7 +1802,7 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  int ldb, int ldd, bool transa, bool transb, bool grad,
                  void *workspace, size_t workspaceSize, bool accumulate, bool use_split_accumulator,
                  int math_sm_count, int m_split, int n_split, bool gemm_producer,
-                 const Tensor *inputCounter, hipStream_t stream, int stream_offset)
+                 const Tensor *inputCounter, hipStream_t stream, int compute_stream_offset)
 {
 /*If no backend is specified with env variable use HIPBLASLT unless it is disabled
   If HIPBLASLT backend is enabled and requested, use it despite ROCBLAS status
@@ -1836,20 +1836,20 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 #ifdef USE_HIPBLASLT
   if (use_hipblaslt || !use_rocblas)
   {
-    // Check stream_offset valid.
-    NVTE_CHECK(stream_offset >= -1 && stream_offset < num_streams);
+    // Check compute_stream_offset valid.
+    NVTE_CHECK(compute_stream_offset >= -1 && compute_stream_offset < num_streams);
     // Init hipblaslt handles (once, globally)
     std::call_once(init_flag, init_hipblaslt_handles);
 
     hipblaslt_gemm(inputA, inputB, outputD, inputBias, outputPreGelu, 
-                 m, n, k, lda, ldb, ldd, 
-                (transa) ? HIPBLAS_OP_T : HIPBLAS_OP_N,
-                (transb) ? HIPBLAS_OP_T : HIPBLAS_OP_N,
-                 grad,
-                 workspace, workspaceSize, accumulate, use_split_accumulator,
-                 math_sm_count, m_split, n_split, gemm_producer,
-                 inputCounter, stream, 
-                 stream_offset == -1 ? nullptr : hipblaslt_handles[stream_offset]);
+                   m, n, k, lda, ldb, ldd, 
+                   (transa) ? HIPBLAS_OP_T : HIPBLAS_OP_N,
+                   (transb) ? HIPBLAS_OP_T : HIPBLAS_OP_N,
+                   grad,
+                   workspace, workspaceSize, accumulate, use_split_accumulator,
+                   math_sm_count, m_split, n_split, gemm_producer,
+                   inputCounter, stream, 
+                   compute_stream_offset == -1 ? nullptr : hipblaslt_handles[compute_stream_offset]);
     return;
   }
 #endif

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1004,15 +1004,14 @@ static inline int getIntEnv(const char *name, int defval, int minval)
 
 } //namespace
 
-static std::once_flag init_flag;
-static hipblasLtHandle_t hipblaslt_handles[num_streams];
 
 /* Warning: only call once per device!
  * When calling nvte_multi_stream_cublas_gemm with hipblaslt backend
  * need to create multiple handles corresponding to compute_streams
  * to avoid a handle be used by multi-streams concurrently.
  */
-static void init_hipblaslt_handles() {
+static void init_hipblaslt_handles(hipblasLtHandle_t* hipblaslt_handles) {
+  NVTE_CHECK(hipblaslt_handles != nullptr);
   for (int i = 0; i < num_streams; i++) {
     NVTE_CHECK_HIPBLASLT(hipblasLtCreate(&hipblaslt_handles[i]));
   }
@@ -1838,8 +1837,16 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
   {
     // Check compute_stream_offset valid.
     NVTE_CHECK(compute_stream_offset >= -1 && compute_stream_offset < num_streams);
-    // Init hipblaslt handles (once, globally)
-    std::call_once(init_flag, init_hipblaslt_handles);
+
+    hipblasLtHandle_t handle = nullptr;
+    if (compute_stream_offset != -1) {
+      // Init hipblaslt handles (once, globally)
+      static std::once_flag init_flag;
+      static hipblasLtHandle_t hipblaslt_handles[num_streams];
+      std::call_once(init_flag, init_hipblaslt_handles, hipblaslt_handles);
+
+      handle = hipblaslt_handles[compute_stream_offset]; 
+    }
 
     hipblaslt_gemm(inputA, inputB, outputD, inputBias, outputPreGelu, 
                    m, n, k, lda, ldb, ldd, 
@@ -1849,7 +1856,8 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                    workspace, workspaceSize, accumulate, use_split_accumulator,
                    math_sm_count, m_split, n_split, gemm_producer,
                    inputCounter, stream, 
-                   compute_stream_offset == -1 ? nullptr : hipblaslt_handles[compute_stream_offset]);
+                   handle);
+    
     return;
   }
 #endif

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1004,6 +1004,16 @@ static inline int getIntEnv(const char *name, int defval, int minval)
 
 } //namespace
 
+static std::once_flag init_flag;
+static hipblasLtHandle_t hipblaslt_handles[num_streams];
+
+// Warning: only call once per device!
+static void init_hipblaslt_handles() {
+  for (int i = 0; i < num_streams; i++) {
+    NVTE_CHECK_HIPBLASLT(hipblasLtCreate(&hipblaslt_handles[i]));
+  }
+}
+
 void hipblaslt_gemm(const Tensor *inputA,
                  const Tensor *inputB,
                  Tensor *outputD,
@@ -1023,7 +1033,8 @@ void hipblaslt_gemm(const Tensor *inputA,
                  int n_split,
                  bool gemm_producer,
                  const Tensor *inputCounter,
-                 hipStream_t stream
+                 hipStream_t stream,
+                 hipblasLtHandle_t handle
 ) {
   void *A = inputA->data.dptr;
   void *A_scale_inverse = inputA->scale_inv.dptr;
@@ -1059,10 +1070,12 @@ void hipblaslt_gemm(const Tensor *inputA,
   int device_id;
   NVTE_CHECK_CUDA(hipGetDevice(&device_id));
 
-  hipblasLtHandle_t handle = cached_handles.get(device_id);
-  if (handle == nullptr)
-  {
-    handle = cached_handles.obtain(device_id);
+  if (handle == nullptr) {
+    handle = cached_handles.get(device_id);
+    if (handle == nullptr)
+    {
+      handle = cached_handles.obtain(device_id);
+    }
   }
 
   hipblasLtMatmulDesc_t       operationDesc = nullptr;
@@ -1785,13 +1798,12 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  int ldb, int ldd, bool transa, bool transb, bool grad,
                  void *workspace, size_t workspaceSize, bool accumulate, bool use_split_accumulator,
                  int math_sm_count, int m_split, int n_split, bool gemm_producer,
-                 const Tensor *inputCounter, hipStream_t stream)
+                 const Tensor *inputCounter, hipStream_t stream, int stream_offset)
 {
 /*If no backend is specified with env variable use HIPBLASLT unless it is disabled
   If HIPBLASLT backend is enabled and requested, use it despite ROCBLAS status
   Otherwise use ROCBLAS 
 */
-
   bool use_hipblaslt = std::getenv("NVTE_USE_HIPBLASLT") != nullptr;
   bool use_rocblas = std::getenv("NVTE_USE_ROCBLAS") != nullptr;
 
@@ -1820,6 +1832,11 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 #ifdef USE_HIPBLASLT
   if (use_hipblaslt || !use_rocblas)
   {
+    // Init hipblaslt handles (once, globally)
+    std::call_once(init_flag, init_hipblaslt_handles);
+    // Check stream_offset valid.
+    NVTE_CHECK(stream_offset >= -1 && stream_offset < num_streams);
+
     hipblaslt_gemm(inputA, inputB, outputD, inputBias, outputPreGelu, 
                  m, n, k, lda, ldb, ldd, 
                 (transa) ? HIPBLAS_OP_T : HIPBLAS_OP_N,
@@ -1827,7 +1844,8 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                  grad,
                  workspace, workspaceSize, accumulate, use_split_accumulator,
                  math_sm_count, m_split, n_split, gemm_producer,
-                 inputCounter, stream);
+                 inputCounter, stream, 
+                 stream_offset == -1 ? nullptr : hipblaslt_handles[stream_offset]);
     return;
   }
 #endif

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1007,7 +1007,11 @@ static inline int getIntEnv(const char *name, int defval, int minval)
 static std::once_flag init_flag;
 static hipblasLtHandle_t hipblaslt_handles[num_streams];
 
-// Warning: only call once per device!
+/* Warning: only call once per device!
+ * When calling nvte_multi_stream_cublas_gemm with hipblaslt backend
+ * need to create multiple handles corresponding to compute_streams
+ * to avoid a handle be used by multi-streams concurrently.
+ */
 static void init_hipblaslt_handles() {
   for (int i = 0; i < num_streams; i++) {
     NVTE_CHECK_HIPBLASLT(hipblasLtCreate(&hipblaslt_handles[i]));
@@ -1832,10 +1836,10 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 #ifdef USE_HIPBLASLT
   if (use_hipblaslt || !use_rocblas)
   {
-    // Init hipblaslt handles (once, globally)
-    std::call_once(init_flag, init_hipblaslt_handles);
     // Check stream_offset valid.
     NVTE_CHECK(stream_offset >= -1 && stream_offset < num_streams);
+    // Init hipblaslt handles (once, globally)
+    std::call_once(init_flag, init_hipblaslt_handles);
 
     hipblaslt_gemm(inputA, inputB, outputD, inputBias, outputPreGelu, 
                  m, n, k, lda, ldb, ldd, 


### PR DESCRIPTION
# Description

- Fix hipblaslt_gemm handle unsafe usage on multi stream scene.
- Update .gitignore to ignore hip files.
- Update gemm workspace from 32MB to 76MB (which is recommended by hipblaslt team.).

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Fix hipblaslt_gemm handle unsafe usage on multi stream scene.
- Update .gitignore to ignore hip files.
- Update gemm workspace from 32MB to 76MB (which is recommended by hipblaslt team.).

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
