### PR TITLE
FP8 OCP support in python code

### DIFF
--- a/ci/core.sh
+++ b/ci/core.sh
@@ -25,7 +25,7 @@ if [ $rc -ne 0 ]; then
 fi
 
 echo ===== Run non GEMM tests =====
-ctest --test-dir build -j4 -E "OperatorTest/GEMMTestSuite"
+ctest --test-dir build -j4 --output-on-failure -E "OperatorTest/GEMMTestSuite"
 test $? -eq 0 || test_run_error "non-GEMM"
 
 for _gemm in hipblaslt rocblas; do
@@ -35,7 +35,7 @@ for _gemm in hipblaslt rocblas; do
         _exclude="-E Test(.*bf16/.*X.X1|.*fp8.*fp16/.*X1X0|.*fp8.*X.X1|.*fp8/|.*bf8/)"
     fi
     echo  ===== Run GEMM $_gemm tests =====
-    ctest --test-dir build -j4 -R "OperatorTest/GEMMTestSuite" $_exclude
+    ctest --test-dir build -j4 --output-on-failure -R "OperatorTest/GEMMTestSuite" $_exclude
     test $? -eq 0 || test_run_error "GEMM $_gemm"
 done
 

--- a/tests/cpp/operator/test_cublaslt_gemm.cu
+++ b/tests/cpp/operator/test_cublaslt_gemm.cu
@@ -142,10 +142,16 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
   (void)cudaGetDeviceProperties(&prop, 0);
 
 #ifdef __HIP_PLATFORM_AMD__
-  if ((isFp8Type(atype) || isFp8Type(btype)) && 
-    !(prop.major == 9 && prop.minor >= 4))
+  if (isFp8Type(atype) || isFp8Type(btype))
   {
-    GTEST_SKIP() << "FP8 is not supported on this HW";
+    bool fp8_supported = (prop.major == 9 && prop.minor >= 4);
+    if (fp8_supported && prop.minor >= 5) {
+      fp8_supported = (std::getenv("NVTE_USE_ROCBLAS") == nullptr) ||
+                      (std::getenv("NVTE_USE_HIPBLASLT") != nullptr);
+    }
+    if (!fp8_supported) {
+      GTEST_SKIP() << "FP8 is not supported in current config";
+    }
   }
 #endif
 

--- a/tests/pytorch/distributed/test_fusible_ops.py
+++ b/tests/pytorch/distributed/test_fusible_ops.py
@@ -23,10 +23,8 @@ from transformer_engine.pytorch.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
 from transformer_engine.pytorch.ops._common import is_float8_tensor
-from transformer_engine.pytorch.utils import is_bf16_compatible
+from transformer_engine.pytorch.utils import is_bf16_compatible, is_fp8_fnuz
 import transformer_engine_torch as tex
-
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 # Check if FP8 is supported
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()
@@ -655,7 +653,7 @@ def _test_fp8_scale_update(
         """Expected absmax and FP8 scale"""
         amax = ref.abs().amax()
         max_val = {
-            "forward": 448.0 if not IS_HIP_EXTENSION else 240.0,
+            "forward": 448.0 if not is_fp8_fnuz() else 240.0,
             "backward": 57344.0,
         }[stage]
         scale = (max_val / amax) / (2**margin)

--- a/tests/pytorch/test_recipe.py
+++ b/tests/pytorch/test_recipe.py
@@ -18,9 +18,8 @@ from transformer_engine.pytorch.fp8 import (
     get_default_fp8_recipe,
 )
 import transformer_engine.pytorch.ops as te_ops
+from transformer_engine.pytorch.utils import is_fp8_fnuz
 import transformer_engine_torch as tex
-
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 # Check if FP8 is supported
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()
@@ -269,7 +268,7 @@ class TestFP8Recipe:
 
                 # Compute scale
                 max_val = {
-                    "forward": 448.0 if not IS_HIP_EXTENSION else 240.0,
+                    "forward": 448.0 if not is_fp8_fnuz() else 240.0,
                     "backward": 57344.0,
                 }[stage]
                 ref_scale = (max_val / ref_amax) / (2**margin)

--- a/tests/pytorch/triton_kernels/test_cast_transpose_triton.py
+++ b/tests/pytorch/triton_kernels/test_cast_transpose_triton.py
@@ -3,10 +3,11 @@
 
 import pytest
 import torch
-import triton
-import triton.language as tl
-from transformer_engine.pytorch.triton_kernels.cast_transpose_triton import te_cast_transpose_noop_triton, te_cast_transpose_dbias_triton, get_te_dtype
-from transformer_engine.pytorch.cpp_extensions import fused_cast_transpose_noop, fused_cast_transpose_bgrad
+from transformer_engine.pytorch.triton_kernels.cast_transpose_triton import (
+    te_cast_transpose_noop_triton, te_cast_transpose_dbias_triton )
+from transformer_engine.pytorch.cpp_extensions import (
+    fused_cast_transpose_noop, fused_cast_transpose_bgrad )
+import transformer_engine_torch as tex
 
 def get_tolerances(in_dtype):
     if in_dtype == torch.float32:
@@ -30,7 +31,7 @@ def get_tolerances(in_dtype):
                           (40960, 128256)
                         ])
 @pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fnuz, torch.float8_e5m2fnuz])
