### PR TITLE
Added support for different layout formats for A,B matrices

### DIFF
--- a/ci/core.sh
+++ b/ci/core.sh
@@ -35,7 +35,7 @@ for _gemm in hipblaslt rocblas; do
     configure_gemm_env $_gemm || continue
     _exclude=""
     if [ $_gemm = "hipblaslt" ]; then
-        _exclude="-E Test(.*bf16/.*X.X1|.*fp8.*fp16/.*X1X0|.*fp8.*X.X1|.*fp8/|.*bf8/)"
+        _exclude="-E Test(.*XTX.|.*XNXT|.*bf16/.*X.X1|.*fp8.*fp16/.*X1X0|.*fp8.*X.X1|.*fp8/|.*bf8/)"
     fi
     check_test_filter $_gemm
     if [ $? -eq 0 ]; then

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -35,7 +35,9 @@ for _gemm in hipblaslt rocblas; do
     configure_gemm_env $_gemm || continue
     _exclude=""
     if [ $_gemm = "hipblaslt" ]; then
-        _exclude="-E Test(.*XTX.|.*XNXT|.*bf16/.*X.X1|.*fp8.*fp16/.*X1X0|.*fp8.*X.X1|.*fp8/|.*bf8/)"
+        _exclude="-E Test(.*XTN|.*XNT|.*bf16/.*X.X1|.*fp8.*fp16/.*X1X0|.*fp8.*X.X1|.*fp8/|.*bf8/)"
+    else
+        _exclude="-E Test(.*XTN|.*XNT)"
     fi
     check_test_filter $_gemm
     if [ $? -eq 0 ]; then

