### PR TITLE
[ROCm] add alternative dw_db kernel and tune kernels for layernorm bwd

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -9,7 +9,6 @@ import triton
 import triton.language as tl
 
 from .norm_common_triton import block_size
-from .norm_common_triton import block_size_bwd, use_blocked_bwd
 
 
 def get_autotune_config(full_tuning_space=False):
@@ -353,7 +352,7 @@ def _layernorm_bwd_dwdb_triton_v2(
     cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     db = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    # Iterate through the rows of x and dy to compute dw and db.git st
+    # Iterate through the rows of x and dy to compute dw and db
     for i in range(0, M, BLOCK_SIZE_M):
         rows = i + tl.arange(0, BLOCK_SIZE_M)
         means = tl.load(Mean + rows, mask=rows < M, other=0.0).to(tl.float32)
@@ -413,8 +412,16 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
         tile_num = 2048
         if IGNORE_DW_DB_IN_FUSED:
             tile_num = 4096
-    BLOCK_SIZE = block_size_bwd(x, tile_num)
+
+    max_fused_size = 32768 // x.element_size()
+    next_power = triton.next_power_of_2(x.shape[1])
+    BLOCK_SIZE = min(max_fused_size, next_power)
+    # For cases with small M and large N, decrease block size to help with occupancy and register spill
+    if tile_num == x.shape[0]:
+        BLOCK_SIZE = min(BLOCK_SIZE, 4096)
+    USE_BLOCKED = x.shape[1] > BLOCK_SIZE
     num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+
     dx = torch.empty_like(x)
     if not IGNORE_DW_DB_IN_FUSED:
         _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
@@ -439,7 +446,7 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
         ZERO_CENTERED_GAMMA=zero_centered_gamma,
         NUM_ROWS=M,
         BLOCK_SIZE_N=BLOCK_SIZE,
-        USE_BLOCKED=use_blocked_bwd(x, tile_num),
+        USE_BLOCKED=USE_BLOCKED,
         num_warps=num_warps,
         IGNORE_DW_DB=IGNORE_DW_DB_IN_FUSED,
     )

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -8,7 +8,8 @@ import torch
 import triton
 import triton.language as tl
 
-from .norm_common_triton import block_size, use_blocked
+from .norm_common_triton import block_size
+from .norm_common_triton import block_size_bwd, use_blocked_bwd
 
 
 def get_autotune_config(full_tuning_space=False):
@@ -132,6 +133,7 @@ def _layernorm_bwd_dx_fused_triton(
     NUM_ROWS: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     USE_BLOCKED: tl.constexpr,
+    IGNORE_DW_DB: tl.constexpr = False,
 ):
     # Map the program id to the elements of X, DX, and DY it should compute.
     pid = tl.program_id(0)
@@ -196,8 +198,9 @@ def _layernorm_bwd_dx_fused_triton(
             # Compute dx and partial sums for dw and db:
 
             dx_row_ptr = DX + row * stride
-            dw_row_ptr = DW + pid * N
-            db_row_ptr = DB + pid * N
+            if not IGNORE_DW_DB:
+                dw_row_ptr = DW + pid * N
+                db_row_ptr = DB + pid * N
 
             for block_idx in tl.range(0, num_col_blocks):
                 cols = block_idx * BLOCK_SIZE_N + col_offsets
@@ -213,16 +216,16 @@ def _layernorm_bwd_dx_fused_triton(
 
                 dx = (wdy - (xhat * c1 + c2)) * rstd
                 tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty))
+                if not IGNORE_DW_DB:
+                    partial_dw = dy * xhat
+                    dw_ptrs = dw_row_ptr + cols
+                    partial_dw += tl.load(dw_ptrs).to(tl.float32)
+                    tl.store(dw_ptrs, partial_dw.to(DW.type.element_ty))
 
-                partial_dw = dy * xhat
-                dw_ptrs = dw_row_ptr + cols
-                partial_dw += tl.load(dw_ptrs)
-                tl.store(dw_ptrs, partial_dw)
-
-                partial_db = dy
-                db_ptrs = db_row_ptr + cols
-                partial_db += tl.load(db_ptrs)
-                tl.store(db_ptrs, partial_db)
+                    partial_db = dy
+                    db_ptrs = db_row_ptr + cols
+                    partial_db += tl.load(db_ptrs).to(tl.float32)
+                    tl.store(db_ptrs, partial_db.to(DB.type.element_ty))
 
             cols = num_col_blocks * BLOCK_SIZE_N + col_offsets
             mask = cols < N