+@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
 def test_cast_tranpose_triton(M, N, in_dtype, out_dtype):
     ## Unit distribution between [-2.0, 1.0]
     input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
@@ -48,8 +49,11 @@ def test_cast_tranpose_triton(M, N, in_dtype, out_dtype):
     amax_tensor_triton = torch.zeros(1, dtype=torch.float32, device='cuda')
     scale_inv_tensor_triton = torch.empty(1, dtype=torch.float32, device='cuda')
 
-    fused_cast_transpose_noop(input_tensor, noop_flag, scale_tensor, amax_tensor, scale_inv_tensor, casted_tensor, transposed_tensor, get_te_dtype(out_dtype), 0, 0, 0)
-    te_cast_transpose_noop_triton(input_tensor, noop_flag, scale_tensor, casted_tensor_triton, transposed_tensor_triton, amax_tensor_triton, scale_inv_tensor_triton, get_te_dtype(out_dtype))
+    fused_cast_transpose_noop(input_tensor, noop_flag, scale_tensor, amax_tensor, scale_inv_tensor,
+                              casted_tensor, transposed_tensor, out_dtype, 0, 0, 0)
+    te_cast_transpose_noop_triton(input_tensor, noop_flag, scale_tensor, casted_tensor_triton,
+                                  transposed_tensor_triton, amax_tensor_triton,
+                                  scale_inv_tensor_triton, out_dtype)
 
     assert torch.equal(casted_tensor, casted_tensor_triton), 'Casted results do not match!'
     assert torch.equal(transposed_tensor, transposed_tensor_triton), 'transposed results do not match!'
@@ -66,7 +70,7 @@ def test_cast_tranpose_triton(M, N, in_dtype, out_dtype):
                           (40960, 128256)
                           ])
 @pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("out_dtype", [torch.float8_e4m3fnuz, torch.float8_e5m2fnuz])
+@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
 def test_cast_tranpose_dbias_triton(M, N, in_dtype, out_dtype):
     ## Unit distribution between [-2.0, 1.0]
     input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
@@ -80,8 +84,10 @@ def test_cast_tranpose_dbias_triton(M, N, in_dtype, out_dtype):
     amax_tensor_triton = torch.zeros(1, dtype=torch.float32, device='cuda')
     scale_inv_tensor_triton = torch.empty(1, dtype=torch.float32, device='cuda')
 
-    dbias_tensor, casted_tensor, transposed_tensor = fused_cast_transpose_bgrad(input_tensor, scale_tensor, amax_tensor, scale_inv_tensor, get_te_dtype(out_dtype), 0, 0, 0)
-    dbias_tensor_triton, casted_tensor_triton, transposed_tensor_triton = te_cast_transpose_dbias_triton(input_tensor, scale_tensor, amax_tensor_triton, scale_inv_tensor_triton, get_te_dtype(out_dtype))
+    dbias_tensor, casted_tensor, transposed_tensor = fused_cast_transpose_bgrad(
+        input_tensor, scale_tensor, amax_tensor, scale_inv_tensor, out_dtype, 0, 0, 0)
+    dbias_tensor_triton, casted_tensor_triton, transposed_tensor_triton = te_cast_transpose_dbias_triton(
+        input_tensor, scale_tensor, amax_tensor_triton, scale_inv_tensor_triton, out_dtype)
 
     assert torch.equal(casted_tensor, casted_tensor_triton), 'Casted results do not match!'
     assert torch.equal(transposed_tensor, transposed_tensor_triton), 'transposed results do not match!'

