### PR TITLE
Avoid poisoning process with CUDA calls as soon as importing

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -17,7 +17,7 @@ from flax import linen as nn
 
 from utils import assert_allclose, assert_tree_like_allclose
 from transformer_engine.jax.dot import type_safe_dot_general, dequantize, quantize
-from transformer_engine.jax.fp8 import FP8MetaPackage, FP8Helper, is_fp8_available, jnp_float8_e4m3_type, jnp_float8_e5m2_type
+from transformer_engine.jax.fp8 import FP8MetaPackage, FP8Helper, is_fp8_available, get_jnp_float8_e4m3_type, get_jnp_float8_e5m2_type
 from transformer_engine.jax.layernorm import layernorm, layernorm_fp8_dot
 from transformer_engine.jax.layernorm_mlp import activation_lu, fused_layernorm_fp8_mlp
 from transformer_engine.jax.cpp_extensions.activation import _jax_act_lu
@@ -29,8 +29,9 @@ from transformer_engine.jax.cpp_extensions.transpose import (
 from transformer_engine.jax.cpp_extensions.quantization import _jax_cast_fp8
 from transformer_engine.jax import cpp_extensions as tex
 from transformer_engine.jax import is_hip_extension
-from transformer_engine.jax.fp8 import jnp_float8_e4m3_type, jnp_float8_e5m2_type
 
+jnp_float8_e4m3_type = get_jnp_float8_e4m3_type()
+jnp_float8_e5m2_type = get_jnp_float8_e5m2_type()
 
 GEMM_CASES = [
     (256, 256, 512),

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -26,7 +26,7 @@ from transformer_engine.jax.attention import (
     canonicalize_attn_mask_type,
     make_swa_mask,
 )
-from transformer_engine.jax.fp8 import jnp_float8_e4m3_type, jnp_float8_e5m2_type, DType as TEDType
+from transformer_engine.jax.fp8 import get_jnp_float8_e4m3_type, get_jnp_float8_e5m2_type, DType as TEDType
 
 PRNGKey = Any
 Shape = Tuple[int, ...]
@@ -1410,8 +1410,8 @@ def dtype_tols(
             TEDType.kFloat32: jnp.float32,
             TEDType.kFloat16: jnp.float16,
             TEDType.kBFloat16: jnp.bfloat16,
-            TEDType.kFloat8E4M3: jnp_float8_e4m3_type,
-            TEDType.kFloat8E5M2: jnp_float8_e5m2_type,
+            TEDType.kFloat8E4M3: get_jnp_float8_e4m3_type(),
+            TEDType.kFloat8E5M2: get_jnp_float8_e5m2_type(),
         }[dtype]
     elif isinstance(dtype, np.dtype):
         dtype = jnp.dtype(dtype)

--- a/tests/pytorch/utils.py
+++ b/tests/pytorch/utils.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 import torch
 
 import transformer_engine.pytorch as te
-from transformer_engine.pytorch.fp8 import torch_float8_e4m3_type, torch_float8_e5m2_type
+from transformer_engine.pytorch.fp8 import get_torch_float8_e4m3_type, get_torch_float8_e5m2_type
 import transformer_engine_torch as tex
+
+torch_float8_e4m3_type = get_torch_float8_e4m3_type()
+torch_float8_e5m2_type = get_torch_float8_e5m2_type()
 
 def str_to_dtype(dtype: str | torch.dtype) -> torch.dtype:
     """Convert type name to PyTorch dtype"""

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -21,8 +21,7 @@ from transformer_engine.transformer_engine_jax import NVTE_Activation_Type
 from .base import BasePrimitive, register_primitive
 from .custom_call import custom_caller, CustomCallArgsWrapper
 from .misc import (
-    jnp_float8_e4m3_type, 
-    jnp_float8_e5m2_type,
+    get_jnp_float8_e4m3_type,
     check_valid_batch_dims,
     jax_dtype_to_te_dtype,
     jax_dtype_to_ir_dtype,
@@ -362,7 +361,7 @@ class ActLuFp8Primitive(BasePrimitive):
         """
         dtype = dtypes.canonicalize_dtype(x_aval.dtype)
         # Currently only support casting to E4M3 only in C side.
-        assert out_dtype == jnp_float8_e4m3_type
+        assert out_dtype == get_jnp_float8_e4m3_type()
         assert dtype in [jnp.float32, jnp.float16, jnp.bfloat16]
         assert amax_aval.dtype == jnp.float32
         assert scale_aval.dtype == jnp.float32

--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -21,7 +21,7 @@ from jax.interpreters.mlir import dtype_to_ir_type
 from transformer_engine.transformer_engine_jax import DType as TEDType
 from transformer_engine import transformer_engine_jax
 
-from ..fp8 import jnp_float8_e4m3_type, jnp_float8_e5m2_type
+from ..fp8 import get_jnp_float8_e4m3_type, get_jnp_float8_e5m2_type
 from ..sharding import get_padded_spec as te_get_padded_spec
 from ..util import is_hip_extension
 
@@ -38,8 +38,8 @@ def te_dtype_to_jax_dtype(te_dtype):
         TEDType.kBFloat16: jnp.bfloat16,
         TEDType.kInt32: jnp.int32,
         TEDType.kInt64: jnp.int64,
-        TEDType.kFloat8E4M3: jnp_float8_e4m3_type,
-        TEDType.kFloat8E5M2: jnp_float8_e5m2_type,
+        TEDType.kFloat8E4M3: get_jnp_float8_e4m3_type(),
+        TEDType.kFloat8E5M2: get_jnp_float8_e5m2_type(),
         TEDType.kByte: jnp.uint8,
     }
 
@@ -75,8 +75,8 @@ def jax_dtype_to_te_dtype(jax_dtype):
         jnp.bfloat16.dtype: TEDType.kBFloat16,
         jnp.int32.dtype: TEDType.kInt32,
         jnp.int64.dtype: TEDType.kInt64,
-        jnp_float8_e4m3_type.dtype: TEDType.kFloat8E4M3,
-        jnp_float8_e5m2_type.dtype: TEDType.kFloat8E5M2,
+        get_jnp_float8_e4m3_type().dtype: TEDType.kFloat8E4M3,
+        get_jnp_float8_e5m2_type().dtype: TEDType.kFloat8E5M2,
         jnp.uint8.dtype: TEDType.kByte,
     }
 

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -22,8 +22,7 @@ from transformer_engine import transformer_engine_jax
 from .base import BasePrimitive, register_primitive
 from .custom_call import custom_caller, CustomCallArgsWrapper
 from .misc import (
-    jnp_float8_e4m3_type, 
-    jnp_float8_e5m2_type,
+    get_jnp_float8_e4m3_type,
     get_padded_spec,
     check_valid_batch_dims,
     jax_dtype_to_te_dtype,
@@ -1044,7 +1043,7 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
         x_aval, gamma_aval, beta_aval, amax_aval, scale_aval, scale_inv_aval = ctx.avals_in
 
         # Currently only support casting to E4M3 only in C side.
-        assert out_dtype == jnp_float8_e4m3_type
+        assert out_dtype == get_jnp_float8_e4m3_type()
 
         assert x_aval.dtype in [jnp.float32, jnp.float16, jnp.bfloat16]
         assert gamma_aval.dtype == beta_aval.dtype
@@ -1355,7 +1354,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
         """
 
         # Currently only support casting to E4M3 only in C side.
-        assert out_dtype == jnp_float8_e4m3_type
+        assert out_dtype == get_jnp_float8_e4m3_type()
 
         if is_ffi_enabled():
             name = "te_rmsnorm_forward_fp8_ffi"

--- a/transformer_engine/jax/cpp_extensions/transpose.py
+++ b/transformer_engine/jax/cpp_extensions/transpose.py
@@ -21,8 +21,8 @@ from transformer_engine.transformer_engine_jax import DType as TEDType
 from .base import BasePrimitive, register_primitive
 from .custom_call import custom_caller, CustomCallArgsWrapper
 from .misc import (
-    jnp_float8_e4m3_type, 
-    jnp_float8_e5m2_type,
+    get_jnp_float8_e4m3_type, 
+    get_jnp_float8_e5m2_type,
     check_valid_batch_dims,
     jax_dtype_to_te_dtype,
     jax_dtype_to_ir_dtype,
@@ -131,8 +131,8 @@ class TransposePrimitive(BasePrimitive):
             jnp.float32,
             jnp.float16,
             jnp.bfloat16,
-            jnp_float8_e4m3_type,
-            jnp_float8_e5m2_type,
+            get_jnp_float8_e4m3_type(),
+            get_jnp_float8_e5m2_type(),
         ]
 
         if is_ffi_enabled():

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -34,8 +34,8 @@ _is_fp8_available = None
 _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]
 
-jnp_float8_e4m3_type = jnp.float8_e4m3fnuz if is_fp8_fnuz() else jnp.float8_e4m3fn
-jnp_float8_e5m2_type = jnp.float8_e5m2fnuz if is_fp8_fnuz() else jnp.float8_e5m2
+get_jnp_float8_e4m3_type = lambda: jnp.float8_e4m3fnuz if is_fp8_fnuz() else jnp.float8_e4m3fn
+get_jnp_float8_e5m2_type = lambda: jnp.float8_e5m2fnuz if is_fp8_fnuz() else jnp.float8_e5m2
 
 def _check_fp8_support(gpu_id) -> Tuple[bool, str]:
     """Return if fp8 support is available"""
@@ -76,6 +76,8 @@ def is_fp8_available(gpu_id=None) -> Tuple[bool, str]:
 
 
 def _format2dtypes(format_: Format):
+    jnp_float8_e4m3_type = get_jnp_float8_e4m3_type()
+    jnp_float8_e5m2_type = get_jnp_float8_e5m2_type()
     if format_ == Format.E4M3:
         return jnp_float8_e4m3_type, jnp_float8_e4m3_type
     if format_ == Format.E5M2:

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -20,11 +20,11 @@ from .utils import get_device_compute_capability, is_fp8_fnuz
 from .jit import jit_fuser
 
 
-__all__ = ["fp8_autocast", "fp8_model_init", "torch_float8_e4m3_type", "torch_float8_e5m2_type"]
+__all__ = ["fp8_autocast", "fp8_model_init", "get_torch_float8_e4m3_type", "get_torch_float8_e5m2_type"]
 
 
-torch_float8_e4m3_type = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-torch_float8_e5m2_type = torch.float8_e5m2fnuz if is_fp8_fnuz() else torch.float8_e5m2
+get_torch_float8_e4m3_type = lambda: torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+get_torch_float8_e5m2_type = lambda: torch.float8_e5m2fnuz if is_fp8_fnuz() else torch.float8_e5m2
 
 
 def check_fp8_support() -> Tuple[bool, str]:
@@ -62,8 +62,8 @@ def get_fp8_torch_dtype(fp8_recipe: DelayedScaling, fprop_tensor: bool = True) -
     if fp8_recipe.fp8_format == Format.E4M3 or (
         fp8_recipe.fp8_format == Format.HYBRID and fprop_tensor
     ):
-        return torch_float8_e4m3_type
-    return torch_float8_e5m2_type
+        return get_torch_float8_e4m3_type()
+    return get_torch_float8_e5m2_type()
 
 
 def get_fp8_te_dtype(fp8_recipe: DelayedScaling, fprop_tensor: bool = True) -> tex.DType:

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -17,12 +17,8 @@ from transformer_engine_torch import DType as TE_DType
 
 from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
-if is_fp8_fnuz():
-    e5m2_data_type = tl.float8e5b16
-    e4m3_data_type = tl.float8e4b8
-else:
-    e5m2_data_type = tl.float8e5
-    e4m3_data_type = tl.float8e4nv
+get_e5m2_data_type = lambda: tl.float8e5b16 if is_fp8_fnuz() else tl.float8e5
+get_e4m3_data_type = lambda: tl.float8e4b8 if is_fp8_fnuz() else tl.float8e4nv
 IS_HIP_EXTENSION = triton.language.constexpr(IS_HIP_EXTENSION)
 
 @triton.jit
@@ -225,11 +221,11 @@ def _unpermute_kernel(
 ):
     if FP8_DTYPE == "e5m2":
         compute_type = tl.float16
-        data_type = e5m2_data_type
+        data_type = get_e5m2_data_type()
         pytorch_tensor_dtype = tl.uint8
     elif FP8_DTYPE == "e4m3":
         compute_type = tl.float16
-        data_type = e4m3_data_type
+        data_type = get_e4m3_data_type()
         pytorch_tensor_dtype = tl.uint8
     else:
         # NOTE: Using fp32 accumulate precision on ROCm.
@@ -343,11 +339,11 @@ def _unpermute_bwd_with_probs_kernel(
 ):
     if FP8_DTYPE == "e5m2":
         compute_type = tl.float16
-        data_type = e5m2_data_type
+        data_type = get_e5m2_data_type()
         pytorch_tensor_dtype = tl.uint8
     elif FP8_DTYPE == "e4m3":
         compute_type = tl.float16
-        data_type = e4m3_data_type
+        data_type = get_e4m3_data_type()
         pytorch_tensor_dtype = tl.uint8
     else:
         compute_type = fwd_output_grad_ptr.dtype.element_ty


### PR DESCRIPTION
# Description

Let's not call `is_fp8_fnuz` outside any function, as that will call `torch.cuda.get_device_capability` and lazily init the CUDA environment:
https://github.com/pytorch/pytorch/blob/c65ee728f069ea9544bdcac815eb0825f45d1633/torch/cuda/__init__.py#L342-L392

Current way will then make all the `CUDA/HIP/ROCM_VISIBLE_DEVICES` changes not effective after importing:
https://github.com/pytorch/pytorch/issues/141678

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Package all `is_fp8_fnuz` related checks that are outside the functions to be inside the lambda functions.

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