@@ -240,16 +243,16 @@ def _layernorm_bwd_dx_fused_triton(
 
             dx = (wdy - (xhat * c1 + c2)) * rstd
             tl.store(dx_row_ptr + cols, dx.to(DX.type.element_ty), mask=mask)
+            if not IGNORE_DW_DB:
+                partial_dw = dy * xhat
+                dw_ptrs = dw_row_ptr + cols
+                partial_dw += tl.load(dw_ptrs, mask=mask).to(tl.float32)
+                tl.store(dw_ptrs, partial_dw.to(DW.type.element_ty), mask=mask)
 
-            partial_dw = dy * xhat
-            dw_ptrs = dw_row_ptr + cols
-            partial_dw += tl.load(dw_ptrs, mask=mask)
-            tl.store(dw_ptrs, partial_dw, mask=mask)
-
-            partial_db = dy
-            db_ptrs = db_row_ptr + cols
-            partial_db += tl.load(db_ptrs, mask=mask)
-            tl.store(db_ptrs, partial_db, mask=mask)
+                partial_db = dy
+                db_ptrs = db_row_ptr + cols
+                partial_db += tl.load(db_ptrs, mask=mask).to(tl.float32)
+                tl.store(db_ptrs, partial_db.to(DB.type.element_ty), mask=mask)
 
             # Advance to next row.
             row += tile_num
@@ -260,9 +263,9 @@ def _layernorm_bwd_dx_fused_triton(
         cols = tl.arange(0, BLOCK_SIZE_N)
         mask = cols < N
         row = pid
-
-        dw_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
-        db_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+        if not IGNORE_DW_DB:
+            dw_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+            db_row = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
 
         for _ in range(0, rows_per_tile):
             # Compute pointers:
@@ -290,16 +293,16 @@ def _layernorm_bwd_dx_fused_triton(
 
             # Write dx:
             tl.store(dx_ptrs + cols, dx.to(DX.type.element_ty), mask=mask)
-
-            # Accumulate partial sums for dw and db:
-            dw_row += dy * xhat
-            db_row += dy
+            if not IGNORE_DW_DB:
+                # Accumulate partial sums for dw and db:
+                dw_row += dy * xhat
+                db_row += dy
 
             # Advance to next row:
             row += tile_num
-
-        tl.store(DW + pid * N + cols, dw_row, mask=mask)
-        tl.store(DB + pid * N + cols, db_row, mask=mask)
+        if not IGNORE_DW_DB:
+            tl.store(DW + pid * N + cols, dw_row.to(DW.type.element_ty), mask=mask)
+            tl.store(DB + pid * N + cols, db_row.to(DB.type.element_ty), mask=mask)
 
 
 @triton.jit
@@ -325,6 +328,43 @@ def _layernorm_bwd_dwdb_triton(
         offs = rows[:, None] * N + cols[None, :]
         dw += tl.load(DW + offs, mask=mask, other=0.0)
         db += tl.load(DB + offs, mask=mask, other=0.0)
+    # Write the final sum to the output.
+    sum_dw = tl.sum(dw, axis=0)
+    sum_db = tl.sum(db, axis=0)
+    tl.store(FINAL_DW + cols, sum_dw.to(FINAL_DW.type.element_ty), mask=cols < N)
+    tl.store(FINAL_DB + cols, sum_db.to(FINAL_DB.type.element_ty), mask=cols < N)
+
+
+@triton.jit
+def _layernorm_bwd_dwdb_triton_v2(
+    X,  # pointer to the input
+    DY,  # pointer to the output gradient
+    Mean,  # pointer to the mean
+    Rstd,  # pointer to the 1/std
+    stride,
+    FINAL_DW,  # pointer to the weights gradient
+    FINAL_DB,  # pointer to the biases gradient
+    M,  # GROUP_SIZE_M
+    N,  # number of columns
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    db = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    # Iterate through the rows of x and dy to compute dw and db.git st
+    for i in range(0, M, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        means = tl.load(Mean + rows, mask=rows < M, other=0.0).to(tl.float32)
+        rstds = tl.load(Rstd + rows, mask=rows < M, other=0.0).to(tl.float32)
+        mask = (rows[:, None] < M) & (cols[None, :] < N)
+        offs = rows[:, None] * stride + cols[None, :]
+        x = tl.load(X + offs, mask=mask, other=0.0).to(tl.float32)
+        dy = tl.load(DY + offs, mask=mask, other=0.0).to(tl.float32)
+        xhat = (x - means[:, None]) * rstds[:, None]
+        dw += dy * xhat
+        db += dy
     # Write the final sum to the output.
     sum_dw = tl.sum(dw, axis=0)
     sum_db = tl.sum(db, axis=0)
@@ -364,17 +404,26 @@ def te_layernorm_fwd_fp8_noalloc_triton(
 # TODO: Add `sm_margin` to the interface.
 def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
     M, N = x.shape
-
-    BLOCK_SIZE = block_size(x)
-    num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+    # calculate dw and db separately when M is small
+    IGNORE_DW_DB_IN_FUSED = M <= 512
     tile_num = max(min(256, M // 4), 1)
-
+    if M <= 512 and M * N < 64 * 1024 * 1024:
+        tile_num = M
+    elif M > 16384:
+        tile_num = 2048
+        if IGNORE_DW_DB_IN_FUSED:
+            tile_num = 4096
+    BLOCK_SIZE = block_size_bwd(x, tile_num)
+    num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
     dx = torch.empty_like(x)
-    _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
-    _dbeta = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
-    dgamma = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
-    dbeta = torch.empty((N,), dtype=gamma.dtype, device=gamma.device)
-
+    if not IGNORE_DW_DB_IN_FUSED:
+        _dgamma = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+        _dbeta = torch.zeros((tile_num, N), dtype=torch.float32, device=gamma.device)
+    else:
+        _dgamma = None
+        _dbeta = None
+    dgamma = torch.zeros((N,), dtype=gamma.dtype, device=gamma.device)
+    dbeta = torch.zeros((N,), dtype=gamma.dtype, device=gamma.device)
     grid_bwd = (tile_num,)
     _layernorm_bwd_dx_fused_triton[grid_bwd](
         dx,
@@ -390,20 +439,43 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
         ZERO_CENTERED_GAMMA=zero_centered_gamma,
         NUM_ROWS=M,
         BLOCK_SIZE_N=BLOCK_SIZE,
-        USE_BLOCKED=use_blocked(x),
+        USE_BLOCKED=use_blocked_bwd(x, tile_num),
         num_warps=num_warps,
+        IGNORE_DW_DB=IGNORE_DW_DB_IN_FUSED,
     )
-
     grid_reduce = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE_N"]),)
-    _layernorm_bwd_dwdb_triton[grid_reduce](
-        _dgamma,
-        _dbeta,
-        dgamma,
-        dbeta,
-        min(tile_num, M),
-        N,
-        BLOCK_SIZE_M=32,
-        BLOCK_SIZE_N=128,
-    )
+    if not IGNORE_DW_DB_IN_FUSED:
+        dwdb_block_n = max(16, N // 256)
+        dwdb_block_n = triton.next_power_of_2(dwdb_block_n)
+        dwdb_block_m = (64 * 128) // dwdb_block_n
+        dwdb_block_m = min(triton.next_power_of_2(tile_num), dwdb_block_m)
+        _layernorm_bwd_dwdb_triton[grid_reduce](
+            _dgamma,
+            _dbeta,
+            dgamma,
+            dbeta,
+            min(tile_num, M),
+            N,
+            BLOCK_SIZE_M=dwdb_block_m,
+            BLOCK_SIZE_N=dwdb_block_n,
+        )
+    else:
+        dwdb_block_n = max(16, N // 256)
+        dwdb_block_n = triton.next_power_of_2(dwdb_block_n)
+        dwdb_block_m = (64 * 128) // dwdb_block_n
+        dwdb_block_m = min(triton.next_power_of_2(M), dwdb_block_m)
+        _layernorm_bwd_dwdb_triton_v2[grid_reduce](
+            x,
+            dz,
+            mu,
+            rsigma,
+            x.stride(0),
+            dgamma,
+            dbeta,
+            M,
+            N,
+            BLOCK_SIZE_M=dwdb_block_m,
+            BLOCK_SIZE_N=dwdb_block_n,
+        )
 
     return dx, dgamma, dbeta

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -8,7 +8,8 @@ import torch
 import triton
 import triton.language as tl
 
-from .norm_common_triton import block_size
+from .norm_common_triton import block_size, use_blocked
+from .norm_common_triton import IS_FP8 as IS_FP8_COMMON
 
 
 def get_autotune_config(full_tuning_space=False):
@@ -408,11 +409,8 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
     tile_num = max(min(256, M // 4), 1)
     if M <= 512 and M * N < 64 * 1024 * 1024:
         tile_num = M
-    elif M > 16384:
+    elif M >= 8192:
         tile_num = 2048
-        if IGNORE_DW_DB_IN_FUSED:
-            tile_num = 4096
-
     max_fused_size = 32768 // x.element_size()
     next_power = triton.next_power_of_2(N)
     BLOCK_SIZE = min(max_fused_size, next_power)

--- a/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm_triton.py
@@ -414,12 +414,15 @@ def te_layernorm_bwd_triton(dz, x, mu, rsigma, gamma, zero_centered_gamma):
             tile_num = 4096
 
     max_fused_size = 32768 // x.element_size()
-    next_power = triton.next_power_of_2(x.shape[1])
+    next_power = triton.next_power_of_2(N)
     BLOCK_SIZE = min(max_fused_size, next_power)
     # For cases with small M and large N, decrease block size to help with occupancy and register spill
-    if tile_num == x.shape[0]:
-        BLOCK_SIZE = min(BLOCK_SIZE, 4096)
-    USE_BLOCKED = x.shape[1] > BLOCK_SIZE
+    if tile_num == M:
+        if tile_num > 256:
+            BLOCK_SIZE = min(BLOCK_SIZE, 2048)
+        else:
+            BLOCK_SIZE = min(BLOCK_SIZE, 4096)
+    USE_BLOCKED = N > BLOCK_SIZE
     num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
 
     dx = torch.empty_like(x)

--- a/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
@@ -53,3 +53,21 @@ def block_size(x):
 
 def use_blocked(x):
     return x.shape[1] > block_size(x)
+
+
+def block_size_bwd(x, tile_num):
+    max_fused_size = 65536 // (x.element_size() * 2)
+    next_power = triton.next_power_of_2(x.shape[1])
+    block_size = min(max_fused_size, next_power)
+    # For cases with small M and large N, decrease block size to help with register spill
+    if tile_num == x.shape[0]:
+        # for better occupancy
+        if tile_num > 256:
+            block_size = min(block_size, 2048)
+        else:
+            block_size = min(block_size, 4096)
+    return block_size
+
+
+def use_blocked_bwd(x, tile_num):
+    return x.shape[1] > block_size_bwd(x, tile_num)

--- a/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
+++ b/transformer_engine/pytorch/triton_kernels/norm_common_triton.py
@@ -53,21 +53,3 @@ def block_size(x):
 
 def use_blocked(x):
     return x.shape[1] > block_size(x)
-
-
-def block_size_bwd(x, tile_num):
-    max_fused_size = 65536 // (x.element_size() * 2)
-    next_power = triton.next_power_of_2(x.shape[1])
-    block_size = min(max_fused_size, next_power)
-    # For cases with small M and large N, decrease block size to help with register spill
-    if tile_num == x.shape[0]:
-        # for better occupancy
-        if tile_num > 256:
-            block_size = min(block_size, 2048)
-        else:
-            block_size = min(block_size, 4096)
-    return block_size
-
-
-def use_blocked_bwd(x, tile_num):
-    return x.shape[1] > block_size_bwd(x, tile_num)


### PR DESCRIPTION
# Description

Improves the performance of the backward pass of the layer norm.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Introduced a new kernel to calculate dgamma and dbeta, useful when M is small. Added a flag to control whether to skip partial dgamma and dbeta calculations in the fused kernel.
- Tuned the fused and reduction kernel heuristics/parameters for better performances.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