--- a/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
@@ -17,9 +17,9 @@ def get_te_dtype(dtype):
         return tex.DType.kFloat16
     if dtype == torch.bfloat16:
         return tex.DType.kBFloat16
-    if dtype == torch.float8_e4m3fnuz:
+    if dtype == torch.float8_e4m3fnuz or dtype == torch.float8_e4m3fn:
         return tex.DType.kFloat8E4M3
-    if dtype == torch.float8_e5m2fnuz:
+    if dtype == torch.float8_e5m2fnuz or dtype == torch.float8_e5m2:
         return tex.DType.kFloat8E5M2
 
 def sizeof(in_dtype):
@@ -27,7 +27,8 @@ def sizeof(in_dtype):
         return 4
     elif in_dtype == torch.float16 or in_dtype == torch.bfloat16:
         return 2
-    elif in_dtype == torch.float8_e4m3fnuz or in_dtype == float8_e5m2fnuz:
+    elif (in_dtype == torch.float8_e4m3fnuz or in_dtype == torch.float8_e5m2fnuz
+          or in_dtype == torch.float8_e4m3fn or in_dtype == torch.float8_e5m2):
         return 1
     return 1
 
@@ -38,7 +39,9 @@ def get_tolerances(in_dtype):
         return 1e-5, 1e-3
     elif in_dtype == torch.bfloat16:
         return 1e-5, 1e-2
-    elif in_dtype == torch.float8_e4m3fnuz or in_dtype == torch.float8_e5m2fnuz:
+    elif (in_dtype == torch.float8_e4m3fnuz or in_dtype == torch.float8_e5m2fnuz
+          or in_dtype == torch.float8_e4m3fn or in_dtype == torch.float8_e5m2):
+        #TODO: different tolerances for FNUZ and OCP
         return 1e-2, 1e-2
     else:
         raise RuntimeError("Invalid type")

--- a/tests/pytorch/utils.py
+++ b/tests/pytorch/utils.py
@@ -8,17 +8,9 @@ from __future__ import annotations
 
 import torch
 
-import transformer_engine
 import transformer_engine.pytorch as te
+from transformer_engine.pytorch.fp8 import torch_float8_e4m3_type, torch_float8_e5m2_type
 import transformer_engine_torch as tex
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
-
-if not IS_HIP_EXTENSION:
-    torch_float8_e4m3_type = torch.float8_e4m3fn
-    torch_float8_e5m2_type = torch.float8_e5m2
-else:
-    torch_float8_e4m3_type = torch.float8_e4m3fnuz
-    torch_float8_e5m2_type = torch.float8_e5m2fnuz
 
 def str_to_dtype(dtype: str | torch.dtype) -> torch.dtype:
     """Convert type name to PyTorch dtype"""

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -118,6 +118,7 @@ def _load_nvrtc():
     return ctypes.CDLL(f"libnvrtc.{_get_sys_extension()}", mode=ctypes.RTLD_GLOBAL)
 
 te_rocm_build = False
+te_uses_fp8_fnuz = False
 
 if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
     try:
@@ -131,3 +132,5 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
     except AttributeError:
         # If the function is not available, we assume it's not a ROCm build
         te_rocm_build = False
+    if te_rocm_build:
+        te_uses_fp8_fnuz = _TE_LIB_CTYPES.nvte_uses_fp8_fnuz()

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -117,6 +117,7 @@ def _load_nvrtc():
     # If all else fails, assume that it is in LD_LIBRARY_PATH and error out otherwise
     return ctypes.CDLL(f"libnvrtc.{_get_sys_extension()}", mode=ctypes.RTLD_GLOBAL)
 
+te_rocm_build = False
 
 if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
     try:
@@ -125,3 +126,8 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
     except OSError:
         pass
     _TE_LIB_CTYPES = _load_library()
+    try:
+        te_rocm_build = _TE_LIB_CTYPES.nvte_is_rocm_build()
+    except AttributeError:
+        # If the function is not available, we assume it's not a ROCm build
+        te_rocm_build = False

