### PR TITLE
Allows compilation with either Hipblaslt or Rocblas disabled

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ The default installation above supports both rocBlas and hipBlasLt in GEMM compu
   export NVTE_USE_HIPBLASLT=1
   export NVTE_USE_ROCBLAS=1
 
+If neither of the aforementioned environment variables are set or both of them are set, then both backends are built. If only one of these environment variables is set, then the other backend is not built.
 When both GEMM backends are supported the aforementioned env variables can be used to select which backend to use. If none is set hipBlasLt is used by default. The hipBlasLt backed has not yet supported all the GEMM configurations in the pytorch unit tests. 
 
 Test

--- a/setup.py
+++ b/setup.py
@@ -80,13 +80,10 @@ def setup_common_extension() -> CMakeExtension:
         #  If one is set and the other is not, then only the corresponding backend is built
         enable_hipblaslt = os.getenv("NVTE_USE_HIPBLASLT") is not None
         enable_rocblas = os.getenv("NVTE_USE_ROCBLAS") is not None
-        if enable_hipblaslt and enable_rocblas:
-            cmake_flags.append("-DUSE_HIPBLASLT=ON")
-            cmake_flags.append("-DUSE_ROCBLAS=ON")
-        elif enable_hipblaslt:
+        if enable_hipblaslt and not enable_rocblas:
             cmake_flags.append("-DUSE_HIPBLASLT=ON")
             cmake_flags.append("-DUSE_ROCBLAS=OFF")
-        elif enable_rocblas:
+        elif enable_rocblas and not enable_hipblaslt:
             cmake_flags.append("-DUSE_HIPBLASLT=OFF")
             cmake_flags.append("-DUSE_ROCBLAS=ON")
         else:

--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,8 @@ def setup_common_extension() -> CMakeExtension:
     cmake_flags = []
     if rocm_build():
         cmake_flags.append("-DUSE_ROCM=ON")
-        if os.getenv("NVTE_USE_HIPBLASLT") is not None:
-            cmake_flags.append("-DUSE_HIPBLASLT=ON")
-        if os.getenv("NVTE_USE_ROCBLAS") is not None:
-            cmake_flags.append("-DUSE_ROCBLAS=ON")
+        cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if bool(int(os.getenv("NVTE_USE_HIPBLASLT", "1"))) else "OFF"))
+        cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if bool(int(os.getenv("NVTE_USE_ROCBLAS", "1"))) else "OFF"))
         if os.getenv("NVTE_AOTRITON_PATH"):
             aotriton_path = Path(os.getenv("NVTE_AOTRITON_PATH"))
             cmake_flags.append(f"-DAOTRITON_PATH={aotriton_path}")

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,21 @@ def setup_common_extension() -> CMakeExtension:
         # HIPBLASLT and ROCBLAS support are controlled as follows:
         #  If neither NVTE_USE_HIPBLASLT nor NVTE_USE_ROCBLAS are set, or both are set, both frameworks are enabled
         #  If one is set and the other is not, then only the corresponding backend is built
-        #  Note that the "no environment variable set" case relies on defaults set in transformer_engine/common/CMakeLists.txt
         enable_hipblaslt = os.getenv("NVTE_USE_HIPBLASLT") is not None
         enable_rocblas = os.getenv("NVTE_USE_ROCBLAS") is not None
+        if enable_hipblaslt and enable_rocblas:
+            cmake_flags.append("-DUSE_HIPBLASLT=ON")
+            cmake_flags.append("-DUSE_ROCBLAS=ON")
+        elif enable_hipblaslt:
+            cmake_flags.append("-DUSE_HIPBLASLT=ON")
+            cmake_flags.append("-DUSE_ROCBLAS=OFF")
+        elif enable_rocblas:
+            cmake_flags.append("-DUSE_HIPBLASLT=OFF")
+            cmake_flags.append("-DUSE_ROCBLAS=ON")
+        else:
+            cmake_flags.append("-DUSE_HIPBLASLT=ON")
+            cmake_flags.append("-DUSE_ROCBLAS=ON")
+
         if enable_hipblaslt or enable_rocblas:
             cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
             cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,18 @@ def setup_common_extension() -> CMakeExtension:
     cmake_flags = []
     if rocm_build():
         cmake_flags.append("-DUSE_ROCM=ON")
-        cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if bool(int(os.getenv("NVTE_USE_HIPBLASLT", "1"))) else "OFF"))
-        cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if bool(int(os.getenv("NVTE_USE_ROCBLAS", "1"))) else "OFF"))
+        # HIPBLASLT and ROCBLAS support are controlled as follows:
+        #  If neither NVTE_USE_HIPBLASLT nor NVTE_USE_ROCBLAS are set, or both are set, both frameworks are enabled
+        #  If one is set and the other is not, then the framework that whose variable is set is enabled and the other is disabled
+        enable_hipblaslt = True
+        enable_rocblas = True
+        if os.getenv("NVTE_USE_HIPBLASLT") is not None:
+            if os.getenv("NVTE_USE_ROCBLAS") is None:
+                enable_rocblas = False
+        elif os.getenv("NVTE_USE_ROCBLAS") is not None:
+          enable_hipblaslt = False
+        cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
+        cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))
         if os.getenv("NVTE_AOTRITON_PATH"):
             aotriton_path = Path(os.getenv("NVTE_AOTRITON_PATH"))
             cmake_flags.append(f"-DAOTRITON_PATH={aotriton_path}")

