### PR TITLE
Workaround test hang with JAX 0.4.35. Add log for test failure

### DIFF
--- a/ci/_utils.sh
+++ b/ci/_utils.sh
@@ -28,6 +28,7 @@ script_error() {
 
 test_run_error() {
     _run_error_count=$((_run_error_count+1))
+    test -n "$@" && echo "Error in test $@" >&2
 }
 
 return_run_results() {

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -26,7 +26,7 @@ fi
 
 echo ===== Run non GEMM tests =====
 ctest --test-dir build -j4 -E "OperatorTest/GEMMTestSuite"
-test $? -eq 0 || test_run_error
+test $? -eq 0 || test_run_error "non-GEMM"
 
 for _gemm in hipblaslt rocblas; do
     configure_gemm_env $_gemm || continue
@@ -36,7 +36,7 @@ for _gemm in hipblaslt rocblas; do
     fi
     echo  ===== Run GEMM $_gemm tests =====
     ctest --test-dir build -j4 -R "OperatorTest/GEMMTestSuite" $_exclude
-    test $? -eq 0 || test_run_error
+    test $? -eq 0 || test_run_error "GEMM $_gemm"
 done
 
 return_run_results

--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -80,19 +80,15 @@ run_test_config_mgpu() {
     case "$_ver" in
     *0.4.35*)
         # Workaround for distributed tests hang with JIT enabled
-        JAX_DISABLE_JIT=1 run 3 test_distributed_fused_attn.py -k 'not test_contex_parallel_allgather_attn[BALANCED'
         _JAX_DISABLE_JIT_FLAG=1
-
-        # Run tests that fail with JIT disabled
-        run 3 test_distributed_fused_attn.py -k 'test_contex_parallel_allgather_attn[BALANCED'
         ;;
     *0.4.31*)
         #Workaround for JAX 0.4.31 regression: crash in test_destributed_fused_attn and test_distributed_layernorm_mlp
         export XLA_FLAGS="--xla_gpu_enable_dot_strength_reduction=false --xla_gpu_enable_command_buffer=CUSTOM_CALL"
-        run 3 test_distributed_fused_attn.py
         ;;
     esac
 
+    JAX_DISABLE_JIT=$_JAX_DISABLE_JIT_FLAG run 3 test_distributed_fused_attn.py
     run_default_fa 3 test_distributed_layernorm.py
     JAX_DISABLE_JIT=$_JAX_DISABLE_JIT_FLAG run_default_fa 3 test_distributed_layernorm_mlp.py
     run_default_fa 3 test_distributed_softmax.py

--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -45,7 +45,7 @@ run() {
     _test_name_tag=`get_test_name_tag $1 $_fus_attn`
     check_test_filter $_test_name_tag || return
     echo "Run [$_fus_attn] $*"
-    pytest -v `get_pytest_junitxml $_test_name_tag` "$TEST_DIR/$@" || test_run_error
+    pytest -v `get_pytest_junitxml $_test_name_tag` "$TEST_DIR/$@" || test_run_error "[$_fus_attn] $1"
     echo "Done [$_fus_attn] $1"
 }
 
@@ -74,12 +74,27 @@ run_test_config() {
 
 run_test_config_mgpu() {
     echo ==== Run mGPU with Fused attention backend: $_fus_attn ====
-    #Workaround for JAX 0.4.31 regression: crash in test_destributed_fused_attn and test_distributed_layernorm_mlp
-    #TODO: remove the flag when switch to a newer JAX that has a fix
-    export XLA_FLAGS="--xla_gpu_enable_dot_strength_reduction=false --xla_gpu_enable_command_buffer=CUSTOM_CALL"
-    run 3 test_distributed_fused_attn.py
+    
+    _JAX_DISABLE_JIT_FLAG=${JAX_DISABLE_JIT:-0}
+    _ver=$(pip show jaxlib | grep Version)
+    case "$_ver" in
+    *0.4.35*)
+        # Workaround for distributed tests hang with JIT enabled
+        JAX_DISABLE_JIT=1 run 3 test_distributed_fused_attn.py -k 'not test_contex_parallel_allgather_attn[BALANCED'
+        _JAX_DISABLE_JIT_FLAG=1
+
+        # Run tests that fail with JIT disabled
+        run 3 test_distributed_fused_attn.py -k 'test_contex_parallel_allgather_attn[BALANCED'
+        ;;
+    *0.4.31*)
+        #Workaround for JAX 0.4.31 regression: crash in test_destributed_fused_attn and test_distributed_layernorm_mlp
+        export XLA_FLAGS="--xla_gpu_enable_dot_strength_reduction=false --xla_gpu_enable_command_buffer=CUSTOM_CALL"
+        run 3 test_distributed_fused_attn.py
+        ;;
+    esac
+
     run_default_fa 3 test_distributed_layernorm.py
-    run_default_fa 3 test_distributed_layernorm_mlp.py
+    JAX_DISABLE_JIT=$_JAX_DISABLE_JIT_FLAG run_default_fa 3 test_distributed_layernorm_mlp.py
     run_default_fa 3 test_distributed_softmax.py
     unset XLA_FLAGS
 }

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -29,7 +29,7 @@ run() {
     echo "Run [$_gemm, $_fus_attn] $@"
     #: ${_WORKERS_COUNT:=1}
     #_args=-n$_WORKERS_COUNT --max-worker-restart=$_WORKERS_COUNT
-    pytest -v `get_pytest_junitxml $_test_name_tag` "$TEST_DIR/$@" || test_run_error
+    pytest -v `get_pytest_junitxml $_test_name_tag` "$TEST_DIR/$@" || test_run_error "[$_gemm, $_fus_attn] $1"
     echo "Done [$_gemm, $_fus_attn] $1"
 }
 


### PR DESCRIPTION
# Description

Disable JAX JIT for tests that hang with it with JAX 0.4.35

CI workaround for [#11602](https://github.com/ROCm/frameworks-internal/issues/11602)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Disable JIT on some test_distributed_fused_attn and test_distributed_layernorm_mlp with JAX 0.4.35
- Add log on test failure that is helpful for log analyzing

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