--- a/tests/cpp/operator/test_cublaslt_gemm.cu
+++ b/tests/cpp/operator/test_cublaslt_gemm.cu
@@ -58,7 +58,7 @@ std::vector<std::tuple<size_t, size_t, size_t>> test_case_sizes = {
 // <A_type, B_type, Bias_Type, Gelu_Type D_type>, <m, k, n>
 class GEMMTestSuite 
   :public ::testing::TestWithParam<std::tuple<
-                                    std::tuple<size_t, size_t, size_t>, bool, bool>>{};
+                                    std::tuple<size_t, size_t, size_t>, bool, bool, bool, bool>>{};
 
 float ref_gelu(float x){
   float cdf = 0.5f * (1.0f + tanhf((0.7978845608028654f * (x + 0.044715f * x * x * x))));
@@ -87,7 +87,7 @@ void compute_ref(
       for(size_t kk = 0; kk < k; kk++){
         float a_val = transa ? (float)a_data[kk + ii*k] : (float)a_data[ii + kk*m];
         float b_val = transb ? (float)b_data[jj + kk*n] : (float)b_data[kk + jj*k];
-        val += a_scale_inv*b_scale_inv*a_val*b_val;
+        val += a_scale_inv*a_val*b_scale_inv*b_val;
       }
       if(bias_data){
         val += (float)bias_data[ii];
@@ -115,13 +115,19 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
   DType dtype = TypeInfo<D_Type>::dtype;
 
   // pytorch tensor storage is row-major while cublas/rocblas is column-major
-  Tensor A({ k, m }, atype);
+  Tensor A;
   if (transa){
     A = Tensor({ m, k }, atype);
   }
-  Tensor B({ n, k }, btype);
+  else {
+    A = Tensor({ k, m }, atype);
+  }
+  Tensor B;
   if (transb){
-    B = Tensor({ k, n }, atype);
+    B = Tensor({ k, n }, btype);
+  }
+  else {
+    B = Tensor({ n, k }, btype);
   }
   Tensor D({ n, m }, dtype);
   Tensor bias;
@@ -265,6 +271,8 @@ TEST_P(GEMMTestSuite, Testfp32xfp32xfp32xfp32xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp32;
   using B_Type = fp32;
@@ -272,7 +280,7 @@ TEST_P(GEMMTestSuite, Testfp32xfp32xfp32xfp32xfp32) {
   using Gelu_Type = fp32;
   using D_Type = fp32;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp16xfp16xfp16xfp16xfp16) {
@@ -284,6 +292,8 @@ TEST_P(GEMMTestSuite, Testfp16xfp16xfp16xfp16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp16;
   using B_Type = fp16;
@@ -291,7 +301,7 @@ TEST_P(GEMMTestSuite, Testfp16xfp16xfp16xfp16xfp16) {
   using Gelu_Type = fp16;
   using D_Type = fp16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf16xbf16xbf16xbf16xbf16) {
@@ -303,6 +313,8 @@ TEST_P(GEMMTestSuite, Testbf16xbf16xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf16;
   using B_Type = bf16;
@@ -310,7 +322,7 @@ TEST_P(GEMMTestSuite, Testbf16xbf16xbf16xbf16xbf16) {
   using Gelu_Type = bf16;
   using D_Type = bf16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp32) {
@@ -322,6 +334,8 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -329,7 +343,7 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp32) {
   using Gelu_Type = bf16;
   using D_Type = fp32;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp16) {
@@ -341,6 +355,8 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -348,7 +364,7 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp16) {
   using Gelu_Type = bf16;
   using D_Type = fp16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf16) {
@@ -360,6 +376,8 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -367,7 +385,7 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf16) {
   using Gelu_Type = bf16;
   using D_Type = bf16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp8) {
@@ -379,6 +397,8 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -386,7 +406,7 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp8) {
   using Gelu_Type = bf16;
   using D_Type = fp8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf8) {
@@ -398,6 +418,8 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -405,7 +427,7 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf8) {
   using Gelu_Type = bf16;
   using D_Type = bf8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp32) {
@@ -417,6 +439,8 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -424,7 +448,7 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp32) {
   using Gelu_Type = bf16;
   using D_Type = fp32;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp16) {
@@ -436,6 +460,8 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -443,7 +469,7 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp16) {
   using Gelu_Type = bf16;
   using D_Type = fp16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf16) {
@@ -455,6 +481,8 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -462,7 +490,7 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf16) {
   using Gelu_Type = bf16;
   using D_Type = bf16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp8) {
@@ -474,6 +502,8 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -481,7 +511,7 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp8) {
   using Gelu_Type = bf16;
   using D_Type = fp8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf8) {
@@ -493,6 +523,8 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -500,7 +532,7 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf8) {
   using Gelu_Type = bf16;
   using D_Type = bf8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp32) {
@@ -512,6 +544,8 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -519,7 +553,7 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp32) {
   using Gelu_Type = bf16;
   using D_Type = fp32;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp16) {
@@ -531,6 +565,8 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -538,7 +574,7 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp16) {
   using Gelu_Type = bf16;
   using D_Type = fp16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf16) {
@@ -550,6 +586,8 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -557,7 +595,7 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf16) {
   using Gelu_Type = bf16;
   using D_Type = bf16;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp8) {
@@ -569,6 +607,8 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -576,7 +616,7 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp8) {
   using Gelu_Type = bf16;
   using D_Type = fp8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf8) {
@@ -588,6 +628,8 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
+  const bool transa = std::get<3>(GetParam());
+  const bool transb = std::get<4>(GetParam());
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -595,7 +637,7 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf8) {
   using Gelu_Type = bf16;
   using D_Type = bf8;
 
-  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n);
+  performTest<A_Type, B_Type, Bias_Type, Gelu_Type, D_Type>(use_bias, use_gelu, m, k, n, transa, transb);
 }
 
 
@@ -605,12 +647,16 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(test_case_sizes),
         ::testing::Values(false, true), //use bias
-        ::testing::Values(false, true)), //use_gelu
+        ::testing::Values(false, true), //use_gelu
+        ::testing::Values(false, true), //transa
+        ::testing::Values(false, true)), //transb
     [](const testing::TestParamInfo<GEMMTestSuite::ParamType>& info) {
+      auto TN = [](bool v){ return v ? "T" : "N"; };
       std::string name = std::to_string(std::get<0>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<1>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<2>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<1>(info.param)) + "X" +
-                         std::to_string(std::get<2>(info.param));
+                         std::to_string(std::get<2>(info.param)) + "X" +
+                         TN(std::get<3>(info.param)) + "X" + TN(std::get<4>(info.param));
       return name;
     });

--- a/tests/cpp/operator/test_cublaslt_gemm.cu
+++ b/tests/cpp/operator/test_cublaslt_gemm.cu
@@ -76,14 +76,18 @@ void compute_ref(
   size_t m, size_t k, size_t n,
   D_Type* ref_d_data,
   float* ref_d_amax,
-  Gelu_Type* ref_gelu_data){
+  Gelu_Type* ref_gelu_data,
+  bool transa,
+  bool transb){
 
   *ref_d_amax = 0;
   for(size_t ii = 0; ii < m; ii++){
     for(size_t jj = 0; jj < n; jj++){
       float val = 0;
       for(size_t kk = 0; kk < k; kk++){
-        val += a_scale_inv*b_scale_inv*((float)a_data[ii + kk*m])*((float)b_data[kk + jj*k]);
+        float a_val = transa ? (float)a_data[kk + ii*k] : (float)a_data[ii + kk*m];
+        float b_val = transb ? (float)b_data[jj + kk*n] : (float)b_data[kk + jj*k];
+        val += a_scale_inv*b_scale_inv*a_val*b_val;
       }
       if(bias_data){
         val += (float)bias_data[ii];
@@ -103,7 +107,7 @@ void compute_ref(
 }
 
 template <typename A_Type, typename B_Type, typename Bias_Type, typename Gelu_Type, typename D_Type>
-void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, const size_t n) {
+void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, const size_t n, bool transa = false, bool transb = false) {
   DType atype = TypeInfo<A_Type>::dtype;
   DType btype = TypeInfo<B_Type>::dtype;
   DType bias_type = TypeInfo<Bias_Type>::dtype;
@@ -112,7 +116,13 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
 
   // pytorch tensor storage is row-major while cublas/rocblas is column-major
   Tensor A({ k, m }, atype);
+  if (transa){
+    A = Tensor({ m, k }, atype);
+  }
   Tensor B({ n, k }, btype);
+  if (transb){
+    B = Tensor({ k, n }, atype);
+  }
   Tensor D({ n, m }, dtype);
   Tensor bias;
   if(use_bias){
@@ -133,8 +143,6 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
   if(isFp8Type(dtype)){
     setRandomScale(&D);
   }
-  bool transa = false;
-  bool transb = false;
   bool grad = false;
   bool accumulate = false;
 
@@ -201,7 +209,9 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
     m, k, n,
     ref_D.get(),
     &ref_amax_d,
-    use_gelu? ref_pre_gelu_out.get(): nullptr);
+    use_gelu? ref_pre_gelu_out.get(): nullptr,
+    transa,
+    transb);
   // check if error message happens in running                             
   (void)cudaDeviceSynchronize();
   auto err = cudaGetLastError();

--- a/tests/cpp/operator/test_cublaslt_gemm.cu
+++ b/tests/cpp/operator/test_cublaslt_gemm.cu
@@ -125,8 +125,8 @@ void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, c
    *    no fp8       → allow NN, TN, NT
    */
   if (has_fp8 && transb) {
-      GTEST_SKIP();
-    }
+    GTEST_SKIP();
+  }
   // pytorch tensor storage is row-major while cublas/rocblas is column-major
   Tensor A;
   if (transa){

--- a/tests/cpp/operator/test_cublaslt_gemm.cu
+++ b/tests/cpp/operator/test_cublaslt_gemm.cu
@@ -54,11 +54,16 @@ std::vector<std::tuple<size_t, size_t, size_t>> test_case_sizes = {
 }  // namespace
 
 
+using Layout = std::pair<bool,bool>;// {transa, transb}
+static const Layout kNN{false,false};
+static const Layout kTN{true ,false};
+static const Layout kNT{false,true };
 
+static const std::vector<Layout> kLayouts = { kNN, kTN, kNT };
 // <A_type, B_type, Bias_Type, Gelu_Type D_type>, <m, k, n>
 class GEMMTestSuite 
   :public ::testing::TestWithParam<std::tuple<
-                                    std::tuple<size_t, size_t, size_t>, bool, bool, bool, bool>>{};
+                                    std::tuple<size_t, size_t, size_t>, bool, bool, Layout>>{};
 
 float ref_gelu(float x){
   float cdf = 0.5f * (1.0f + tanhf((0.7978845608028654f * (x + 0.044715f * x * x * x))));
@@ -107,13 +112,21 @@ void compute_ref(
 }
 
 template <typename A_Type, typename B_Type, typename Bias_Type, typename Gelu_Type, typename D_Type>
-void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, const size_t n, bool transa = false, bool transb = false) {
+void performTest(bool use_bias, bool use_gelu, const size_t m, const size_t k, const size_t n, bool transa, bool transb) {
   DType atype = TypeInfo<A_Type>::dtype;
   DType btype = TypeInfo<B_Type>::dtype;
   DType bias_type = TypeInfo<Bias_Type>::dtype;
   DType gelu_type = TypeInfo<Gelu_Type>::dtype;
   DType dtype = TypeInfo<D_Type>::dtype;
 
+  const bool has_fp8 = isFp8Type(atype) || isFp8Type(btype);
+  /* 
+   *    fp8 present  → allow NN, TN   
+   *    no fp8       → allow NN, TN, NT
+   */
+  if (has_fp8 && transb) {
+      GTEST_SKIP();
+    }
   // pytorch tensor storage is row-major while cublas/rocblas is column-major
   Tensor A;
   if (transa){
@@ -271,8 +284,9 @@ TEST_P(GEMMTestSuite, Testfp32xfp32xfp32xfp32xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp32;
   using B_Type = fp32;
@@ -292,8 +306,9 @@ TEST_P(GEMMTestSuite, Testfp16xfp16xfp16xfp16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp16;
   using B_Type = fp16;
@@ -313,8 +328,9 @@ TEST_P(GEMMTestSuite, Testbf16xbf16xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf16;
   using B_Type = bf16;
@@ -334,8 +350,9 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -355,8 +372,9 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -376,8 +394,9 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -397,8 +416,9 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -418,8 +438,9 @@ TEST_P(GEMMTestSuite, Testfp8xfp8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = fp8;
@@ -439,8 +460,9 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -460,8 +482,9 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -481,8 +504,9 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -502,8 +526,9 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -523,8 +548,9 @@ TEST_P(GEMMTestSuite, Testfp8xbf8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = fp8;
   using B_Type = bf8;
@@ -544,8 +570,9 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp32) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -565,8 +592,9 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -586,8 +614,9 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf16) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -607,8 +636,9 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xfp8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -628,8 +658,9 @@ TEST_P(GEMMTestSuite, Testbf8xfp8xbf16xbf16xbf8) {
   const size_t n = std::get<2>(std::get<0>(GetParam()));
   const bool use_bias = std::get<1>(GetParam());
   const bool use_gelu = std::get<2>(GetParam());
-  const bool transa = std::get<3>(GetParam());
-  const bool transb = std::get<4>(GetParam());
+  const Layout layout  = std::get<3>(GetParam());
+  const bool transa = layout.first;
+  const bool transb = layout.second;
 
   using A_Type = bf8;
   using B_Type = fp8;
@@ -648,15 +679,15 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(test_case_sizes),
         ::testing::Values(false, true), //use bias
         ::testing::Values(false, true), //use_gelu
-        ::testing::Values(false, true), //transa
-        ::testing::Values(false, true)), //transb
+        ::testing::ValuesIn(kLayouts)),//transa,transb
     [](const testing::TestParamInfo<GEMMTestSuite::ParamType>& info) {
       auto TN = [](bool v){ return v ? "T" : "N"; };
+      const auto layout = std::get<3>(info.param);
       std::string name = std::to_string(std::get<0>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<1>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<2>(std::get<0>(info.param))) + "X" +
                          std::to_string(std::get<1>(info.param)) + "X" +
                          std::to_string(std::get<2>(info.param)) + "X" +
-                         TN(std::get<3>(info.param)) + "X" + TN(std::get<4>(info.param));
+                         TN(layout.first) + TN(layout.second);
       return name;
     });

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1044,6 +1044,8 @@ void hipblaslt_gemm(const Tensor *inputA,
   void *B = inputB->data.dptr;
   void *B_scale_inverse = inputB->scale_inv.dptr;
   void *D = outputD->data.dptr;
+  // void *D_amax = outputD->amax.dptr;
+  // void *D_scale = outputD->scale.dptr;
   void *bias_ptr = inputBias->data.dptr;
   const bool bias = bias_ptr != nullptr;
   void *pre_gelu_out = outputPreGelu->data.dptr;
@@ -1054,6 +1056,7 @@ void hipblaslt_gemm(const Tensor *inputA,
   const hipDataType B_type = get_hipblaslt_dtype(inputB->data.dtype);
   const hipDataType D_type = get_hipblaslt_dtype(outputD->data.dtype);
   const hipDataType bias_type = get_hipblaslt_dtype(inputBias->data.dtype);
+  // const hipblasltDatatype_t aux_type = get_hipblaslt_dtype(outputPreGelu->data.dtype);
 
   NVTE_CHECK(!is_fp8_dtype(inputA->data.dtype) || A_scale_inverse != nullptr,
              "FP8 input to GEMM requires inverse of scale!");
@@ -1128,11 +1131,28 @@ void hipblaslt_gemm(const Tensor *inputA,
                                                      HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                                      &B_scale_inverse,
                                                      sizeof(B_scale_inverse)));
+    // if (is_fp8_dtype(outputD->data.dtype)) {
+    //   NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
+    //                                                     HIPBLASLT_MATMUL_DESC_AMAX_D_POINTER,
+    //                                                     &D_amax,
+    //                                                     sizeof(D_amax)));
+
+    //   NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
+    //                                                     HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER ,
+    //                                                     &D_scale,
+    //                                                     sizeof(D_scale)));
+    // }
     if (bias) {
       NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
                                                        HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE,
                                                        &bias_type, sizeof(bias_type)));
     }
+    // if (gelu){
+    //   NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
+    //                                                     HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_DATA_TYPE,
+    //                                                     &aux_type,
+    //                                                     sizeof(aux_type)));
+    // }
   }
 
   if (bias && gelu) {

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1044,6 +1044,7 @@ void hipblaslt_gemm(const Tensor *inputA,
   void *B = inputB->data.dptr;
   void *B_scale_inverse = inputB->scale_inv.dptr;
   void *D = outputD->data.dptr;
+  //Added for fp8 gelu_fusion support
   // void *D_amax = outputD->amax.dptr;
   // void *D_scale = outputD->scale.dptr;
   void *bias_ptr = inputBias->data.dptr;
@@ -1131,6 +1132,8 @@ void hipblaslt_gemm(const Tensor *inputA,
                                                      HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                                      &B_scale_inverse,
                                                      sizeof(B_scale_inverse)));
+    //Added for fp8 gelu_fusion support
+
     // if (is_fp8_dtype(outputD->data.dtype)) {
     //   NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
     //                                                     HIPBLASLT_MATMUL_DESC_AMAX_D_POINTER,
@@ -1147,6 +1150,8 @@ void hipblaslt_gemm(const Tensor *inputA,
                                                        HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE,
                                                        &bias_type, sizeof(bias_type)));
     }
+    //Added for fp8 gelu_fusion support
+    
     // if (gelu){
     //   NVTE_CHECK_HIPBLASLT(hipblasLtMatmulDescSetAttribute(operationDesc,
     //                                                     HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_DATA_TYPE,


### PR DESCRIPTION
# Description

Added different layout types for A & B matrices(TT, TN, NN, NT).
Default is NN.

Also added this as a variable to be set while running the cpp unit tests.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added support for different layout types for A & B matrices.
- Modified the corresponding calculation in cpu_ref for gemm

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
