### PR TITLE
[ROCm] integrate layernorm Triton kernels 

### DIFF
--- a/tests/pytorch/triton_kernels/test_common_triton.py
+++ b/tests/pytorch/triton_kernels/test_common_triton.py
@@ -10,6 +10,11 @@ import torch
 
 from transformer_engine.pytorch import cpp_extensions as tex
 
+from transformer_engine.pytorch.triton_kernels.norm_common_triton import (
+    e4m3_type,
+    e5m2_type,
+)
+
 
 # Mimics behavior of `fillUniform` from `tests/cpp/test_common.cu`.
 
@@ -33,12 +38,7 @@ def get_tolerances(dtype):
         return 1e-5, 1e-3
     elif dtype == torch.bfloat16:
         return 1e-5, 1e-2
-    elif (
-        dtype == torch.float8_e4m3fnuz
-        or dtype == torch.float8_e5m2fnuz
-        or dtype == torch.float8_e4m3fn
-        or dtype == torch.float8_e5m2
-    ):
+    elif dtype == e4m3_type or dtype == e5m2_type:
         # TODO: different tolerances for FNUZ and OCP
         return 1e-2, 1e-2
     else:
@@ -49,6 +49,7 @@ def get_tolerances(dtype):
 # Arguments:
 #     t: actual tensor
 #     r: expected tensor
+# NOTE: DO NOT upcast inputs to fp32 if you are using te_compare for any precision other than fp32
 def te_compare_results(t, r, atol, rtol, msg):
     assert t.dtype == r.dtype, f"Tensor dtypes don't match: {t.dtype} vs {r.dtype}."
     assert t.shape == r.shape, f"Tensor shapes don't match: {t.shape} vs {r.shape}."
@@ -137,9 +138,13 @@ def output_dtypes_str(dtypes_str):
 
 # Convert descriptive type string to PyTorch type.
 def str_to_torch_dtype(dtype_str):
-    return {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}[
-        dtype_str[1:] if dtype_str[0] in {"i", "o"} else dtype_str
-    ]
+    return {
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+        "fp32": torch.float32,
+        "fp8e4": e4m3_type,
+        "fp8e5": e5m2_type,
+    }[dtype_str[1:] if dtype_str[0] in {"i", "o"} else dtype_str]
 
 
 # Common pytest skip conditions:

--- a/tests/pytorch/triton_kernels/test_common_triton.py
+++ b/tests/pytorch/triton_kernels/test_common_triton.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from transformer_engine.pytorch import cpp_extensions as tex
+
+
+# Mimics behavior of `fillUniform` from `tests/cpp/test_common.cu`.
+
+rng_seed = 12345
+rng = np.random.default_rng(np.random.MT19937(rng_seed))
+
+
+def fill_uniform(shape, dtype):
+    x = rng.uniform(-2.0, 1.0, shape)
+    x = x.astype(np.float32)
+    x = torch.tensor(x, device="cuda")
+    x = x.to(dtype)
+    return x
+
+
+# Mimics behavior of `getTolerances` from `tests/cpp/test_common.cu`.
+def get_tolerances(dtype):
+    if dtype == torch.float32:
+        return 1e-6, 5e-6
+    elif dtype == torch.float16:
+        return 1e-5, 1e-3
+    elif dtype == torch.bfloat16:
+        return 1e-5, 1e-2
+    elif (
+        dtype == torch.float8_e4m3fnuz
+        or dtype == torch.float8_e5m2fnuz
+        or dtype == torch.float8_e4m3fn
+        or dtype == torch.float8_e5m2
+    ):
+        # TODO: different tolerances for FNUZ and OCP
+        return 1e-2, 1e-2
+    else:
+        raise RuntimeError("Invalid type")
+
+
+# PyTorch implementation of `compareResults` C++ function from `tests/cpp/test_common.cu`.
+# Arguments:
+#     t: actual tensor
+#     r: expected tensor
+def te_compare_results(t, r, atol, rtol, msg):
+    assert t.dtype == r.dtype, f"Tensor dtypes don't match: {t.dtype} vs {r.dtype}."
+    assert t.shape == r.shape, f"Tensor shapes don't match: {t.shape} vs {r.shape}."
+    assert atol > 0, "Absolute tolerance must be positive."
+    assert rtol > 0, "Relative tolerance must be positive."
+    dtype = t.dtype
+    t = t.cpu().to(torch.float32).to(torch.float64)
+    r = r.cpu().to(torch.float32).to(torch.float64)
+    diff = t - r
+    atol_mismatch = torch.abs(diff) > atol
+    nonzero_r = r != 0
+    rtol_mismatch = torch.full_like(atol_mismatch, False)
+    rtol_mismatch[nonzero_r] = torch.abs(diff[nonzero_r] / r[nonzero_r]) > rtol
+    mismatch = atol_mismatch & (~nonzero_r | rtol_mismatch)
+    has_mismatch = torch.any(mismatch).item()
+    # for fp32 the floating point comparison is enough to error out
+    if has_mismatch and dtype != torch.float32:
+        # check if it is just a failure of round to nearest choosing different side of the real value
+        # for non fp32 types
+        mean = (t + r) / 2
+        eps = 1e-6
+        mean_one_plus_eps = mean * (1 + eps)
+        mean_one_minus_eps = mean * (1 - eps)
+        mean_gte_zero = mean >= 0
+        mean_p = torch.where(mean_gte_zero, mean_one_plus_eps, mean_one_minus_eps)
+        mean_m = torch.where(mean_gte_zero, mean_one_minus_eps, mean_one_plus_eps)
+        cast_mean_p = (
+            mean_p.to(torch.float32).to(dtype).to(torch.float32).to(torch.float64)
+        )
+        cast_mean_m = (
+            mean_m.to(torch.float32).to(dtype).to(torch.float32).to(torch.float64)
+        )
+        min_tr = torch.minimum(t, r)
+        max_tr = torch.maximum(t, r)
+        round_check = ~((cast_mean_m == min_tr) & (cast_mean_p == max_tr))
+        mismatch = mismatch & round_check
+        has_mismatch = torch.any(mismatch).item()
+    if has_mismatch:
+        # TODO: Improve base message, add max absolute and relative differences.
+        base_msg = "There are tensor mismatches."
+        if isinstance(msg, str):
+            msg = f"{msg}\n\n{base_msg}\n"
+        elif isinstance(msg, types.LambdaType):
+            msg = msg(base_msg)
+        else:
+            msg = base_msg
+        assert False, msg
+
+
+# Call PyTorch tensor comparison function or TE tensor comparison function.
+def compare_results(provider, actual, expected, atol, rtol, msg):
+    assert provider in {"torch", "te"}
+    if provider == "torch":
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol, msg=msg)
+    else:
+        te_compare_results(actual, expected, atol, rtol, msg)
+
+
+# Convert PyTorch type to TE type.
+def get_te_dtype(dtype):
+    return {
+        torch.float32: tex.DType.kFloat32,
+        torch.float16: tex.DType.kFloat16,
+        torch.bfloat16: tex.DType.kBFloat16,
+        torch.float8_e4m3fnuz: tex.DType.kFloat8E4M3,
+        torch.float8_e4m3fn: tex.DType.kFloat8E4M3,
+        torch.float8_e5m2fnuz: tex.DType.kFloat8E5M2,
+        torch.float8_e5m2: tex.DType.kFloat8E5M2,
+    }[dtype]
+
+
+# Get size in bytes of a given PyTorch type.
+def sizeof(dtype):
+    return torch.finfo(dtype).bits // 8
+
+
+# Add `i` prefix to identify input type.
+def input_dtypes_str(dtypes_str):
+    return ["i" + dtype_str for dtype_str in dtypes_str]
+
+
+# Add `o` prefix to identify output type.
+def output_dtypes_str(dtypes_str):
+    return ["o" + dtype_str for dtype_str in dtypes_str]
+
+
+# Convert descriptive type string to PyTorch type.
+def str_to_torch_dtype(dtype_str):
+    return {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}[
+        dtype_str[1:] if dtype_str[0] in {"i", "o"} else dtype_str
+    ]
+
+
+# Common pytest skip conditions:
+
+
+def skip_in_dtype_gt_out_dtype(in_dtype, out_dtype):
+    if sizeof(in_dtype) < sizeof(out_dtype):
+        pytest.skip("size of input dtype < size of output dtype")
+
+
+def skip_mixed_16bit_float_types(in_dtype, out_dtype):
+    if (in_dtype == torch.float16 and out_dtype == torch.bfloat16) or (
+        in_dtype == torch.bfloat16 and out_dtype == torch.float16
+    ):
+        pytest.skip("hipified implementation does not support mixing fp16 and bf16")

--- a/tests/pytorch/triton_kernels/test_layernorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_triton.py
@@ -77,19 +77,17 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
     amax_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
     scale_inv_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
 
