### PR TITLE
[Feat] optim TE_HIPBLASLT_ALGO_LOAD logic

### DIFF
--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1184,11 +1184,8 @@ void hipblaslt_gemm(const Tensor *inputA,
           ws_size_min
         )) {
           cached_algo.algo = algo_arr[0].algo;
-          if (ws_size_min != cached_algo.ws_size_min)
-          {
-            cached_algo.ws_size_min = ws_size_min;
-            algoCache.store(gemm_cfg, cached_algo);
-          }
+          cached_algo.ws_size_min = ws_size_min;
+          algoCache.store(gemm_cfg, cached_algo);
         }
       }
       

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1161,7 +1161,6 @@ void hipblaslt_gemm(const Tensor *inputA,
   {
     bool logTuning = getIntEnv("TE_HIPBLASLT_LOG_TUNING", 0, 0) != 0;
 
-#if HIP_VERSION >= 60000000
     // Find algo base algo_id directly if tuning file is set.
     if (cached_algo.hasId())
     {
@@ -1184,15 +1183,15 @@ void hipblaslt_gemm(const Tensor *inputA,
           ws_size_min
         )) {
           cached_algo.algo = algo_arr[0].algo;
+          cached_algo.ws_size_min = algo_arr[0].workspaceSize;
           algoCache.store(gemm_cfg, cached_algo);
         }
       }
-      
+
       if (logTuning && !cached_algo.algo.has_value()) {
         std::cout << "[WARNING] Cannot get corresponding solution from cached algoId " << cached_algo.algoId << std::endl;
       }
     }
-#endif // #if HIP_VERSION >= 60000000
 
     int firstAlgo = getIntEnv("TE_HIPBLASLT_ALGO_SELECTION", 0, 0);
     int tuneLoopCount = getIntEnv("TE_HIPBLASLT_TUNING_RUN_COUNT", 0, 0);