--- a/transformer_engine/common/amd_detail/hip_float8.h
+++ b/transformer_engine/common/amd_detail/hip_float8.h
@@ -8,6 +8,7 @@
 #ifdef __HIPCC__
 
 #include <hip/hip_runtime.h>
+#include <hip/hip_version.h> //For RTC it should be included explicitly
 
 #if HIP_VERSION >= 60200000
 #include <hip/hip_fp8.h>

--- a/transformer_engine/common/ck_fused_attn/CMakeLists.txt
+++ b/transformer_engine/common/ck_fused_attn/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 project(ck_fused_attn LANGUAGES HIP CXX)
 # generate ck fused attn kernels, both fwd/bwd
 
-set(CK_FUSED_ATTN_TARGET_GPUS "gfx942" CACHE STRING "Target Architecture to build ck_fused_attn backend")
+set(CK_FUSED_ATTN_TARGET_GPUS "gfx942,gfx950" CACHE STRING "Target Architecture to build ck_fused_attn backend")
 
 # remove files that should be regenerated
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/gen_src/tmp ${CMAKE_CURRENT_BINARY_DIR}/gen_src/blob_list.txt)

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.cpp
@@ -114,7 +114,6 @@ bool is_aotriton_backend_supported(
 
   return true;
 #else
-  NVTE_ERROR("AOTriton backend not compiled.");
   return false;
 #endif // USE_FUSED_ATTN_AOTRITON
 }

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -82,10 +82,10 @@ bool is_ck_backend_supported(
 
   const int device_id = cuda::current_device();
   const int gpu_arch = cuda::sm_arch(device_id);
-  //only gfx942 and gfx950 supported
+  //only gfx94x and gfx95x supported
   if(gpu_arch != 94 && gpu_arch != 95){
     if(nvte_log_ck_config){
-      std::cout<<"only GFX 9.4 and 9.5 are supported"<<std::endl;
+      std::cout<<"Only gfx94x and gfx95x are supported"<<std::endl;
     }
     return false;
   }

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -81,11 +81,11 @@ bool is_ck_backend_supported(
   }
 
   const int device_id = cuda::current_device();
-  const std::string sm_arch_name_ = cuda::sm_arch_name(device_id);
-  //only gfx942 supported
-  if(!(sm_arch_name_.find("gfx942")!=std::string::npos)){
+  const int gpu_arch = cuda::sm_arch(device_id);
+  //only gfx942 and gfx950 supported
+  if(gpu_arch != 94 && gpu_arch != 95){
     if(nvte_log_ck_config){
-      std::cout<<"only gfx942 is supported"<<std::endl;
+      std::cout<<"only GFX 9.4 and 9.5 are supported"<<std::endl;
     }
     return false;
   }
@@ -159,7 +159,6 @@ bool is_ck_backend_supported(
   }
   return true;
 #else
-  NVTE_ERROR("CK fused attn backend not compiled.");
   return false;
 #endif // USE_FUSED_ATTN_CK
 }

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Optional, Union, Callable, NamedTuple
 from typing_extensions import Literal
 from pydantic.dataclasses import dataclass
-from transformer_engine.common import te_rocm_build
+from transformer_engine.common import te_uses_fp8_fnuz
 
 
 class _FormatHelper(NamedTuple):
@@ -38,7 +38,7 @@ class Format(Enum):
             FP8 tensors in the forward pass are in e4m3 format,
             FP8 tensors in the backward pass are in e5m2 format
     """
-    E4M3 = (_FormatHelper(max_fwd=240, max_bwd=240) if te_rocm_build
+    E4M3 = (_FormatHelper(max_fwd=240, max_bwd=240) if te_uses_fp8_fnuz
             else _FormatHelper(max_fwd=448, max_bwd=448))
     E5M2 = _FormatHelper(max_fwd=57344, max_bwd=57344)
     HYBRID = _FormatHelper(max_fwd=E4M3.max_fwd, max_bwd=E5M2.max_bwd)

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Optional, Union, Callable, NamedTuple
 from typing_extensions import Literal
 from pydantic.dataclasses import dataclass
+from transformer_engine.common import te_rocm_build
 
 
 class _FormatHelper(NamedTuple):
@@ -37,8 +38,8 @@ class Format(Enum):
             FP8 tensors in the forward pass are in e4m3 format,
             FP8 tensors in the backward pass are in e5m2 format
     """
-    #TODO: check NV H100 or AMD MI300 first 
-    E4M3 = _FormatHelper(max_fwd=240, max_bwd=240)
+    E4M3 = (_FormatHelper(max_fwd=240, max_bwd=240) if te_rocm_build
+            else _FormatHelper(max_fwd=448, max_bwd=448))
     E5M2 = _FormatHelper(max_fwd=57344, max_bwd=57344)
     HYBRID = _FormatHelper(max_fwd=E4M3.max_fwd, max_bwd=E5M2.max_bwd)
 

--- a/transformer_engine/common/recipe/delayed_scaling.cu
+++ b/transformer_engine/common/recipe/delayed_scaling.cu
@@ -37,7 +37,7 @@ inline float fp8_dtype_max(DType dtype) {
 #ifndef __HIP_PLATFORM_AMD__
       return 448;
 #else
-      return 240;
+      return te_fp8_fnuz() ? 240 : 448;
 #endif
     case DType::kFloat8E5M2:
       return 57344;

--- a/transformer_engine/common/util/system.cpp
+++ b/transformer_engine/common/util/system.cpp
@@ -84,3 +84,13 @@ extern "C" bool nvte_is_rocm_build() {
   return false;
 #endif
 }
+
+#ifdef USE_ROCM
+extern "C" bool nvte_uses_fp8_fnuz() 
+{
+#if HIP_VERSION >= 60300000
+  return te_fp8_fnuz();
+#endif
+  return true; // default to true for older versions that only support
+}
+#endif

--- a/transformer_engine/common/util/system.cpp
+++ b/transformer_engine/common/util/system.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.
@@ -74,3 +76,11 @@ NVTE_INSTANTIATE_GETENV(std::filesystem::path, std::filesystem::path());
 bool file_exists(const std::string &path) { return static_cast<bool>(std::ifstream(path.c_str())); }
 
 }  // namespace transformer_engine
+
+extern "C" bool nvte_is_rocm_build() {
+#ifdef USE_ROCM
+  return true;
+#else
+  return false;
+#endif
+}

--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -21,8 +21,9 @@ from jax.interpreters.mlir import dtype_to_ir_type
 from transformer_engine.transformer_engine_jax import DType as TEDType
 from transformer_engine import transformer_engine_jax
 
+from ..fp8 import jnp_float8_e4m3_type, jnp_float8_e5m2_type
 from ..sharding import get_padded_spec as te_get_padded_spec
-from ..util import is_hip_extension, jnp_float8_e4m3_type, jnp_float8_e5m2_type
+from ..util import is_hip_extension
 
 
 def te_dtype_to_jax_dtype(te_dtype):

--- a/transformer_engine/jax/csrc/extensions/ffi.cpp
+++ b/transformer_engine/jax/csrc/extensions/ffi.cpp
@@ -33,16 +33,14 @@ DType convert_ffi_datatype_to_te_dtype(const xla::ffi::DataType &type) {
     case xla::ffi::DataType::BF16:
       return DType::kBFloat16;
       break;
-#ifndef USE_ROCM
     case xla::ffi::DataType::F8E5M2:
-#else
+#ifdef USE_ROCM
     case xla::ffi::DataType::F8E5M2FNUZ:
 #endif
       return DType::kFloat8E5M2;
       break;
-#ifndef USE_ROCM
     case xla::ffi::DataType::F8E4M3FN:
-#else
+#ifdef USE_ROCM
     case xla::ffi::DataType::F8E4M3FNUZ:
 #endif
       return DType::kFloat8E4M3;

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -44,7 +44,7 @@ def _check_fp8_support(gpu_id) -> Tuple[bool, str]:
         if gpu_arch in [94, 95]:
             return True, ""
         else:
-            return False, "GFX 9.4 or 9.5 required for FP8 execution."
+            return False, "Device arch gfx94x or gfx95x required for FP8 execution."
     if gpu_arch >= 90:  # hopper and above
         return True, ""
     if gpu_arch < 89:  # pre-ada

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -16,7 +16,7 @@ import jax.numpy as jnp
 from flax.core.frozen_dict import FrozenDict
 from flax.linen import fp8_ops
 
-from .util import is_hip_extension, jnp_float8_e4m3_type, jnp_float8_e5m2_type
+from .util import is_hip_extension, is_fp8_fnuz
 
 from transformer_engine.transformer_engine_jax import DType
 
@@ -34,15 +34,17 @@ _is_fp8_available = None
 _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]
 
+jnp_float8_e4m3_type = jnp.float8_e4m3fnuz if is_fp8_fnuz() else jnp.float8_e4m3fn
+jnp_float8_e5m2_type = jnp.float8_e5m2fnuz if is_fp8_fnuz() else jnp.float8_e5m2
 
 def _check_fp8_support(gpu_id) -> Tuple[bool, str]:
     """Return if fp8 support is available"""
+    gpu_arch = get_device_compute_capability(gpu_id)
     if is_hip_extension():
-        if get_device_compute_capability(gpu_id) == 94:
+        if gpu_arch == 94 or gpu_arch == 95:
             return True, ""
         else:
-            return False, "Only MI300 machines support fp8"
-    gpu_arch = get_device_compute_capability(gpu_id)
+            return False, "GFX 9.4 or 9.5 required for FP8 execution."
     if gpu_arch >= 90:  # hopper and above
         return True, ""
     if gpu_arch < 89:  # pre-ada

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -41,7 +41,7 @@ def _check_fp8_support(gpu_id) -> Tuple[bool, str]:
     """Return if fp8 support is available"""
     gpu_arch = get_device_compute_capability(gpu_id)
     if is_hip_extension():
-        if gpu_arch == 94 or gpu_arch == 95:
+        if gpu_arch in [94, 95]:
             return True, ""
         else:
             return False, "GFX 9.4 or 9.5 required for FP8 execution."

--- a/transformer_engine/jax/util.py
+++ b/transformer_engine/jax/util.py
@@ -2,8 +2,9 @@
 # License for AMD contributions = MIT. See LICENSE for more information
 from functools import cache
 import importlib.metadata
-import jax, jax.numpy as jnp
+import jax
 import re
+from transformer_engine.transformer_engine_jax import get_device_compute_capability
 
 # check whether ROCm is supported by JAX
 @cache
@@ -18,17 +19,13 @@ def is_hip_extension() -> bool:
     pass
   return False
 
-
-if not is_hip_extension():
-  jnp_float8_e4m3_type = jnp.float8_e4m3fn
-  jnp_float8_e5m2_type = jnp.float8_e5m2
-else:
-  jnp_float8_e4m3_type = jnp.float8_e4m3fnuz
-  jnp_float8_e5m2_type = jnp.float8_e5m2fnuz
-
 if is_hip_extension():
+  @cache
   def is_mi200():
       """check whether this machine is mi200/210/250"""
       import re
       return (re.search('AMD Instinct MI2.0', jax.devices()[0].device_kind) is not None)
   
+@cache
+def is_fp8_fnuz():
+  return is_hip_extension() and get_device_compute_capability(0) == 94

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -11,19 +11,23 @@ from collections import deque
 from typing import Callable, List, Optional, Dict, Any, Tuple, Union
 
 import torch
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 import transformer_engine_torch as tex
 from transformer_engine.common.recipe import DelayedScaling, Format
 
 from .constants import dist_group_type
-from .utils import get_device_compute_capability
+from .utils import get_device_compute_capability, is_fp8_fnuz
 from .jit import jit_fuser
 
 
-__all__ = ["fp8_autocast", "fp8_model_init"]
+__all__ = ["fp8_autocast", "fp8_model_init", "torch_float8_e4m3_type", "torch_float8_e5m2_type"]
+
+
+torch_float8_e4m3_type = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+torch_float8_e5m2_type = torch.float8_e5m2fnuz if is_fp8_fnuz() else torch.float8_e5m2
 
 
 def check_fp8_support() -> Tuple[bool, str]:
-    from torch.utils.cpp_extension import IS_HIP_EXTENSION
     if IS_HIP_EXTENSION:
         if get_device_compute_capability() == (9, 4):
             return True, ""
@@ -51,8 +55,8 @@ def get_fp8_torch_dtype(fp8_recipe: DelayedScaling, fprop_tensor: bool = True) -
     if fp8_recipe.fp8_format == Format.E4M3 or (
         fp8_recipe.fp8_format == Format.HYBRID and fprop_tensor
     ):
-        return torch.float8_e4m3fn
-    return torch.float8_e5m2fn
+        return torch_float8_e4m3_type
+    return torch_float8_e5m2_type
 
 
 def get_fp8_te_dtype(fp8_recipe: DelayedScaling, fprop_tensor: bool = True) -> tex.DType:

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -30,10 +30,16 @@ torch_float8_e5m2_type = torch.float8_e5m2fnuz if is_fp8_fnuz() else torch.float
 def check_fp8_support() -> Tuple[bool, str]:
     if IS_HIP_EXTENSION:
         gpu_arch = get_device_compute_capability()
-        if gpu_arch == (9, 4) or gpu_arch == (9, 5):
+        if gpu_arch == (9, 4):
             return True, ""
+        elif gpu_arch == (9, 5):
+            if (os.getenv("NVTE_USE_HIPBLASLT") is not None
+                or os.getenv("NVTE_USE_ROCBLAS") is None):
+                return True, ""
+            else:
+                return False, "Using HipBlasLt is required on gfx95x for FP8 execution."
         else:
-            return False, "GFX 9.4 or 9.5 required for FP8 execution."
+            return False, "Device arch gfx94x or gfx95x required for FP8 execution."
     else:
         """Return if fp8 support is available"""
         if get_device_compute_capability() >= (9, 0):  # hopper and above

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -29,10 +29,11 @@ torch_float8_e5m2_type = torch.float8_e5m2fnuz if is_fp8_fnuz() else torch.float
 
 def check_fp8_support() -> Tuple[bool, str]:
     if IS_HIP_EXTENSION:
-        if get_device_compute_capability() == (9, 4):
+        gpu_arch = get_device_compute_capability()
+        if gpu_arch == (9, 4) or gpu_arch == (9, 5):
             return True, ""
         else:
-            return False, "Only MI300 machines support fp8"
+            return False, "GFX 9.4 or 9.5 required for FP8 execution."
     else:
         """Return if fp8 support is available"""
         if get_device_compute_capability() >= (9, 0):  # hopper and above

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -41,6 +41,7 @@ from ..cpp_extensions import (
 )
 from ..constants import dist_group_type
 from ..float8_tensor import Float8Tensor
+from ..utils import get_device_compute_capability
 
 __all__ = ["initialize_ub", "destroy_ub"]
 
@@ -55,9 +56,13 @@ layers_atomic_ring_exchange = []
 
 
 def get_cublas_workspace_size_bytes() -> None:
-    """Return 76 MiB for AMD GPU, 32 MiB if using hopper, 4 MiB for all other architectures."""
+    """Return workspace size needed for current architecture"""
     if IS_HIP_EXTENSION:
-        return 79_691_776
+        """Return 64 MiB for gfx50x, 32 MiB for all other architectures."""
+        if get_device_compute_capability() == (9, 5):
+            return 67_108_864
+        return 33_554_432        
+    """Return 32 MiB if using hopper, 4 MiB for all other architectures."""
     if torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 9:
         return 33_554_432
     return 4_194_304

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -16,6 +18,7 @@ from contextlib import contextmanager
 
 import torch
 import torch.nn.functional as F
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import transformer_engine_torch as tex
 from ._common import _ParameterInitMeta
@@ -52,7 +55,9 @@ layers_atomic_ring_exchange = []
 
 
 def get_cublas_workspace_size_bytes() -> None:
-    """Return 32 MiB if using hopper, 4 MiB for all other architectures."""
+    """Return 76 MiB for AMD GPU, 32 MiB if using hopper, 4 MiB for all other architectures."""
+    if IS_HIP_EXTENSION:
+        return 79_691_776
     if torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 9:
         return 33_554_432
     return 4_194_304

--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -12,9 +12,9 @@ import torch
 import transformer_engine_torch as tex
 from transformer_engine.pytorch.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
+from transformer_engine.pytorch.utils import is_fp8_fnuz
 from .multi_tensor_apply import multi_tensor_applier
 from ..float8_tensor import Float8Tensor
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 
 def get_fp8_meta(fp8_tensor):
@@ -202,7 +202,7 @@ class FusedAdam(torch.optim.Optimizer):
             torch.float16: torch.full(
                 [1], torch.finfo(torch.float16).max / 2.0, dtype=torch.float32
             ),
-            torch.uint8: torch.full([1], 240.0 if IS_HIP_EXTENSION else 448.0, dtype=torch.float32),
+            torch.uint8: torch.full([1], 240.0 if is_fp8_fnuz() else 448.0, dtype=torch.float32),
         }
         self._scales = {}
         self.use_decoupled_grad = use_decoupled_grad

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -12,11 +12,12 @@ import torch
 import triton
 import triton.language as tl
 