--- a/setup.py
+++ b/setup.py
@@ -77,16 +77,15 @@ def setup_common_extension() -> CMakeExtension:
         cmake_flags.append("-DUSE_ROCM=ON")
         # HIPBLASLT and ROCBLAS support are controlled as follows:
         #  If neither NVTE_USE_HIPBLASLT nor NVTE_USE_ROCBLAS are set, or both are set, both frameworks are enabled
-        #  If one is set and the other is not, then the framework that whose variable is set is enabled and the other is disabled
-        enable_hipblaslt = True
-        enable_rocblas = True
-        if os.getenv("NVTE_USE_HIPBLASLT") is not None:
-            if os.getenv("NVTE_USE_ROCBLAS") is None:
-                enable_rocblas = False
-        elif os.getenv("NVTE_USE_ROCBLAS") is not None:
-          enable_hipblaslt = False
-        cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
-        cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))
+        #  If one is set and the other is not, then only the corresponding backend is built
+        enable_hipblaslt = os.getenv("NVTE_USE_HIPBLASLT") is not None
+        enable_rocblas = os.getenv("NVTE_USE_ROCBLAS") is None
+
+        # If neither environment variable is set, then both frameworks will be built based on the defaults
+        # in transformer_engine/common/CMakeLists.txt
+        if enable_hipblaslt or enable_rocblas:
+            cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
+            cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))
         if os.getenv("NVTE_AOTRITON_PATH"):
             aotriton_path = Path(os.getenv("NVTE_AOTRITON_PATH"))
             cmake_flags.append(f"-DAOTRITON_PATH={aotriton_path}")

--- a/setup.py
+++ b/setup.py
@@ -78,11 +78,9 @@ def setup_common_extension() -> CMakeExtension:
         # HIPBLASLT and ROCBLAS support are controlled as follows:
         #  If neither NVTE_USE_HIPBLASLT nor NVTE_USE_ROCBLAS are set, or both are set, both frameworks are enabled
         #  If one is set and the other is not, then only the corresponding backend is built
+        #  Note that the "no environment variable set" case relies on defaults set in transformer_engine/common/CMakeLists.txt
         enable_hipblaslt = os.getenv("NVTE_USE_HIPBLASLT") is not None
-        enable_rocblas = os.getenv("NVTE_USE_ROCBLAS") is None
-
-        # If neither environment variable is set, then both frameworks will be built based on the defaults
-        # in transformer_engine/common/CMakeLists.txt
+        enable_rocblas = os.getenv("NVTE_USE_ROCBLAS") is not None
         if enable_hipblaslt or enable_rocblas:
             cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
             cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))

--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,6 @@ def setup_common_extension() -> CMakeExtension:
             cmake_flags.append("-DUSE_HIPBLASLT=ON")
             cmake_flags.append("-DUSE_ROCBLAS=ON")
 
-        if enable_hipblaslt or enable_rocblas:
-            cmake_flags.append("-DUSE_HIPBLASLT=" + ("ON" if enable_hipblaslt else "OFF"))
-            cmake_flags.append("-DUSE_ROCBLAS=" + ("ON" if enable_rocblas else "OFF"))
         if os.getenv("NVTE_AOTRITON_PATH"):
             aotriton_path = Path(os.getenv("NVTE_AOTRITON_PATH"))
             cmake_flags.append(f"-DAOTRITON_PATH={aotriton_path}")

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <transformer_engine/gemm.h>
 #include <transformer_engine/transformer_engine.h>
+#include <map>
 #ifdef USE_HIPBLASLT
 #include <unistd.h>
 #include <vector>


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

The documentation states that the environment variables NVTE_USE_HIPBLASLT is used to enable or disable Hipblaslt and NVTE_USE_ROCBLAS is used to enable or disable rocblas, but setup.py was previously enabling each if these was set at all (not checking 0 or 1), and CMakefiles.txt was defaulting both to on, so it was impossible to disable either. 
A [Rocblas refactoring](https://github.com/ROCm/rocBLAS/pull/1572) has removed F8 support, making it necessary to build TE with rocblas disabled.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Use the values of NVTE_USE_HIPBLASLT and NVTE_USE_ROCBLAS to control whether or not hipblaslt and rocblas support is enabled, respectively
- Fix an error where the multimap STL was missing if NVTE_USE_ROCBLAS  was false

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
