### PR TITLE
transpose cache on/off switch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,7 +279,9 @@ At runtime, you can enable specific triton kernels using the specific environmen
 Transpose Cache
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In fine tuning workloads like LORA where W is frozen and only the adapter weights are trainable,  $dl/dx = W^T (dl/dy) + B^T(A^T dl/dy)$. Since W is frozen we can cache W^T at the 
-expense of using more memory. A and B are lora matrices. This feature is enabled by default. To turn it of set `export ENABLE_TRANPOSE_CACHE=False`.
+expense of using more memory. A and B are lora matrices.The cache is enabled by default. To turn it off use 
+
+- `export ENABLE_TRANPOSE_CACHE=False`.
 
 Transformer Engine
 ******************

--- a/README.rst
+++ b/README.rst
@@ -276,6 +276,11 @@ At runtime, you can enable specific triton kernels using the specific environmen
 * NVTE_USE_RMSNORM_TRITON=1 can be used to enable rmsnorm triton kernels.
 
 
+Transpose Cache
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In fine tuning workloads like LORA where W is frozen and only the adapter weights are trainable,  $dl/dx = W^T (dl/dy) + B^T(A^T dl/dy)$. Since W is frozen we can cache W^T at the 
+expense of using more memory. A and B are lora matrices. This feature is enabled by default. To turn it of set `export ENABLE_TRANPOSE_CACHE=False`.
+
 Transformer Engine
 ******************
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -991,7 +991,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                     fp8_meta=self.fp8_meta,
                     fp8_meta_index=fp8_meta_index,
                     amax=dummy_amax,
-                    with_transpose_cache=torch.is_grad_enabled(),
+                    with_transpose_cache=torch.is_grad_enabled() and os.getenv("ENABLE_TRANSPOSE_CACHE", True),
                 )
 
             # Redo parameter wrap in case we broke it above


### PR DESCRIPTION
# Transpose Cache ON/OFF SWITCH

In fine tuning workloads like LORA where W is frozen and only the adapter weights are trainable,  $dl/dx = W^T (dl/dy) + B^T(A^T dl/dy)$. Since W is frozen we can cache W^T at the 
expense of using more memory. A and B are lora matrices. This feature is enabled by default. To turn it off set 

- `export ENABLE_TRANPOSE_CACHE=False`, defaults to True

Setting the default to True ensures that we don't change the current behavior. 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
