### PR TITLE
Add definition for te_fp8_fnuz when ROCm version is 6.2

### DIFF
--- a/transformer_engine/common/amd_detail/hip_float8.h
+++ b/transformer_engine/common/amd_detail/hip_float8.h
@@ -79,6 +79,7 @@ static inline bool te_fp8_fnuz() { return false; }
 #else //HIP_VERSION >= 60300000
 typedef __hip_fp8_e4m3_fnuz _te_hip_fp8_e4m3;
 typedef __hip_fp8_e5m2_fnuz _te_hip_fp8_e5m2;
+static inline bool te_fp8_fnuz() { return true; }
 #endif //HIP_VERSION >= 60300000
 
 struct te_hip_fp8_e4m3 {  


### PR DESCRIPTION
# Description

Before https://github.com/ROCm/clr/commit/353f15afa6cfb0fc1eebbc618be47e0cb639c321 (In ROCm6.2), FP8 OCP is not added and the code implementation is in FNUZ, so we define `te_fp8_fnuz()` to return true, to fix the following error:

```logs
transformer_engine/common/recipe/delayed_scaling.hip:42:14: error: use of undeclared identifier 'te_fp8_fnuz'
     42 |       return te_fp8_fnuz() ? 240 : 448;
        |              ^
  1 error generated when compiling for gfx90a.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Define `te_fp8_fnuz` for ROCm 6.2

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
