### PR TITLE
[Fix] permute fusion number of forward output and backward input is not match

### DIFF
--- a/transformer_engine/pytorch/permutation.py
+++ b/transformer_engine/pytorch/permutation.py
@@ -524,7 +524,7 @@ class _moe_chunk_sort(torch.autograd.Function):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # pylint: disable=missing-function-docstring
         if not inp.numel():
-            return inp, torch.tensor([], device=inp.device)
+            return inp
 
         assert inp.is_cuda, "TransformerEngine needs CUDA."
         assert split_sizes.is_cuda, "TransformerEngine needs CUDA."


### PR DESCRIPTION
# Description

Fix permute fusion number of forward output and backward input is not match when inp.numel() is zero.

This is a nvidia's upstream code bug. And it was fixed on PR https://github.com/NVIDIA/TransformerEngine/pull/1468. But this PR involves a feature which relates to PTX. It can't cherry-pick it directly now.

It will return two tensor when expert of MoE dispatched token is 0 but backward function only accepts one tensor. It will raise a runtime error because the number of parameters and arguments is not matched. 
## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