@@ -1222,35 +1221,6 @@ void hipblaslt_gemm(const Tensor *inputA,
     algoArr.resize(algoTotalCount);
 
     NVTE_CHECK_HIPBLASLT(hipblasLtMatmulPreferenceDestroy(preference));
-
-    //If cached algo exists in persistent storage we just need to find matching hipblasLtMatmulAlgo_t
-    if (cached_algo.hasId() && !cached_algo.algo.has_value())
-    {
-      int idx = (cached_algo.index < algoTotalCount) ? cached_algo.index : 0;
-      for (int i=0; i<algoTotalCount; i++)
-      {
-        const auto &algo = algoArr[idx];
-        if (algo.state == HIPBLAS_STATUS_SUCCESS)
-        {
-          if (cached_algo.algoId == cached_algo.getAlgoId(algo.algo))
-          {
-            cached_algo.algo = algo.algo;
-            if (algo.workspaceSize != cached_algo.ws_size_min || idx != cached_algo.index)
-            {
-              cached_algo.ws_size_min = algo.workspaceSize;
-              cached_algo.index = idx;
-              algoCache.store(gemm_cfg, cached_algo);
-            }
-            break;
-          }
-        }
-        idx = (idx + 1) % algoTotalCount;
-      }
-      if (logTuning && !cached_algo.algo.has_value())
-      {
-        std::cout << "[WARNING] Cannot find cached algoId " << cached_algo.algoId << " in hipBLASLt results" << std::endl;
-      }
-    }
 
     //No suitable entry in autotune cache or could not find matched algo in hipBLASLt results
     if (!cached_algo.algo.has_value())

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1160,7 +1160,8 @@ void hipblaslt_gemm(const Tensor *inputA,
   if (algoCache.find(gemm_cfg, workspaceSize, cached_algo) == 0 || !cached_algo.algo.has_value())
   {
     bool logTuning = getIntEnv("TE_HIPBLASLT_LOG_TUNING", 0, 0) != 0;
-    
+
+#if HIP_VERSION >= 60000000
     // Find algo base algo_id directly if tuning file is set.
     if (cached_algo.hasId())
     {
@@ -1195,6 +1196,7 @@ void hipblaslt_gemm(const Tensor *inputA,
         std::cout << "[WARNING] Cannot get corresponding solution from cached algoId " << cached_algo.algoId << std::endl;
       }
     }
+#endif // #if HIP_VERSION >= 60000000
 
     int firstAlgo = getIntEnv("TE_HIPBLASLT_ALGO_SELECTION", 0, 0);
     int tuneLoopCount = getIntEnv("TE_HIPBLASLT_TUNING_RUN_COUNT", 0, 0);
@@ -1355,10 +1357,11 @@ void hipblaslt_gemm(const Tensor *inputA,
       cached_algo.ws_size_min = algoArr[bestAlgo].workspaceSize;
       cached_algo.ws_size_max = workspaceSize;
 
-      if (logTuning)
-        std::cout << "[INFO] Use hipBLASLt algo [" << bestAlgo << "] " << cached_algo.algoId << std::endl;
-
       algoCache.store(gemm_cfg, cached_algo);
+    }
+
+    if (logTuning) {
+      std::cout << "[INFO] Use hipBLASLt algo [" << cached_algo.index << "] " << cached_algo.algoId << std::endl;
     }
   }
 

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1184,7 +1184,6 @@ void hipblaslt_gemm(const Tensor *inputA,
           ws_size_min
         )) {
           cached_algo.algo = algo_arr[0].algo;
-          cached_algo.ws_size_min = ws_size_min;
           algoCache.store(gemm_cfg, cached_algo);
         }
       }

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1204,8 +1204,8 @@ void hipblaslt_gemm(const Tensor *inputA,
     if (tuneLoopCount)
     {
       /* HIPBLASLT may return hundreds of algos for some configs
-      * Limit amount by default. User may override with env
-      */
+       * Limit amount by default. User may override with env
+       */
       static const int defaultAlgoCount = 16;
       algoTuneCount = getIntEnv("TE_HIPBLASLT_TUNING_ALGO_COUNT", defaultAlgoCount, 1);
     }

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <optional>
 #include <hipblaslt/hipblaslt.h>
+#include <hipblaslt/hipblaslt-ext.hpp>
 #endif
 #ifdef USE_ROCBLAS
 #define ROCBLAS_BETA_FEATURES_API 
@@ -1158,17 +1159,53 @@ void hipblaslt_gemm(const Tensor *inputA,
   GemmAlgoCache::Algo cached_algo;
   if (algoCache.find(gemm_cfg, workspaceSize, cached_algo) == 0 || !cached_algo.algo.has_value())
   {
+    bool logTuning = getIntEnv("TE_HIPBLASLT_LOG_TUNING", 0, 0) != 0;
+    
+    // Find algo base algo_id directly if tuning file is set.
+    if (cached_algo.hasId())
+    {
+      std::vector<hipblasLtMatmulHeuristicResult_t> algo_arr;
+      std::vector<int> algo_index{static_cast<int>(cached_algo.algoId)};
+      
+      if (hipblaslt_ext::getAlgosFromIndex(handle, algo_index, algo_arr) == HIPBLAS_STATUS_SUCCESS &&
+          algo_arr[0].state == HIPBLAS_STATUS_SUCCESS) {
+        size_t ws_size_min = 0;
+        if (HIPBLAS_STATUS_SUCCESS == hipblaslt_ext::matmulIsAlgoSupported(
+          handle,
+          operationDesc, 
+          static_cast<const void*>(&one),
+          Adesc, 
+          Bdesc, 
+          static_cast<const void*>(&beta),
+          Ddesc,
+          Ddesc,
+          algo_arr[0].algo,
+          ws_size_min
+        )) {
+          cached_algo.algo = algo_arr[0].algo;
+          if (ws_size_min != cached_algo.ws_size_min)
+          {
+            cached_algo.ws_size_min = ws_size_min;
+            algoCache.store(gemm_cfg, cached_algo);
+          }
+        }
+      }
+      
+      if (logTuning && !cached_algo.algo.has_value()) {
+        std::cout << "[WARNING] Cannot get corresponding solution from cached algoId " << cached_algo.algoId << std::endl;
+      }
+    }
+
     int firstAlgo = getIntEnv("TE_HIPBLASLT_ALGO_SELECTION", 0, 0);
     int tuneLoopCount = getIntEnv("TE_HIPBLASLT_TUNING_RUN_COUNT", 0, 0);
     int algoTuneCount = 1;
     std::vector<hipblasLtMatmulHeuristicResult_t> algoArr;
-    bool logTuning = getIntEnv("TE_HIPBLASLT_LOG_TUNING", 0, 0) != 0;
 
     if (tuneLoopCount)
     {
       /* HIPBLASLT may return hundreds of algos for some configs
-       * Limit amount by default. User may override with env
-       */
+      * Limit amount by default. User may override with env
+      */
       static const int defaultAlgoCount = 16;
       algoTuneCount = getIntEnv("TE_HIPBLASLT_TUNING_ALGO_COUNT", defaultAlgoCount, 1);
     }
@@ -1189,7 +1226,7 @@ void hipblaslt_gemm(const Tensor *inputA,
     NVTE_CHECK_HIPBLASLT(hipblasLtMatmulPreferenceDestroy(preference));
 
     //If cached algo exists in persistent storage we just need to find matching hipblasLtMatmulAlgo_t
-    if (cached_algo.hasId())
+    if (cached_algo.hasId() && !cached_algo.algo.has_value())
     {
       int idx = (cached_algo.index < algoTotalCount) ? cached_algo.index : 0;
       for (int i=0; i<algoTotalCount; i++)


### PR DESCRIPTION
# Description

We try to use hipblaslt-bench to do tuning offline and we found the best algo id of hipblaslt-bench generally not be included in the return value of `hipblasLtMatmulAlgoGetHeuristic` when algo count is small.  So it cannot apply the best solution on runtime.

Generally we think the best algo id from hipblaslt-bench is better than TE auto tuning because of hipblaslt-bench owns more extensive search scope. 

We hope to apply the best algo id directly on TE to avoid tuning again.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