+from transformer_engine.pytorch.utils import is_fp8_fnuz
 from transformer_engine_torch import DType as TE_DType
 
 from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
-if IS_HIP_EXTENSION:
+if is_fp8_fnuz():
     e5m2_data_type = tl.float8e5b16
     e4m3_data_type = tl.float8e4b8
 else:

--- a/transformer_engine/pytorch/triton_kernels/cast_transpose_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/cast_transpose_triton.py
@@ -6,25 +6,26 @@ import torch
 import transformer_engine_torch as tex
 import triton
 import triton.language as tl
+from ..utils import is_fp8_fnuz
 
 def is_fp8_dtype(dtype):
     return dtype in (tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2)
 
 def get_triton_dtype(dtype: tex.DType):
     if dtype == tex.DType.kFloat8E4M3:
-        return tl.float8e4b8
+        return tl.float8e4b8 if is_fp8_fnuz() else tl.float8e4nv
     if dtype == tex.DType.kFloat8E5M2:
-        return tl.float8e5b16
+        return tl.float8e5b16 if is_fp8_fnuz() else tl.float8e5
 
 def get_te_dtype(dtype):
-    if dtype == torch.float8_e4m3fnuz:
+    if dtype == torch.float8_e4m3fnuz or dtype == torch.float8_e4m3fn:
         return tex.DType.kFloat8E4M3