-    y_triton, mu_triton, rsigma_triton, scale_inv_triton = (
-        te_layernorm_fwd_fp8_noalloc_triton(
-            x,
-            gamma,
-            beta,
-            epsilon,
-            scale,
-            y_triton,
-            amax_triton,
-            scale_inv_triton,
-            out_dtype,
-            zero_centered_gamma,
-        )
+    y_triton, mu_triton, rsigma_triton = te_layernorm_fwd_fp8_noalloc_triton(
+        x,
+        gamma,
+        beta,
+        epsilon,
+        scale,
+        y_triton,
+        amax_triton,
+        scale_inv_triton,
+        out_dtype,
+        zero_centered_gamma,
     )
 
     # Run Hipified forward reference.

--- a/tests/pytorch/triton_kernels/test_layernorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_triton.py
@@ -9,6 +9,7 @@ from transformer_engine.pytorch import cpp_extensions as tex
 from transformer_engine.pytorch.triton_kernels.norm_common_triton import (
     get_fwd_ln_sm_margin,
     get_bwd_ln_sm_margin,
+    IS_FP8,
 )
 from transformer_engine.pytorch.triton_kernels.layernorm_triton import (
     te_layernorm_bwd_triton,
@@ -30,7 +31,7 @@ from test_common_triton import (
 
 test_idtypes_str = input_dtypes_str(["fp32", "fp16"])
 
-test_odtypes_str = output_dtypes_str(["fp32", "bf16", "fp16"])
+test_odtypes_str = output_dtypes_str(["fp32", "bf16", "fp16", "fp8e4"])
 
 test_shapes = [
     (2048, 12288),
@@ -64,18 +65,41 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
     gamma = fill_uniform(N, in_dtype)
     beta = fill_uniform(N, in_dtype)
     dz = fill_uniform((M, N), in_dtype)
+    if IS_FP8(out_dtype):
+        scale = fill_uniform((1,), torch.float32)
+    else:
+        scale = torch.empty(0, device="cuda")
 
     epsilon = 1e-5
 
     # Run Triton forward.
     y_triton = torch.empty((M, N), dtype=out_dtype, device="cuda")
-    y_triton, mu_triton, rsigma_triton = te_layernorm_fwd_fp8_noalloc_triton(
-        x, gamma, beta, epsilon, y_triton, out_dtype, zero_centered_gamma
+    amax_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
+    scale_inv_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
+
+    y_triton, mu_triton, rsigma_triton, scale_inv_triton = (
+        te_layernorm_fwd_fp8_noalloc_triton(
+            x,
+            gamma,
+            beta,
+            epsilon,
+            scale,
+            y_triton,
+            amax_triton,
+            scale_inv_triton,
+            out_dtype,
+            zero_centered_gamma,
+        )
     )
 
     # Run Hipified forward reference.
-    scale = amax = scale_inv = torch.empty(0, device="cuda")
     y_hipified = torch.empty((M, N), dtype=out_dtype, device="cuda")
+    if IS_FP8(out_dtype):
+        amax_hipified = torch.full((1,), 0.0, device="cuda")
+        scale_inv_hipified = torch.full((1,), 0.0, device="cuda")
+    else:
+        amax_hipified = scale_inv_hipified = torch.empty(0, device="cuda")
+
     y_hipified, mu_hipified, rsigma_hipified = tex.layernorm_fwd_fp8_noalloc(
         x,
         gamma,
@@ -83,8 +107,8 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         epsilon,
         scale,
         y_hipified,
-        amax,
-        scale_inv,
+        amax_hipified,
+        scale_inv_hipified,
         get_te_dtype(out_dtype),
         get_fwd_ln_sm_margin(),
         zero_centered_gamma,
@@ -109,6 +133,23 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         rtol_stats,
         lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n",
     )
+    if IS_FP8(out_dtype):
+        compare_results(
+            "torch",
+            amax_triton,
+            amax_hipified,
+            atol_stats,
+            rtol_stats,
+            lambda msg: f"amax does not match triton <-> hip\n\n{msg}\n",
+        )
+        compare_results(
+            "torch",
+            scale_inv_triton,
+            scale_inv_hipified,
+            atol_stats,
+            rtol_stats,
+            lambda msg: f"scale_inv does not match triton <-> hip\n\n{msg}\n",
+        )
 
     # Assert on y:
     atol, rtol = get_tolerances(out_dtype)
@@ -118,8 +159,9 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         # TODO: Investigate test failures when using atol=5e-7.
         # atol = 5e-7
         pass
+    # NOTE: DO NOT upcast inputs to fp32 if you are using te_compare for any precision other than fp32
     compare_results(
-        "torch",
+        "te" if IS_FP8(out_dtype) else "torch",
         y_triton,
         y_hipified,
         atol,
@@ -127,53 +169,54 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         lambda msg: f"y does not match triton <-> hip\n\n{msg}\n",
     )
 
-    # Run Triton backward.
-    dx_triton, dgamma_triton, dbeta_triton = te_layernorm_bwd_triton(
-        dz,
-        x,
-        mu_triton,
-        rsigma_triton,
-        gamma,
-        zero_centered_gamma,
-    )
+    if not IS_FP8(out_dtype):
+        # Run Triton backward.
+        dx_triton, dgamma_triton, dbeta_triton = te_layernorm_bwd_triton(
+            dz,
+            x,
+            mu_triton,
+            rsigma_triton,
+            gamma,
+            zero_centered_gamma,
+        )
 
-    # Run Hipified backward reference.
-    dx_hipified, dgamma_hipified, dbeta_hipified = tex.layernorm_bwd(
-        dz,
-        x,
-        mu_hipified,
-        rsigma_hipified,
-        gamma,
-        get_bwd_ln_sm_margin(),
-        zero_centered_gamma,
-    )
+        # Run Hipified backward reference.
+        dx_hipified, dgamma_hipified, dbeta_hipified = tex.layernorm_bwd(
+            dz,
+            x,
+            mu_hipified,
+            rsigma_hipified,
+            gamma,
+            get_bwd_ln_sm_margin(),
+            zero_centered_gamma,
+        )
 
-    # Assert on dx, dgamma and dbeta:
-    atol_bwd = 1.5e-4
-    rtol_bwd = 1e-4
-    # TE comparison deals with fp16 rounding errors.
-    bwd_cmp = "te" if in_dtype == out_dtype == torch.float16 else "torch"
-    compare_results(
-        bwd_cmp,
-        dx_triton,
-        dx_hipified,
-        atol_bwd,
-        rtol_bwd,
-        lambda msg: f"dx does not match triton <-> hip\n\n{msg}\n",
-    )
-    compare_results(
-        bwd_cmp,
-        dgamma_triton,
-        dgamma_hipified,
-        atol_bwd,
-        rtol_bwd,
-        lambda msg: f"dgamma does not match triton <-> hip\n\n{msg}\n",
-    )
-    compare_results(
-        bwd_cmp,
-        dbeta_triton,
-        dbeta_hipified,
-        atol_bwd,
-        rtol_bwd,
-        lambda msg: f"dbeta does not match triton <-> hip\n\n{msg}\n",
-    )
+        # Assert on dx, dgamma and dbeta:
+        atol_bwd = 1.5e-4
+        rtol_bwd = 1e-4
+        # TE comparison deals with fp16 rounding errors.
+        bwd_cmp = "te" if in_dtype == out_dtype == torch.float16 else "torch"
+        compare_results(
+            bwd_cmp,
+            dx_triton,
+            dx_hipified,
+            atol_bwd,
+            rtol_bwd,
+            lambda msg: f"dx does not match triton <-> hip\n\n{msg}\n",
+        )
+        compare_results(
+            bwd_cmp,
+            dgamma_triton,
+            dgamma_hipified,
+            atol_bwd,
+            rtol_bwd,
+            lambda msg: f"dgamma does not match triton <-> hip\n\n{msg}\n",
+        )
+        compare_results(
+            bwd_cmp,
+            dbeta_triton,
+            dbeta_hipified,
+            atol_bwd,
+            rtol_bwd,
+            lambda msg: f"dbeta does not match triton <-> hip\n\n{msg}\n",
+        )

--- a/tests/pytorch/triton_kernels/test_layernorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_triton.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+import pytest
+import torch
+
+from transformer_engine.pytorch import cpp_extensions as tex
+from transformer_engine.pytorch.triton_kernels.norm_common_triton import (
+    get_fwd_ln_sm_margin,
+    get_bwd_ln_sm_margin,
+)
+from transformer_engine.pytorch.triton_kernels.layernorm_triton import (
+    te_layernorm_bwd_triton,
+    te_layernorm_fwd_fp8_noalloc_triton,
+)
+
+from test_common_triton import (
+    input_dtypes_str,
+    output_dtypes_str,
+    str_to_torch_dtype,
+    skip_in_dtype_gt_out_dtype,
+    skip_mixed_16bit_float_types,
+    fill_uniform,
+    get_te_dtype,
+    get_tolerances,
+    compare_results,
+)
+
+
+test_idtypes_str = input_dtypes_str(["fp32", "fp16"])
+
+test_odtypes_str = output_dtypes_str(["fp32", "bf16", "fp16"])
+
+test_shapes = [
+    (2048, 12288),
+    (768, 1024),
+    (256, 65536),
+    (128, 6144),
+    (64, 2304),
+    (229, 541),
+    (71, 3571),
+    (29, 17389),
+]
+
+all_boolean = [False, True]
+
+
+@pytest.mark.parametrize("in_dtype", test_idtypes_str)
+@pytest.mark.parametrize("out_dtype", test_odtypes_str)
+@pytest.mark.parametrize("M, N", test_shapes)
+@pytest.mark.parametrize("zero_centered_gamma", all_boolean)
+def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
+    # Get Torch data types:
+    in_dtype = str_to_torch_dtype(in_dtype)
+    out_dtype = str_to_torch_dtype(out_dtype)
+
+    # Skip conditions:
+    skip_in_dtype_gt_out_dtype(in_dtype, out_dtype)
+    skip_mixed_16bit_float_types(in_dtype, out_dtype)
+
+    # Generate tensors:
+    x = fill_uniform((M, N), in_dtype)
+    gamma = fill_uniform(N, in_dtype)
+    beta = fill_uniform(N, in_dtype)
+    dz = fill_uniform((M, N), in_dtype)
+
+    epsilon = 1e-5
+
+    # Run Triton forward.
+    y_triton = torch.empty((M, N), dtype=out_dtype, device="cuda")
+    y_triton, mu_triton, rsigma_triton = te_layernorm_fwd_fp8_noalloc_triton(
+        x, gamma, beta, epsilon, y_triton, out_dtype, zero_centered_gamma
+    )
+
+    # Run Hipified forward reference.
+    scale = amax = scale_inv = torch.empty(0, device="cuda")
+    y_hipified = torch.empty((M, N), dtype=out_dtype, device="cuda")
+    y_hipified, mu_hipified, rsigma_hipified = tex.layernorm_fwd_fp8_noalloc(
+        x,
+        gamma,
+        beta,
+        epsilon,
+        scale,
+        y_hipified,
+        amax,
+        scale_inv,
+        get_te_dtype(out_dtype),
+        get_fwd_ln_sm_margin(),
+        zero_centered_gamma,
+    )
+
+    # Assert on mu and rsigma:
+    atol_stats, _ = get_tolerances(torch.float32)
+    rtol_stats = 5e-5
+    compare_results(
+        "torch",
+        mu_triton,
+        mu_hipified,
+        atol_stats,
+        rtol_stats,
+        lambda msg: f"mu does not match triton <-> hip\n\n{msg}\n",
+    )
+    compare_results(
+        "torch",
+        rsigma_triton,
+        rsigma_hipified,
+        atol_stats,
+        rtol_stats,
+        lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n",
+    )
+
+    # Assert on y:
+    atol, rtol = get_tolerances(out_dtype)
+    if out_dtype == torch.float32:
+        # Everything pass with default fp32 atol=1e-6. TE C++ test uses atol=5e-7, this tolerance causes
+        # some minor failures in Triton test.
+        # TODO: Investigate test failures when using atol=5e-7.
+        # atol = 5e-7
+        pass
+    compare_results(
+        "torch",
+        y_triton,
+        y_hipified,
+        atol,
+        rtol,
+        lambda msg: f"y does not match triton <-> hip\n\n{msg}\n",
+    )
+
+    # Run Triton backward.
+    dx_triton, dgamma_triton, dbeta_triton = te_layernorm_bwd_triton(
+        dz,
+        x,
+        mu_triton,
+        rsigma_triton,
+        gamma,
+        zero_centered_gamma,
+    )
+
+    # Run Hipified backward reference.
+    dx_hipified, dgamma_hipified, dbeta_hipified = tex.layernorm_bwd(
+        dz,
+        x,
+        mu_hipified,
+        rsigma_hipified,
+        gamma,
+        get_bwd_ln_sm_margin(),
+        zero_centered_gamma,
+    )
+
+    # Assert on dx, dgamma and dbeta:
+    atol_bwd = 1.5e-4
+    rtol_bwd = 1e-4
+    # TE comparison deals with fp16 rounding errors.
+    bwd_cmp = "te" if in_dtype == out_dtype == torch.float16 else "torch"
+    compare_results(
+        bwd_cmp,
+        dx_triton,
+        dx_hipified,
+        atol_bwd,
+        rtol_bwd,
+        lambda msg: f"dx does not match triton <-> hip\n\n{msg}\n",
+    )
+    compare_results(
+        bwd_cmp,
+        dgamma_triton,
+        dgamma_hipified,
+        atol_bwd,
+        rtol_bwd,
+        lambda msg: f"dgamma does not match triton <-> hip\n\n{msg}\n",
+    )
+    compare_results(
+        bwd_cmp,
+        dbeta_triton,
+        dbeta_hipified,
+        atol_bwd,
+        rtol_bwd,
+        lambda msg: f"dbeta does not match triton <-> hip\n\n{msg}\n",
+    )

--- a/tests/pytorch/triton_kernels/test_layernorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_triton.py
@@ -76,7 +76,7 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
     y_triton = torch.empty((M, N), dtype=out_dtype, device="cuda")
     amax_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
     scale_inv_triton = torch.zeros((1,), device="cuda") if IS_FP8(out_dtype) else None
-
+    sm_margin = 0
     y_triton, mu_triton, rsigma_triton = te_layernorm_fwd_fp8_noalloc_triton(
         x,
         gamma,
@@ -87,6 +87,7 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         amax_triton,
         scale_inv_triton,
         out_dtype,
+        sm_margin,
         zero_centered_gamma,
     )
 
@@ -175,6 +176,7 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
             mu_triton,
             rsigma_triton,
             gamma,
+            sm_margin,
             zero_centered_gamma,
         )
 

--- a/tests/pytorch/triton_kernels/test_norm_common_triton.py
+++ b/tests/pytorch/triton_kernels/test_norm_common_triton.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+import torch
+from transformer_engine.pytorch import cpp_extensions as tex
+from transformer_engine.pytorch.triton_kernels.norm_common_triton import get_num_sms
+
+from test_common_triton import get_te_dtype
+
+
+def test_sm_margin():
+    num_sms = get_num_sms()
+    assert num_sms > 0
+    assert get_num_sms(0) == num_sms
+    assert get_num_sms(-5) == num_sms
+    assert get_num_sms(1) == num_sms - 1
+    assert get_num_sms(100 * num_sms) == 1
+
+
+def test_get_te_dtype():
+    assert get_te_dtype(torch.float32) == tex.DType.kFloat32
+    assert get_te_dtype(torch.float16) == tex.DType.kFloat16
+    assert get_te_dtype(torch.bfloat16) == tex.DType.kBFloat16
+    assert get_te_dtype(torch.float8_e4m3fnuz) == tex.DType.kFloat8E4M3
+    assert get_te_dtype(torch.float8_e4m3fn) == tex.DType.kFloat8E4M3
+    assert get_te_dtype(torch.float8_e5m2fnuz) == tex.DType.kFloat8E5M2
+    assert get_te_dtype(torch.float8_e5m2) == tex.DType.kFloat8E5M2

--- a/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm_triton.py
@@ -1,107 +1,34 @@
 # Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # License for AMD contributions = MIT. See LICENSE for more information
 
+
 import pytest
 import torch
-import os
 
-from transformer_engine.pytorch.triton_kernels.rmsnorm_triton import te_rmsnorm_fwd_fp8_noalloc_triton, te_rmsnorm_fwd_noalloc_triton, te_rmsnorm_fwd_inf_triton, te_rmsnorm_bwd_triton, get_num_sms
 from transformer_engine.pytorch import cpp_extensions as tex
+from transformer_engine.pytorch.triton_kernels.norm_common_triton import (
+    get_fwd_ln_sm_margin,
+    get_bwd_ln_sm_margin,
+    get_inf_ln_sm_margin,
+)
+from transformer_engine.pytorch.triton_kernels.rmsnorm_triton import (
+    te_rmsnorm_fwd_fp8_noalloc_triton,
+    te_rmsnorm_fwd_noalloc_triton,
+    te_rmsnorm_fwd_inf_triton,
+    te_rmsnorm_bwd_triton,
+)
 
-
-def get_te_dtype(dtype):
-    if dtype == torch.float32:
-        return tex.DType.kFloat32
-    if dtype == torch.float16:
-        return tex.DType.kFloat16
-    if dtype == torch.bfloat16:
-        return tex.DType.kBFloat16
-    if dtype == torch.float8_e4m3fnuz or dtype == torch.float8_e4m3fn:
-        return tex.DType.kFloat8E4M3
-    if dtype == torch.float8_e5m2fnuz or dtype == torch.float8_e5m2:
-        return tex.DType.kFloat8E5M2
-
-
-# get size in bytes of given PyTorch type
-def sizeof(in_dtype):
-    return torch.finfo(in_dtype).bits // 8
-
-
-def get_tolerances(in_dtype):
-    if in_dtype == torch.float32:
-        return 1e-6, 5e-6
-    elif in_dtype == torch.float16:
-        return 1e-5, 1e-3
-    elif in_dtype == torch.bfloat16:
-        return 1e-5, 1e-2
-    elif (in_dtype == torch.float8_e4m3fnuz or in_dtype == torch.float8_e5m2fnuz
-          or in_dtype == torch.float8_e4m3fn or in_dtype == torch.float8_e5m2):
-        #TODO: different tolerances for FNUZ and OCP
-        return 1e-2, 1e-2
-    else:
-        raise RuntimeError("Invalid type")
-
-
-# PyTorch implementation of `compareResults` C++ function from `tests/cpp/test_common.cu`.
-# Arguments:
-#     t: actual tensor
-#     r: expected tensor
-def te_compare_results(t, r, atol, rtol):
-    assert t.dtype == r.dtype, f"Tensor dtypes don't match: {t.dtype} vs {r.dtype}."
-    assert t.shape == r.shape, f"Tensor shapes don't match: {t.shape} vs {r.shape}."
-    assert atol > 0, "Absolute tolerance must be positive."
-    assert rtol > 0, "Relative tolerance must be positive."
-    dtype = t.dtype
-    t = t.cpu().to(torch.float32).to(torch.float64)
-    r = r.cpu().to(torch.float32).to(torch.float64)
-    diff = t - r
-    atol_mismatch = torch.abs(diff) > atol
-    nonzero_r = r != 0
-    rtol_mismatch = torch.full_like(atol_mismatch, False)
-    rtol_mismatch[nonzero_r] = torch.abs(diff[nonzero_r] / r[nonzero_r]) > rtol
-    mismatch = torch.logical_and(atol_mismatch, torch.logical_or(torch.logical_not(nonzero_r), rtol_mismatch))
-    has_mismatch = torch.any(mismatch).item()
-    # for fp32 the floating point comparison is enough to error out
-    if has_mismatch and dtype != torch.float32:
-        # check if it is just a failure of round to nearest choosing different side of the real value
-        # for non fp32 types
-        mean = (t + r) / 2
-        eps = 1e-6
-        mean_one_plus_eps = mean * (1 + eps)
-        mean_one_minus_eps = mean * (1 - eps)
-        mean_gte_zero = mean >= 0
-        mean_p = torch.where(mean_gte_zero, mean_one_plus_eps, mean_one_minus_eps)
-        mean_m = torch.where(mean_gte_zero, mean_one_minus_eps, mean_one_plus_eps)
-        cast_mean_p = mean_p.to(torch.float32).to(dtype).to(torch.float32).to(torch.float64)
-        cast_mean_m = mean_m.to(torch.float32).to(dtype).to(torch.float32).to(torch.float64)
-        min_tr = torch.minimum(t, r)
-        max_tr = torch.maximum(t, r)
-        round_check = torch.logical_not(torch.logical_and(cast_mean_m == min_tr, cast_mean_p == max_tr))
-        mismatch = torch.logical_and(mismatch, round_check)
-        has_mismatch = torch.any(mismatch).item()
-    # TODO: improve assertion message adding more information
-    assert not has_mismatch, "There are tensor mismatches."
-
-
-def get_ln_sm_margin(sm_margin_type):
-    try:
-        sm_margin = max(int(os.getenv(f"NVTE_{sm_margin_type}_LAYERNORM_SM_MARGIN", "0")), 0)
-    except ValueError:
-        sm_margin = 0
-    assert sm_margin >= 0
-    return sm_margin
-
-
-def get_fwd_ln_sm_margin():
-    return get_ln_sm_margin("FWD")
-
-
-def get_bwd_ln_sm_margin():
-    return get_ln_sm_margin("BWD")
-
-
-def get_inf_ln_sm_margin():
-    return get_ln_sm_margin("INF")
+from test_common_triton import (
+    input_dtypes_str,
+    output_dtypes_str,
+    str_to_torch_dtype,
+    skip_in_dtype_gt_out_dtype,
+    skip_mixed_16bit_float_types,
+    fill_uniform,
+    get_te_dtype,
+    get_tolerances,
+    compare_results,
+)
 
 
 test_shapes = [
@@ -115,16 +42,9 @@ test_shapes = [
     (29, 17389),
 ]
 
-# descriptive type strings to better identify pytest test cases
-test_dtypes_str = ['fp32', 'fp16', 'bf16']
-# add i prefix to identify input type
-test_idtypes_str = ["i" + dtype_str for dtype_str in test_dtypes_str]
-# add o prefix to identify output type
-test_odtypes_str = ["o" + dtype_str for dtype_str in test_dtypes_str]
-
-# convert descriptive type strings to torch types
-def str_to_torch_dtype(dtype_str):
-    return {'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32}[dtype_str[1:]]
+test_types_str = ["fp32", "fp16", "bf16"]
+test_idtypes_str = input_dtypes_str(test_types_str)
+test_odtypes_str = output_dtypes_str(test_types_str)
 
 all_boolean = [True, False]
 
@@ -140,22 +60,15 @@ def test_rmsnorm_fwd_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
     out_dtype = str_to_torch_dtype(out_dtype)
 
     # skip conditions
-    if sizeof(in_dtype) < sizeof(out_dtype):
-        pytest.skip("size of input dtype < size of output dtype")
-    if (in_dtype==torch.float16 and out_dtype==torch.bfloat16) or (in_dtype==torch.bfloat16 and out_dtype==torch.float16):
-        pytest.skip("hipified rmsnorm kernel does not support mixing fp16 and bf16")
+    skip_in_dtype_gt_out_dtype(in_dtype, out_dtype)
+    skip_mixed_16bit_float_types(in_dtype, out_dtype)
 
     # generate input tensors
-    ## Uniform distribution between [-2.0, 1.0]
-    torch.manual_seed(0)
-    input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    input_tensor = input_tensor.to(in_dtype)
+    input_tensor = fill_uniform((M, N), in_dtype)
     # in hipfied kernel cpp test, weight type == input_type
-    gamma_tensor = torch.rand(N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    gamma_tensor = gamma_tensor.to(in_dtype)
-    dz_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
+    gamma_tensor = fill_uniform(N, in_dtype)
     # in hipfied kernel cpp test, dz is of weight type
-    dz_tensor = dz_tensor.to(in_dtype)
+    dz_tensor = fill_uniform((M, N), in_dtype)
 
     # other parameters:
     epsilon = 1e-5
@@ -178,14 +91,26 @@ def test_rmsnorm_fwd_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
     # assert on ln_out
     ln_out_atol = 1e-8
     _, ln_out_rtol = get_tolerances(out_dtype)
-    torch.testing.assert_close(ln_out_triton, ln_out_hipified, atol=ln_out_atol, rtol=ln_out_rtol,
-                               msg=lambda msg: f"ln_out does not match triton <-> hip\n\n{msg}\n")
+    compare_results(
+        "torch",
+        ln_out_triton,
+        ln_out_hipified,
+        ln_out_atol,
+        ln_out_rtol,
+        lambda msg: f"ln_out does not match triton <-> hip\n\n{msg}\n",
+    )
 
     # assert on rsigma
     rsigma_atol, rsigma_rtol = 1e-6, 5e-5
     # rsigma is of type fp32
-    torch.testing.assert_close(rsigma_triton, rsigma_hipified, atol=rsigma_atol, rtol=rsigma_rtol,
-                               msg=lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n")
+    compare_results(
+        "torch",
+        rsigma_triton,
+        rsigma_hipified,
+        rsigma_atol,
+        rsigma_rtol,
+        lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n",
+    )
 
     # run triton bwd
     dx_triton, dgamma_triton = te_rmsnorm_bwd_triton(dz_tensor, input_tensor, rsigma_triton, gamma_tensor, bwd_ln_sm_margin, zero_centered_gamma)
@@ -201,10 +126,24 @@ def test_rmsnorm_fwd_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
     # C++ test, so TE comparison behavior and error tolerances are used.
 
     # assert on dx
-    te_compare_results(dx_triton, dx_hipified, atol_bwd, rtol_bwd)
+    compare_results(
+        "te",
+        dx_triton,
+        dx_hipified,
+        atol_bwd,
+        rtol_bwd,
+        lambda msg: f"dx does not match triton <-> hip\n\n{msg}\n"
+    )
 
     # assert on dgamma
-    te_compare_results(dgamma_triton, dgamma_hipified, atol_bwd, rtol_bwd)
+    compare_results(
+        "te",
+        dgamma_triton,
+        dgamma_hipified,
+        atol_bwd,
+        rtol_bwd,
+        lambda msg: f"dgamma does not match triton <-> hip\n\n{msg}\n",
+    )
 
 
 @pytest.mark.parametrize("M, N", test_shapes)
@@ -213,11 +152,8 @@ def test_rmsnorm_fwd_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
 def test_rmsnorm_fwd_noalloc_triton(M, N, in_dtype, zero_centered_gamma):
     in_dtype = str_to_torch_dtype(in_dtype)
-    ## Uniform distribution between [-2.0, 1.0]
-    input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    input_tensor = input_tensor.to(in_dtype)
-    gamma_tensor = torch.rand(N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    gamma_tensor = gamma_tensor.to(in_dtype)
+    input_tensor = fill_uniform((M, N), in_dtype)
+    gamma_tensor = fill_uniform(N, in_dtype)
 
     epsilon = 1e-5
     fwd_ln_sm_margin = get_fwd_ln_sm_margin()
@@ -230,9 +166,23 @@ def test_rmsnorm_fwd_noalloc_triton(M, N, in_dtype, zero_centered_gamma):
     ln_out_hipified = torch.empty(M, N, dtype=in_dtype, device='cuda')
     ln_out_hipified, rsigma_hipified = tex.rmsnorm_fwd_noalloc(input_tensor, gamma_tensor, ln_out_hipified, epsilon, fwd_ln_sm_margin, zero_centered_gamma)
     atol, rtol = get_tolerances(in_dtype)
-    assert torch.allclose(ln_out_triton, ln_out_hipified, atol=atol, rtol=rtol), 'ln_out does not match'
+    compare_results(
+        "torch",
+        ln_out_triton,
+        ln_out_hipified,
+        atol,
+        rtol,
+        lambda msg: f"ln_out does not match triton <-> hip\n\n{msg}\n",
+    )
     # rsigma is of type fp32
-    assert torch.allclose(rsigma_triton, rsigma_hipified, atol=1e-6, rtol=5e-5), 'rsigma does not match'
+    compare_results(
+        "torch",
+        rsigma_triton,
+        rsigma_hipified,
+        1e-6,
+        5e-5,
+        lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n",
+    )
 
 
 @pytest.mark.parametrize("M, N", test_shapes)
@@ -241,11 +191,9 @@ def test_rmsnorm_fwd_noalloc_triton(M, N, in_dtype, zero_centered_gamma):
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
 def test_rmsnorm_fwd_inf_triton(M, N, in_dtype, zero_centered_gamma):
     in_dtype = str_to_torch_dtype(in_dtype)
-    ## Uniform distribution between [-2.0, 1.0]
-    input_tensor = torch.rand(M, N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    input_tensor = input_tensor.to(in_dtype)
-    gamma_tensor = torch.rand(N, dtype=torch.float32, device='cuda') * 3.0 - 2.0
-    gamma_tensor = gamma_tensor.to(in_dtype)
+
+    input_tensor = fill_uniform((M, N), in_dtype)
+    gamma_tensor = fill_uniform(N, in_dtype)
 
     epsilon = 1e-5
     inf_ln_sm_margin = get_inf_ln_sm_margin()
@@ -256,13 +204,11 @@ def test_rmsnorm_fwd_inf_triton(M, N, in_dtype, zero_centered_gamma):
     # run the reference hipified kernel path
     ln_out_hipified = tex.rmsnorm_fwd_inf(input_tensor, gamma_tensor, epsilon, inf_ln_sm_margin, zero_centered_gamma)
     atol, rtol = get_tolerances(in_dtype)
-    assert torch.allclose(ln_out_triton, ln_out_hipified, atol=atol, rtol=rtol), 'ln_out does not match'
-
-
-def test_sm_margin():
-    num_sms = get_num_sms()
-    assert num_sms > 0
-    assert get_num_sms(0) == num_sms
-    assert get_num_sms(-5) == num_sms
-    assert get_num_sms(1) == num_sms - 1
-    assert get_num_sms(100 * num_sms) == 1
+    compare_results(
+        "torch",
+        ln_out_triton,
+        ln_out_hipified,
+        atol,
+        rtol,
+        lambda msg: f"ln_out does not match triton <-> hip\n\n{msg}\n",
+    )

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -440,7 +440,7 @@ def _layernorm_bwd_dwdb_triton_v2(
     tl.store(FINAL_DB + cols, sum_db.to(FINAL_DB.type.element_ty), mask=cols < N)
 
 
-# TODO: Implement persistent kernel in forward and add `sm_margin` to the interface.
+# TODO: Add support for `sm_margin > 0`.
 def te_layernorm_fwd_fp8_noalloc_triton(
     x,
     gamma,
@@ -510,7 +510,7 @@ def te_layernorm_fwd_fp8_noalloc_triton(
     return y, mu, rsigma
 
 
-# TODO: Add `sm_margin` to the interface.
+# TODO: Add support for `sm_margin > 0`.
 def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma):
     if sm_margin is not None and sm_margin > 0:
         warnings.warn(

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+from itertools import product
+
+import torch
+import triton
+import triton.language as tl
+
+from .norm_common_triton import block_size, use_blocked
+
+
+def get_autotune_config(full_tuning_space=False):
+    if full_tuning_space:
+        tuning_space = product([1, 2, 4], [4, 8, 16])
+    else:
+        tuning_space = [(1, 8), (1, 16), (2, 16), (4, 4), (4, 8), (4, 16)]
+    return [
+        triton.Config({"waves_per_eu": waves_per_eu}, num_warps=num_warps, num_stages=1)
+        for waves_per_eu, num_warps in tuning_space
+    ]
+
+
+@triton.autotune(
+    configs=get_autotune_config(), key=["n_rows", "n_cols"], use_cuda_graph=True
+)
+@triton.jit
+def _layernorm_fwd_triton(
+    x_ptr,
+    y_ptr,
+    w_ptr,
+    b_ptr,
+    mean_ptr,
+    rstd_ptr,
+    x_row_stride,
+    y_row_stride,
+    n_rows,
+    n_cols,
+    eps,
+    ZERO_CENTERED_GAMMA: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+
+    # program id
+    row = tl.program_id(0)
+    x_ptr_start = x_ptr + (row * x_row_stride)
+    y_ptr_start = y_ptr + (row * y_row_stride)
+
+    loop_num = tl.cdiv(n_cols, BLOCK_SIZE) - 1
+
+    # calculate mean
+    mean = 0
+    _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    loop_num_l = loop_num
+    for b in range(0, loop_num_l):
+        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)  # Unmasked loads
+        _mean += x_block
+
+    # For last iteration, do masked load
+    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x_block = tl.load(
+        x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
+    ).to(tl.float32)
+    _mean += x_block
+    mean = tl.sum(_mean, axis=0) / n_cols
+
+    # variance
+    _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    loop_num_l = loop_num
+    for b in range(0, loop_num_l):
+        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)  # Unmasked loads
+        x_block = x_block - mean
+        _var += x_block * x_block
+
+    # For last iteration, do masked load
+    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x_block = tl.load(
+        x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
+    ).to(tl.float32)
+    x_block = tl.where(col_offsets < n_cols, x_block - mean, 0.0)
+    _var += x_block * x_block
+
+    var = tl.sum(_var, axis=0) / n_cols
+    rstd = tl.rsqrt(var + eps)
+
+    # Write mean / rstd
+    tl.store(mean_ptr + row, mean)
+    tl.store(rstd_ptr + row, rstd)
+
+    # Normalize and store
+    loop_num_l = loop_num
+    for b in range(0, loop_num_l):
+        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        w_block = tl.load(w_ptr + col_offsets).to(tl.float32)
+        b_block = tl.load(b_ptr + col_offsets).to(tl.float32)
+        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)
+        if ZERO_CENTERED_GAMMA:
+            w_block += 1
+        y_block = (x_block - mean) * rstd
+        y_block = y_block * w_block + b_block
+        tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty))
+
+    # For last iteration, do masked load and store
+    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+    w_block = tl.load(w_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    b_block = tl.load(b_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    x_block = tl.load(x_ptr_start + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    if ZERO_CENTERED_GAMMA:
+        w_block += 1
+    y_block = (x_block - mean) * rstd
+    y_block = y_block * w_block + b_block
+    tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty), mask=mask)
+
+
+@triton.jit
+def _layernorm_bwd_dx_fused_triton(
+    DX,  # pointer to the input gradient
+    DY,  # pointer to the output gradient
+    DW,  # pointer to the partial sum of weights gradient
+    DB,  # pointer to the partial sum of biases gradient
+    X,  # pointer to the input
+    W,  # pointer to the weights
+    Mean,  # pointer to the mean
+    Rstd,  # pointer to the 1/std
+    stride,  # how much to increase the pointer when moving by 1 row
+    N,  # number of columns in X
+    ZERO_CENTERED_GAMMA: tl.constexpr,
+    NUM_ROWS: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    USE_BLOCKED: tl.constexpr,
+):
+    # Map the program id to the elements of X, DX, and DY it should compute.
+    pid = tl.program_id(0)
+    tile_num = tl.num_programs(0)
+    rows_per_tile = NUM_ROWS // tile_num
+    if pid < NUM_ROWS % tile_num:
+        rows_per_tile += 1
+
+    if USE_BLOCKED:
+        # Blocked approach:
+
+        col_offsets = tl.arange(0, BLOCK_SIZE_N)
+        num_col_blocks = tl.cdiv(N, BLOCK_SIZE_N) - 1
+        row = pid
+
+        for _ in range(0, rows_per_tile):
+            # Load row statistics:
+            mean = tl.load(Mean + row)
+            rstd = tl.load(Rstd + row)
+
+            # Accumulate c1 and c2 sums:
+
+            x_row_ptr = X + row * stride
+            dy_row_ptr = DY + row * stride
+
+            c1 = 0.0
+            c2 = 0.0
+
+            for block_idx in tl.range(0, num_col_blocks):
+                cols = block_idx * BLOCK_SIZE_N + col_offsets
+
+                x = tl.load(x_row_ptr + cols).to(tl.float32)
+                dy = tl.load(dy_row_ptr + cols).to(tl.float32)
+                w = tl.load(W + cols).to(tl.float32)
+
+                xhat = (x - mean) * rstd
+                if ZERO_CENTERED_GAMMA:
+                    w += 1
+                wdy = w * dy
+                c1 += tl.sum(xhat * wdy, axis=0)
+                c2 += tl.sum(wdy, axis=0)
+
+            cols = num_col_blocks * BLOCK_SIZE_N + col_offsets
+            mask = cols < N
+
+            x = tl.load(x_row_ptr + cols, mask=mask, other=0).to(tl.float32)
+            dy = tl.load(dy_row_ptr + cols, mask=mask, other=0).to(tl.float32)
+            w = tl.load(W + cols, mask=mask, other=0).to(tl.float32)
+
+            xhat = (x - mean) * rstd
+            if ZERO_CENTERED_GAMMA:
+                w += 1
+            wdy = w * dy
+            xhat = tl.where(mask, xhat, 0)
+            wdy = tl.where(mask, wdy, 0)
+            c1 += tl.sum(xhat * wdy, axis=0)
+            c2 += tl.sum(wdy, axis=0)
+
+            c1 /= N
+            c2 /= N
+
+            # Compute dx and partial sums for dw and db:
+
+            dx_row_ptr = DX + row * stride
+            dw_row_ptr = DW + pid * N
+            db_row_ptr = DB + pid * N
+
+            for block_idx in tl.range(0, num_col_blocks):
+                cols = block_idx * BLOCK_SIZE_N + col_offsets
+
+                x = tl.load(x_row_ptr + cols).to(tl.float32)
+                dy = tl.load(dy_row_ptr + cols).to(tl.float32)
+                w = tl.load(W + cols).to(tl.float32)
+
+                xhat = (x - mean) * rstd
+                if ZERO_CENTERED_GAMMA:
+                    w += 1
+                wdy = w * dy
+
+                dx = (wdy - (xhat * c1 + c2)) * rstd
+                tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty))
+
+                partial_dw = dy * xhat
+                dw_ptrs = dw_row_ptr + cols
+                partial_dw += tl.load(dw_ptrs)
+                tl.store(dw_ptrs, partial_dw)
+
+                partial_db = dy
+                db_ptrs = db_row_ptr + cols
+                partial_db += tl.load(db_ptrs)
+                tl.store(db_ptrs, partial_db)
+
+            cols = num_col_blocks * BLOCK_SIZE_N + col_offsets
+            mask = cols < N
+
+            x = tl.load(x_row_ptr + cols, mask=mask, other=0).to(tl.float32)
+            dy = tl.load(dy_row_ptr + cols, mask=mask, other=0).to(tl.float32)
+            w = tl.load(W + cols, mask=mask, other=0).to(tl.float32)
+
+            xhat = (x - mean) * rstd
+            if ZERO_CENTERED_GAMMA:
+                w += 1
+            wdy = w * dy
+            xhat = tl.where(mask, xhat, 0)
+            wdy = tl.where(mask, wdy, 0)
+
+            dx = (wdy - (xhat * c1 + c2)) * rstd
+            tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty), mask=mask)
+
+            partial_dw = dy * xhat
+            dw_ptrs = dw_row_ptr + cols
+            partial_dw += tl.load(dw_ptrs, mask=mask)
+            tl.store(dw_ptrs, partial_dw, mask=mask)
+
+            partial_db = dy
+            db_ptrs = db_row_ptr + cols
+            partial_db += tl.load(db_ptrs, mask=mask)
+            tl.store(db_ptrs, partial_db, mask=mask)
+
+            # Advance to next row.
+            row += tile_num
+
+    else:
+        # Unblocked approach:
+
+        cols = tl.arange(0, BLOCK_SIZE_N)
+        mask = cols < N
+        row = pid
+
+        dw_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+        db_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+
+        for _ in range(0, rows_per_tile):
+            # Compute pointers:
+            x_ptrs = X + row * stride
+            dy_ptrs = DY + row * stride
+            dx_ptrs = DX + row * stride
+
+            # Load data to SRAM:
+            x = tl.load(x_ptrs + cols, mask=mask, other=0).to(tl.float32)
+            dy = tl.load(dy_ptrs + cols, mask=mask, other=0).to(tl.float32)
+            w = tl.load(W + cols, mask=mask, other=0).to(tl.float32)
+            mean = tl.load(Mean + row)
+            rstd = tl.load(Rstd + row)
+
+            # Compute dx:
+            xhat = (x - mean) * rstd
+            if ZERO_CENTERED_GAMMA:
+                w += 1
+            wdy = w * dy
+            xhat = tl.where(mask, xhat, 0)
+            wdy = tl.where(mask, wdy, 0)
+            c1 = tl.sum(xhat * wdy, axis=0) / N
+            c2 = tl.sum(wdy, axis=0) / N
+            dx = (wdy - (xhat * c1 + c2)) * rstd
+
+            # Write dx:
+            tl.store(dx_ptrs + cols, dx.to(DX.type.element_ty), mask=mask)
+
+            # Accumulate partial sums for dw and db:
+            dw_row += dy * xhat
+            db_row += dy
+
+            # Advance to next row:
+            row += tile_num
+
+        tl.store(DW + pid * N + cols, dw_row, mask=mask)
+        tl.store(DB + pid * N + cols, db_row, mask=mask)
+
+
+@triton.jit
+def _layernorm_bwd_dwdb_triton(
+    DW,  # pointer to the partial sum of weights gradient
+    DB,  # pointer to the partial sum of biases gradient
+    FINAL_DW,  # pointer to the weights gradient
+    FINAL_DB,  # pointer to the biases gradient
+    M,  # GROUP_SIZE_M
+    N,  # number of columns
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    # Map the program id to the elements of DW and DB it should compute.
+    pid = tl.program_id(0)
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    db = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    # Iterate through the rows of DW and DB to sum the partial sums.
+    for i in range(0, M, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        mask = (rows[:, None] < M) & (cols[None, :] < N)
+        offs = rows[:, None] * N + cols[None, :]
+        dw += tl.load(DW + offs, mask=mask, other=0.0)
+        db += tl.load(DB + offs, mask=mask, other=0.0)
+    # Write the final sum to the output.
+    sum_dw = tl.sum(dw, axis=0)
+    sum_db = tl.sum(db, axis=0)
+    tl.store(FINAL_DW + cols, sum_dw.to(FINAL_DW.type.element_ty), mask=cols < N)
+    tl.store(FINAL_DB + cols, sum_db.to(FINAL_DB.type.element_ty), mask=cols < N)
+
+
+# TODO: Implement persistent kernel in forward and add `sm_margin` to the interface.
+def te_layernorm_fwd_fp8_noalloc_triton(
+    x, gamma, beta, eps, y, out_dtype, zero_centered_gamma
+):
+    M, N = x.shape
+    y = y.view(out_dtype)
+    mu = torch.empty((M,), dtype=torch.float32, device=x.device)
+    rsigma = torch.empty((M,), dtype=torch.float32, device=x.device)
+
+    BLOCK_SIZE = block_size(x)
+    _layernorm_fwd_triton[(M,)](
+        x,
+        y,
+        gamma,
+        beta,
+        mu,
+        rsigma,
+        x.stride(0),
+        y.stride(0),
+        M,
+        N,
+        eps,
+        ZERO_CENTERED_GAMMA=zero_centered_gamma,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return y, mu, rsigma
+
+
+# TODO: Add `sm_margin` to the interface.
+def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
+    M, N = x.shape
+
+    BLOCK_SIZE = block_size(x)
+    num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+    tile_num = max(min(256, M // 4), 1)
+
+    dx = torch.empty_like(x)
+    _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+    _dbeta = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+    dgamma = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
+    dbeta = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
+
+    grid_bwd = (tile_num,)
+    _layernorm_bwd_dx_fused_triton[grid_bwd](
+        dx,
+        dz,
+        _dgamma,
+        _dbeta,
+        x,
+        gamma,
+        mu,
+        rsigma,
+        x.stride(0),
+        N,
+        ZERO_CENTERED_GAMMA=zero_centered_gamma,
+        NUM_ROWS=M,
+        BLOCK_SIZE_N=BLOCK_SIZE,
+        USE_BLOCKED=use_blocked(x),
+        num_warps=num_warps,
+    )
+
+    grid_reduce = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE_N"]),)
+    _layernorm_bwd_dwdb_triton[grid_reduce](
+        _dgamma,
+        _dbeta,
+        dgamma,
+        dbeta,
+        min(tile_num, M),
+        N,
+        BLOCK_SIZE_M=32,
+        BLOCK_SIZE_N=128,
+    )
+
+    return dx, dgamma, dbeta

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -74,10 +74,8 @@ def _layernorm_fwd_triton(
         loop_num = tl.cdiv(n_cols, BLOCK_SIZE) - 1
 
         # calculate mean
-        mean = 0
         _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        loop_num_l = loop_num
-        for b in range(0, loop_num_l):
+        for b in range(0, loop_num):
             col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
             x_block = tl.load(x_ptr_start + col_offsets).to(
                 tl.float32
@@ -85,7 +83,7 @@ def _layernorm_fwd_triton(
             _mean += x_block
 
         # For last iteration, do masked load
-        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         x_block = tl.load(
             x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
         ).to(tl.float32)
@@ -94,8 +92,7 @@ def _layernorm_fwd_triton(
 
         # variance
         _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        loop_num_l = loop_num
-        for b in range(0, loop_num_l):
+        for b in range(0, loop_num):
             col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
             x_block = tl.load(x_ptr_start + col_offsets).to(
                 tl.float32
@@ -104,7 +101,7 @@ def _layernorm_fwd_triton(
             _var += x_block * x_block
 
         # For last iteration, do masked load
-        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         x_block = tl.load(
             x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
         ).to(tl.float32)
@@ -119,8 +116,7 @@ def _layernorm_fwd_triton(
         tl.store(rstd_ptr + row, rstd)
 
         # Normalize and store
-        loop_num_l = loop_num
-        for b in range(0, loop_num_l):
+        for b in range(0, loop_num):
             col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
             w_block = tl.load(w_ptr + col_offsets).to(tl.float32)
             b_block = tl.load(b_ptr + col_offsets).to(tl.float32)
@@ -136,7 +132,7 @@ def _layernorm_fwd_triton(
             tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty))
 
         # For last iteration, do masked load and store
-        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         mask = col_offsets < n_cols
         w_block = tl.load(w_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
         b_block = tl.load(b_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
@@ -263,7 +259,6 @@ def _layernorm_bwd_dx_fused_triton(
             if ZERO_CENTERED_GAMMA:
                 w += 1
             wdy = w * dy
-            xhat = tl.where(mask, xhat, 0)
             wdy = tl.where(mask, wdy, 0)
             c1 += tl.sum(xhat * wdy, axis=0)
             c2 += tl.sum(wdy, axis=0)
@@ -314,8 +309,6 @@ def _layernorm_bwd_dx_fused_triton(
             if ZERO_CENTERED_GAMMA:
                 w += 1
             wdy = w * dy
-            xhat = tl.where(mask, xhat, 0)
-            wdy = tl.where(mask, wdy, 0)
 
             dx = (wdy - (xhat * c1 + c2)) * rstd
             tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty), mask=mask)
@@ -361,7 +354,6 @@ def _layernorm_bwd_dx_fused_triton(
             if ZERO_CENTERED_GAMMA:
                 w += 1
             wdy = w * dy
-            xhat = tl.where(mask, xhat, 0)
             wdy = tl.where(mask, wdy, 0)
             c1 = tl.sum(xhat * wdy, axis=0) / N
             c2 = tl.sum(wdy, axis=0) / N

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -35,6 +35,7 @@ def _layernorm_fwd_triton(
     rstd_ptr,
     scale_ptr,
     amax_ptr,
+    scale_inv_ptr,
     x_row_stride,
     y_row_stride,
     n_rows,
@@ -156,6 +157,9 @@ def _layernorm_fwd_triton(
 
     if IS_FP8:
         if APPLY_ATOMIC:
+            if pid == 0:
+                scale_inv = tl.fdiv(1.0, scale)
+                tl.store(scale_inv_ptr, scale_inv)
             tl.atomic_max(amax_ptr, amax, sem="relaxed")
         else:
             tl.store(amax_ptr + pid, amax)
@@ -165,6 +169,8 @@ def _layernorm_fwd_triton(
 def _layernorm_fwd_reduce_triton(
     amax_input_ptr,
     amax_output_ptr,
+    scale_ptr,
+    scale_inv_ptr,
     n_rows,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -180,6 +186,11 @@ def _layernorm_fwd_reduce_triton(
     amax = tl.max(_amax, axis=-1)
 
     tl.atomic_max(amax_output_ptr, amax, sem="relaxed")
+
+    if pid == 0:
+        scale = tl.load(scale_ptr)
+        scale_inv = tl.fdiv(1.0, scale)
+        tl.store(scale_inv_ptr, scale_inv)
 
 
 @triton.jit
@@ -463,6 +474,7 @@ def te_layernorm_fwd_fp8_noalloc_triton(
         rsigma,
         scale,
         amax if APPLY_ATOMIC else amax_temp,
+        scale_inv,
         x.stride(0),
         y.stride(0),
         M,
@@ -482,13 +494,13 @@ def te_layernorm_fwd_fp8_noalloc_triton(
         _layernorm_fwd_reduce_triton[(triton.cdiv(M, 256),)](
             amax_temp,
             amax,
+            scale,
+            scale_inv,
             M,
             256,
         )
 
-    scale_inv = (1.0 / scale) if IS_FP8 else None
-
-    return y, mu, rsigma, scale_inv
+    return y, mu, rsigma
 
 
 # TODO: Add `sm_margin` to the interface.

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -8,7 +8,6 @@ import torch
 import triton
 import triton.language as tl
 
-from .norm_common_triton import block_size, use_blocked
 from .norm_common_triton import IS_FP8 as IS_FP8_COMMON
 
 
@@ -199,6 +198,7 @@ def _layernorm_bwd_dx_fused_triton(
     NUM_ROWS: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     USE_BLOCKED: tl.constexpr,
+    IGNORE_DW_DB: tl.constexpr = False,
 ):
     # Map the program id to the elements of X, DX, and DY it should compute.
     pid = tl.program_id(0)
@@ -263,8 +263,9 @@ def _layernorm_bwd_dx_fused_triton(
             # Compute dx and partial sums for dw and db:
 
             dx_row_ptr = DX + row * stride
-            dw_row_ptr = DW + pid * N
-            db_row_ptr = DB + pid * N
+            if not IGNORE_DW_DB:
+                dw_row_ptr = DW + pid * N
+                db_row_ptr = DB + pid * N
 
             for block_idx in tl.range(0, num_col_blocks):
                 cols = block_idx * BLOCK_SIZE_N + col_offsets
@@ -280,16 +281,16 @@ def _layernorm_bwd_dx_fused_triton(
 
                 dx = (wdy - (xhat * c1 + c2)) * rstd
                 tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty))
+                if not IGNORE_DW_DB:
+                    partial_dw = dy * xhat
+                    dw_ptrs = dw_row_ptr + cols
+                    partial_dw += tl.load(dw_ptrs).to(tl.float32)
+                    tl.store(dw_ptrs, partial_dw.to(DW.type.element_ty))
 
-                partial_dw = dy * xhat
-                dw_ptrs = dw_row_ptr + cols
-                partial_dw += tl.load(dw_ptrs)
-                tl.store(dw_ptrs, partial_dw)
-
-                partial_db = dy
-                db_ptrs = db_row_ptr + cols
-                partial_db += tl.load(db_ptrs)
-                tl.store(db_ptrs, partial_db)
+                    partial_db = dy
+                    db_ptrs = db_row_ptr + cols
+                    partial_db += tl.load(db_ptrs).to(tl.float32)
+                    tl.store(db_ptrs, partial_db.to(DB.type.element_ty))
 
             cols = num_col_blocks * BLOCK_SIZE_N + col_offsets
             mask = cols < N
@@ -307,16 +308,16 @@ def _layernorm_bwd_dx_fused_triton(
 
             dx = (wdy - (xhat * c1 + c2)) * rstd
             tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty), mask=mask)
+            if not IGNORE_DW_DB:
+                partial_dw = dy * xhat
+                dw_ptrs = dw_row_ptr + cols
+                partial_dw += tl.load(dw_ptrs, mask=mask).to(tl.float32)
+                tl.store(dw_ptrs, partial_dw.to(DW.type.element_ty), mask=mask)
 
-            partial_dw = dy * xhat
-            dw_ptrs = dw_row_ptr + cols
-            partial_dw += tl.load(dw_ptrs, mask=mask)
-            tl.store(dw_ptrs, partial_dw, mask=mask)
-
-            partial_db = dy
-            db_ptrs = db_row_ptr + cols
-            partial_db += tl.load(db_ptrs, mask=mask)
-            tl.store(db_ptrs, partial_db, mask=mask)
+                partial_db = dy
+                db_ptrs = db_row_ptr + cols
+                partial_db += tl.load(db_ptrs, mask=mask).to(tl.float32)
+                tl.store(db_ptrs, partial_db.to(DB.type.element_ty), mask=mask)
 
             # Advance to next row.
             row += tile_num
@@ -327,9 +328,9 @@ def _layernorm_bwd_dx_fused_triton(
         cols = tl.arange(0, BLOCK_SIZE_N)
         mask = cols < N
         row = pid
-
-        dw_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
-        db_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+        if not IGNORE_DW_DB:
+            dw_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+            db_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
 
         for _ in range(0, rows_per_tile):
             # Compute pointers:
@@ -357,16 +358,16 @@ def _layernorm_bwd_dx_fused_triton(
 
             # Write dx:
             tl.store(dx_ptrs + cols, dx.to(DX.type.element_ty), mask=mask)
-
-            # Accumulate partial sums for dw and db:
-            dw_row += dy * xhat
-            db_row += dy
+            if not IGNORE_DW_DB:
+                # Accumulate partial sums for dw and db:
+                dw_row += dy * xhat
+                db_row += dy
 
             # Advance to next row:
             row += tile_num
-
-        tl.store(DW + pid * N + cols, dw_row, mask=mask)
-        tl.store(DB + pid * N + cols, db_row, mask=mask)
+        if not IGNORE_DW_DB:
+            tl.store(DW + pid * N + cols, dw_row.to(DW.type.element_ty), mask=mask)
+            tl.store(DB + pid * N + cols, db_row.to(DB.type.element_ty), mask=mask)
 
 
 @triton.jit
@@ -392,6 +393,43 @@ def _layernorm_bwd_dwdb_triton(
         offs = rows[:, None] * N + cols[None, :]
         dw += tl.load(DW + offs, mask=mask, other=0.0)
         db += tl.load(DB + offs, mask=mask, other=0.0)
+    # Write the final sum to the output.
+    sum_dw = tl.sum(dw, axis=0)
+    sum_db = tl.sum(db, axis=0)
+    tl.store(FINAL_DW + cols, sum_dw.to(FINAL_DW.type.element_ty), mask=cols < N)
+    tl.store(FINAL_DB + cols, sum_db.to(FINAL_DB.type.element_ty), mask=cols < N)
+
+
+@triton.jit
+def _layernorm_bwd_dwdb_triton_v2(
+    X,  # pointer to the input
+    DY,  # pointer to the output gradient
+    Mean,  # pointer to the mean
+    Rstd,  # pointer to the 1/std
+    stride,
+    FINAL_DW,  # pointer to the weights gradient
+    FINAL_DB,  # pointer to the biases gradient
+    M,  # GROUP_SIZE_M
+    N,  # number of columns
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    db = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    # Iterate through the rows of x and dy to compute dw and db
+    for i in range(0, M, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        means = tl.load(Mean + rows, mask=rows < M, other=0.0).to(tl.float32)
+        rstds = tl.load(Rstd + rows, mask=rows < M, other=0.0).to(tl.float32)
+        mask = (rows[:, None] < M) & (cols[None, :] < N)
+        offs = rows[:, None] * stride + cols[None, :]
+        x = tl.load(X + offs, mask=mask, other=0.0).to(tl.float32)
+        dy = tl.load(DY + offs, mask=mask, other=0.0).to(tl.float32)
+        xhat = (x - means[:, None]) * rstds[:, None]
+        dw += dy * xhat
+        db += dy
     # Write the final sum to the output.
     sum_dw = tl.sum(dw, axis=0)
     sum_db = tl.sum(db, axis=0)
@@ -456,17 +494,34 @@ def te_layernorm_fwd_fp8_noalloc_triton(
 # TODO: Add `sm_margin` to the interface.
 def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
     M, N = x.shape
-
-    BLOCK_SIZE = block_size(x)
-    num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+    # calculate dw and db separately when M is small
+    IGNORE_DW_DB_IN_FUSED = M <= 512
     tile_num = max(min(256, M // 4), 1)
+    if M <= 512 and M * N < 64 * 1024 * 1024:
+        tile_num = M
+    elif M >= 8192:
+        tile_num = 2048
+    max_fused_size = 32768 // x.element_size()
+    next_power = triton.next_power_of_2(N)
+    BLOCK_SIZE = min(max_fused_size, next_power)
+    # For cases with small M and large N, decrease block size to help with occupancy and register spill
+    if tile_num == M:
+        if tile_num > 256:
+            BLOCK_SIZE = min(BLOCK_SIZE, 2048)
+        else:
+            BLOCK_SIZE = min(BLOCK_SIZE, 4096)
+    USE_BLOCKED = N > BLOCK_SIZE
+    num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
 
     dx = torch.empty_like(x)
-    _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
-    _dbeta = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
-    dgamma = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
-    dbeta = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
-
+    if not IGNORE_DW_DB_IN_FUSED:
+        _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+        _dbeta = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+    else:
+        _dgamma = None
+        _dbeta = None
+    dgamma = torch.zeros((N,), dtype=gamma.dtype, device=gamma.device)
+    dbeta = torch.zeros((N,), dtype=gamma.dtype, device=gamma.device)
     grid_bwd = (tile_num,)
     _layernorm_bwd_dx_fused_triton[grid_bwd](
         dx,
@@ -482,20 +537,43 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
         ZERO_CENTERED_GAMMA=zero_centered_gamma,
         NUM_ROWS=M,
         BLOCK_SIZE_N=BLOCK_SIZE,
-        USE_BLOCKED=use_blocked(x),
+        USE_BLOCKED=USE_BLOCKED,
         num_warps=num_warps,
+        IGNORE_DW_DB=IGNORE_DW_DB_IN_FUSED,
     )
-
     grid_reduce = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE_N"]),)
-    _layernorm_bwd_dwdb_triton[grid_reduce](
-        _dgamma,
-        _dbeta,
-        dgamma,
-        dbeta,
-        min(tile_num, M),
-        N,
-        BLOCK_SIZE_M=32,
-        BLOCK_SIZE_N=128,
-    )
+    if not IGNORE_DW_DB_IN_FUSED:
+        dwdb_block_n = max(16, N // 256)
+        dwdb_block_n = triton.next_power_of_2(dwdb_block_n)
+        dwdb_block_m = (64 * 128) // dwdb_block_n
+        dwdb_block_m = min(triton.next_power_of_2(tile_num), dwdb_block_m)
+        _layernorm_bwd_dwdb_triton[grid_reduce](
+            _dgamma,
+            _dbeta,
+            dgamma,
+            dbeta,
+            min(tile_num, M),
+            N,
+            BLOCK_SIZE_M=dwdb_block_m,
+            BLOCK_SIZE_N=dwdb_block_n,
+        )
+    else:
+        dwdb_block_n = max(16, N // 256)
+        dwdb_block_n = triton.next_power_of_2(dwdb_block_n)
+        dwdb_block_m = (64 * 128) // dwdb_block_n
+        dwdb_block_m = min(triton.next_power_of_2(M), dwdb_block_m)
+        _layernorm_bwd_dwdb_triton_v2[grid_reduce](
+            x,
+            dz,
+            mu,
+            rsigma,
+            x.stride(0),
+            dgamma,
+            dbeta,
+            M,
+            N,
+            BLOCK_SIZE_M=dwdb_block_m,
+            BLOCK_SIZE_N=dwdb_block_n,
+        )
 
     return dx, dgamma, dbeta

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -7,7 +7,7 @@ from itertools import product
 import torch
 import triton
 import triton.language as tl
-
+import warnings
 from .norm_common_triton import IS_FP8 as IS_FP8_COMMON
 
 
@@ -442,8 +442,23 @@ def _layernorm_bwd_dwdb_triton_v2(
 
 # TODO: Implement persistent kernel in forward and add `sm_margin` to the interface.
 def te_layernorm_fwd_fp8_noalloc_triton(
-    x, gamma, beta, eps, scale, y, amax, scale_inv, out_dtype, zero_centered_gamma
+    x,
+    gamma,
+    beta,
+    eps,
+    scale,
+    y,
+    amax,
+    scale_inv,
+    out_dtype,
+    sm_margin,
+    zero_centered_gamma,
 ):
+    if sm_margin is not None and sm_margin > 0:
+        warnings.warn(
+            '"sm_margin" is not supported in the Triton based forward layer-norm kernel. '
+            + f"sm_margin={sm_margin} will be ignored."
+        )
     M, N = x.shape
     y = y.view(out_dtype)
     IS_FP8 = IS_FP8_COMMON(out_dtype)
@@ -496,7 +511,12 @@ def te_layernorm_fwd_fp8_noalloc_triton(
 
 
 # TODO: Add `sm_margin` to the interface.
-def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
+def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma):
+    if sm_margin is not None and sm_margin > 0:
+        warnings.warn(
+            '"sm_margin" is not supported in the Triton based backward layer-norm kernel. '
+            + f"sm_margin={sm_margin} will be ignored."
+        )
     M, N = x.shape
     # calculate dw and db separately when M is small
     IGNORE_DW_DB_IN_FUSED = M <= 512

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -9,6 +9,7 @@ import triton
 import triton.language as tl
 
 from .norm_common_triton import block_size, use_blocked
+from .norm_common_triton import IS_FP8 as IS_FP8_COMMON
 
 
 def get_autotune_config(full_tuning_space=False):
@@ -33,6 +34,8 @@ def _layernorm_fwd_triton(
     b_ptr,
     mean_ptr,
     rstd_ptr,
+    scale_ptr,
+    amax_ptr,
     x_row_stride,
     y_row_stride,
     n_rows,
@@ -40,80 +43,144 @@ def _layernorm_fwd_triton(
     eps,
     ZERO_CENTERED_GAMMA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    IS_FP8: tl.constexpr,
+    APPLY_ATOMIC: tl.constexpr,
+    PERSISTENT: tl.constexpr,
 ):
 
     # program id
-    row = tl.program_id(0)
-    x_ptr_start = x_ptr + (row * x_row_stride)
-    y_ptr_start = y_ptr + (row * y_row_stride)
+    pid = tl.program_id(0)
+    num_tiles = tl.num_programs(0)
 
-    loop_num = tl.cdiv(n_cols, BLOCK_SIZE) - 1
+    if PERSISTENT:
+        rows_per_tile = n_rows // num_tiles
+        if pid < n_rows % num_tiles:
+            rows_per_tile += 1
+            start_row = rows_per_tile * pid
+        else:
+            start_row = (rows_per_tile * pid) + (n_rows % num_tiles)
+    else:
+        rows_per_tile = 1
+        start_row = pid
 
-    # calculate mean
-    mean = 0
-    _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-    loop_num_l = loop_num
-    for b in range(0, loop_num_l):
-        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)  # Unmasked loads
+    if IS_FP8:
+        scale = tl.load(scale_ptr)
+        amax = 0.0
+
+    for row in range(start_row, start_row + rows_per_tile):
+        x_ptr_start = x_ptr + (row * x_row_stride)
+        y_ptr_start = y_ptr + (row * y_row_stride)
+
+        loop_num = tl.cdiv(n_cols, BLOCK_SIZE) - 1
+
+        # calculate mean
+        mean = 0
+        _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        loop_num_l = loop_num
+        for b in range(0, loop_num_l):
+            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            x_block = tl.load(x_ptr_start + col_offsets).to(
+                tl.float32
+            )  # Unmasked loads
+            _mean += x_block
+
+        # For last iteration, do masked load
+        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x_block = tl.load(
+            x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
+        ).to(tl.float32)
         _mean += x_block
+        mean = tl.sum(_mean, axis=0) / n_cols
 
-    # For last iteration, do masked load
-    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    x_block = tl.load(
-        x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
-    ).to(tl.float32)
-    _mean += x_block
-    mean = tl.sum(_mean, axis=0) / n_cols
+        # variance
+        _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        loop_num_l = loop_num
+        for b in range(0, loop_num_l):
+            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            x_block = tl.load(x_ptr_start + col_offsets).to(
+                tl.float32
+            )  # Unmasked loads
+            x_block = x_block - mean
+            _var += x_block * x_block
 
-    # variance
-    _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-    loop_num_l = loop_num
-    for b in range(0, loop_num_l):
-        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)  # Unmasked loads
-        x_block = x_block - mean
+        # For last iteration, do masked load
+        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x_block = tl.load(
+            x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
+        ).to(tl.float32)
+        x_block = tl.where(col_offsets < n_cols, x_block - mean, 0.0)
         _var += x_block * x_block
 
-    # For last iteration, do masked load
-    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    x_block = tl.load(
-        x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
-    ).to(tl.float32)
-    x_block = tl.where(col_offsets < n_cols, x_block - mean, 0.0)
-    _var += x_block * x_block
+        var = tl.sum(_var, axis=0) / n_cols
+        rstd = tl.rsqrt(var + eps)
 
-    var = tl.sum(_var, axis=0) / n_cols
-    rstd = tl.rsqrt(var + eps)
+        # Write mean / rstd
+        tl.store(mean_ptr + row, mean)
+        tl.store(rstd_ptr + row, rstd)
 
-    # Write mean / rstd
-    tl.store(mean_ptr + row, mean)
-    tl.store(rstd_ptr + row, rstd)
+        # Normalize and store
+        loop_num_l = loop_num
+        for b in range(0, loop_num_l):
+            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            w_block = tl.load(w_ptr + col_offsets).to(tl.float32)
+            b_block = tl.load(b_ptr + col_offsets).to(tl.float32)
+            x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)
+            if ZERO_CENTERED_GAMMA:
+                w_block += 1
+            y_block = (x_block - mean) * rstd
+            y_block = y_block * w_block + b_block
+            if IS_FP8:
+                amax_temp = tl.max(tl.abs(y_block), axis=-1)
+                amax = amax_temp if amax_temp > amax else amax
+                y_block = y_block * scale
+            tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty))
 
-    # Normalize and store
-    loop_num_l = loop_num
-    for b in range(0, loop_num_l):
-        col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        w_block = tl.load(w_ptr + col_offsets).to(tl.float32)
-        b_block = tl.load(b_ptr + col_offsets).to(tl.float32)
-        x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)
+        # For last iteration, do masked load and store
+        col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = col_offsets < n_cols
+        w_block = tl.load(w_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+        b_block = tl.load(b_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+        x_block = tl.load(x_ptr_start + col_offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
         if ZERO_CENTERED_GAMMA:
             w_block += 1
         y_block = (x_block - mean) * rstd
         y_block = y_block * w_block + b_block
-        tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty))
+        if IS_FP8:
+            amax_temp = tl.max(tl.abs(y_block), axis=-1)
+            amax = amax_temp if amax_temp > amax else amax
+            y_block = y_block * scale
+        tl.store(
+            y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty), mask=mask
+        )
 
-    # For last iteration, do masked load and store
-    col_offsets = loop_num_l * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = col_offsets < n_cols
-    w_block = tl.load(w_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-    b_block = tl.load(b_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-    x_block = tl.load(x_ptr_start + col_offsets, mask=mask, other=0.0).to(tl.float32)
-    if ZERO_CENTERED_GAMMA:
-        w_block += 1
-    y_block = (x_block - mean) * rstd
-    y_block = y_block * w_block + b_block
-    tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty), mask=mask)
+    if IS_FP8:
+        if APPLY_ATOMIC:
+            tl.atomic_max(amax_ptr, amax, sem="relaxed")
+        else:
+            tl.store(amax_ptr + pid, amax)
+
+
+@triton.jit
+def _layernorm_fwd_reduce_triton(
+    amax_input_ptr,
+    amax_output_ptr,
+    n_rows,
+    BLOCK_SIZE: tl.constexpr,
+):
+
+    # program id
+    pid = tl.program_id(0)
+
+    amax_offs = tl.arange(0, BLOCK_SIZE) + (pid * BLOCK_SIZE)
+    amax_input_ptrs = amax_input_ptr + amax_offs
+    amax_mask = amax_offs < n_rows
+    _amax = tl.load(amax_input_ptrs, mask=amax_mask, other=0.0)
+
+    amax = tl.max(_amax, axis=-1)
+
+    tl.atomic_max(amax_output_ptr, amax, sem="relaxed")
 
 
 @triton.jit
@@ -334,14 +401,21 @@ def _layernorm_bwd_dwdb_triton(
 
 # TODO: Implement persistent kernel in forward and add `sm_margin` to the interface.
 def te_layernorm_fwd_fp8_noalloc_triton(
-    x, gamma, beta, eps, y, out_dtype, zero_centered_gamma
+    x, gamma, beta, eps, scale, y, amax, scale_inv, out_dtype, zero_centered_gamma
 ):
     M, N = x.shape
     y = y.view(out_dtype)
+    IS_FP8 = IS_FP8_COMMON(out_dtype)
     mu = torch.empty((M,), dtype=torch.float32, device=x.device)
     rsigma = torch.empty((M,), dtype=torch.float32, device=x.device)
+    amax_temp = (
+        torch.empty((M,), dtype=torch.float32, device=x.device) if IS_FP8 else None
+    )
 
-    BLOCK_SIZE = block_size(x)
+    APPLY_ATOMIC = M < 512
+
+    max_fused_size = 16384 // x.element_size()
+    BLOCK_SIZE = min(max_fused_size, triton.next_power_of_2(x.shape[1]))
     _layernorm_fwd_triton[(M,)](
         x,
         y,
@@ -349,6 +423,8 @@ def te_layernorm_fwd_fp8_noalloc_triton(
         beta,
         mu,
         rsigma,
+        scale,
+        amax if APPLY_ATOMIC else amax_temp,
         x.stride(0),
         y.stride(0),
         M,
@@ -356,9 +432,25 @@ def te_layernorm_fwd_fp8_noalloc_triton(
         eps,
         ZERO_CENTERED_GAMMA=zero_centered_gamma,
         BLOCK_SIZE=BLOCK_SIZE,
+        IS_FP8=IS_FP8,
+        APPLY_ATOMIC=APPLY_ATOMIC,
+        # TODO: Improve performance with persistent kernel
+        # Persistent kernel currently lags behind non persistent version
+        # It also lags behind TE implementation in a few cases
+        PERSISTENT=False,
     )
 
-    return y, mu, rsigma
+    if IS_FP8 and not APPLY_ATOMIC:
+        _layernorm_fwd_reduce_triton[(triton.cdiv(M, 256),)](
+            amax_temp,
+            amax,
+            M,
+            256,
+        )
+
+    scale_inv = (1.0 / scale) if IS_FP8 else None
+
+    return y, mu, rsigma, scale_inv
 
 
 # TODO: Add `sm_margin` to the interface.

--- a/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+import os
+
+import torch
+import triton
+
+
+def get_ln_sm_margin(sm_margin_type):
+    assert sm_margin_type in {"FWD", "BWD", "INF"}
+    try:
+        sm_margin = max(
+            int(os.getenv(f"NVTE_{sm_margin_type}_LAYERNORM_SM_MARGIN", "0")), 0
+        )
+    except ValueError:
+        sm_margin = 0
+    assert sm_margin >= 0
+    return sm_margin
+
+
+def get_fwd_ln_sm_margin():
+    return get_ln_sm_margin("FWD")
+
+
+def get_bwd_ln_sm_margin():
+    return get_ln_sm_margin("BWD")
+
+
+def get_inf_ln_sm_margin():
+    return get_ln_sm_margin("INF")
+
+
+def get_num_sms(sm_margin=None):
+    num_sms = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+    if sm_margin is not None and sm_margin > 0:
+        num_sms = max(num_sms - int(sm_margin), 1)
+    return num_sms
+
+
+def num_programs(x, sm_margin=None):
+    return min(x.shape[0], get_num_sms(sm_margin))
+
+
+def block_size(x):
+    max_fused_size = 65536 // x.element_size()
+    block_size = min(max_fused_size, triton.next_power_of_2(x.shape[1]))
+    return block_size
+
+
+def use_blocked(x):
+    return x.shape[1] > block_size(x)

--- a/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
@@ -8,6 +8,18 @@ import torch
 import triton
 
 
+def is_cdna4():
+    return triton.runtime.driver.active.get_current_target().arch == "gfx950"
+
+
+e4m3_type = torch.float8_e4m3fn if is_cdna4() else torch.float8_e4m3fnuz
+e5m2_type = torch.float8_e5m2 if is_cdna4() else torch.float8_e5m2fnuz
+
+
+def IS_FP8(dtype):
+    return (dtype == e4m3_type) or (dtype == e5m2_type)
+
+
 def get_ln_sm_margin(sm_margin_type):
     assert sm_margin_type in {"FWD", "BWD", "INF"}
     try:

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm_triton.py
@@ -7,24 +7,7 @@ import triton
 import triton.language as tl
 from itertools import product
 
-
-def get_num_sms(sm_margin=None):
-    num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-    if sm_margin is not None and sm_margin > 0:
-        num_sms = max(num_sms - sm_margin, 1)
-    return num_sms
-
-
-def num_programs(x, sm_margin=None):
-    return min(x.shape[0], get_num_sms(sm_margin))
-
-
-def block_size(x):
-    return min(65536 // x.element_size(), triton.next_power_of_2(x.shape[1]))
-
-
-def use_blocked(x):
-    return x.shape[1] > block_size(x)
+from .norm_common_triton import num_programs, block_size, use_blocked
 
 
 def dg_tmp_rows(x, sm_margin=None):


### PR DESCRIPTION
# Description

This PR adds LayerNorm forward and backward Triton kernels (developed by Triton Kernels team) to Transformer Engine.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add forward and backward LayerNorm Triton kernels for `fp32`, `fp16` and `bf16` data types. `fp8` isn't yet supported. Forward performance on MI300X is better or equal to TE CUDA implementation on H100. Backward performance on MI300X still lags behind TE CUDA implementation on H100.
- Add unit test that compares Triton LayerNorm implementation with Hipified TE reference implementation.
- Promote code reuse between RMSNorm and LayerNorm TE Triton kernels.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
