### PR TITLE
update hipify_torch submodule for version 2

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -416,9 +416,23 @@ def uninstall_te_wheel_packages():
         ]
     )
 
+def detect_hipify_v2():
+    try:
+        from torch.utils.hipify import __version__
+        from packaging.version import Version
+        if Version(__version__) >= Version("2.0.0"):
+            return True
+    except Exception as e:
+        print("failed to detect pytorch hipify version, defaulting to version 1.0.0 behavior")
+        print(e)
+    return False
+
 def hipify(base_dir, src_dir, sources, include_dirs):
     cwd = os.getcwd()
-    hipify_module = importlib.import_module("3rdparty.hipify_torch.hipify_torch.hipify_python")
+    if detect_hipify_v2():
+        hipify_module = importlib.import_module("3rdparty.hipify_torch.hipify_torch.v2.hipify_python")
+    else:
+        hipify_module = importlib.import_module("3rdparty.hipify_torch.hipify_torch.hipify_python")
     do_hipify = hipify_module.hipify
 
     hipify_result = do_hipify(

--- a/hipify_custom_map.json
+++ b/hipify_custom_map.json
@@ -2,6 +2,8 @@
  "custom_map" : {
         "<cuda_bf16.h>" : "<hip/hip_bfloat16.h>",
         "<cuda_fp8.h>" : "\"amd_detail/hip_float8.h\"",
+        "util/cuda_runtime.h" : "util/hip_runtime.h",
+        "ATen/cudnn/Handle.h" : "ATen/miopen/Handle.h",
         "CUfunc_cache" : "hipFuncCache_t", 
         "<nvtx3/nvToolsExt.h>" : "<roctracer/roctx.h>"
  }


### PR DESCRIPTION
Update the hipify_torch submodule to conditionally use version 2 of the hipify mappings.