-    if dtype == torch.float8_e5m2fnuz:
+    if dtype == torch.float8_e5m2fnuz or dtype == torch.float8_e5m2:
         return tex.DType.kFloat8E5M2
 
 def get_fp8_max(dtype: tex.DType):
     if dtype == tex.DType.kFloat8E4M3:
-        return 240.0
+        return 240.0 if is_fp8_fnuz() else 448.0
     if dtype == tex.DType.kFloat8E5M2:
         return 57344.0
 

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -254,6 +254,10 @@ if IS_HIP_EXTENSION:
       import re
       return (re.search('AMD Instinct MI308', torch.cuda.get_device_name(torch.cuda.current_device())) is not None)
 
+@functools.lru_cache(maxsize=None)
+def is_fp8_fnuz():
+    return IS_HIP_EXTENSION and get_device_compute_capability() == (9, 4)
+
 def is_bf16_compatible() -> None:
     if IS_HIP_EXTENSION:
         # only MI200 and MI300 machines support bf16

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -244,11 +244,13 @@ def assert_dim_for_fp8_exec(tensor: torch.Tensor) -> None:
     )
 
 if IS_HIP_EXTENSION:
+    @functools.lru_cache(maxsize=None)
     def is_mi200():
       """check whether this machine is mi200/210/250"""
       import re
       return (re.search('AMD Instinct MI2.0', torch.cuda.get_device_name(torch.cuda.current_device())) is not None)
     
+    @functools.lru_cache(maxsize=None)
     def is_mi308():
       """check whether this machine is mi308"""
       import re
@@ -260,8 +262,8 @@ def is_fp8_fnuz():
 
 def is_bf16_compatible() -> None:
     if IS_HIP_EXTENSION:
-        # only MI200 and MI300 machines support bf16
-        if get_device_compute_capability() == (9, 4) or is_mi200():
+        # only MI200 and newer machines support bf16
+        if get_device_compute_capability() in [(9, 4), (9, 5)] or is_mi200():
             return True
         else:
             return False


### PR DESCRIPTION
# Description

Add FP8 OCP/FNUZ selection and enable GFX 9.5

Fixes: [TE] general fp8 support exploration [#11197](https://github.com/ROCm/frameworks-internal/issues/11197)
WIP: [TE] OCP fp8 bring-up on MI350 [#11918](https://github.com/ROCm/frameworks-internal/issues/11918)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Modify TE python code to use FP8 FNUZ for GFX 9.4 only
- Enable GFX 9.5 for CK and pytorch, jax integration

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
