### PR TITLE
Fixed attention benchmark script and added it to CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ downloads/
 .pytest_cache/
 compile_commands.json
 .nfs
+**/profiler_outputs/
+**/times.csv
+

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -73,7 +73,7 @@ columns = [
     ]
 
 output_csv="times.csv"
-
+cwd = os.getcwd()
 # Runs benchmark with warmup iterations and profiles using rocprof
 def benchmark_dot_product_attention(model, attention, column_name, dirname):
     config = model_configs[model]
@@ -145,6 +145,10 @@ def parse_helper(model, dirname, fwd_search_pattern, bwd_search_pattern, column_
     # Extract kernel timing values    
     fwd_values = df[df["Name"].str.contains(fwd_search_pattern)]["AverageNs"].to_numpy()
     bwd_values = df[df["Name"].str.contains(bwd_search_pattern)]["AverageNs"].to_numpy()
+
+    if len(bwd_values) == 0:
+        return False  # CK V3 not supported or kernel_func not found
+    
     t_attn_avg = np.empty(len(fwd_values) + len(bwd_values))
     t_attn_avg[:len(fwd_values)] = fwd_values
     t_attn_avg[len(fwd_values):] = bwd_values
@@ -154,19 +158,27 @@ def parse_helper(model, dirname, fwd_search_pattern, bwd_search_pattern, column_
     df_times.loc[model, f"{column_name} Kernels (bwd)"] = t_attn_avg[len(fwd_values):].sum() / 1e6
     df_times.loc[model, f"{column_name} Kernels (fwd+bwd)"] = t_attn_avg.sum() / 1e6
 
+    return True
+
 # Parses profiler logs for different attention backends
 def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton, use_ck_bwd_v3):
     if perf_dir_flash_attn:
         parse_helper(model, perf_dir_flash_attn, "FmhaFwd", "FmhaBwd", "FlashAttention", df_times)
 
     if perf_dir_fused_attn:
-        bwd_pattern = "kernel_func" if use_ck_bwd_v3 else "FmhaBwd"
-        parse_helper(model, perf_dir_fused_attn, "FmhaFwd", bwd_pattern, "FusedAttention", df_times)
+        ck_v3_success = False
+        if use_ck_bwd_v3:
+            ck_v3_success = parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "kernel_func", "FusedAttention", df_times)
+        if not ck_v3_success:
+            parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "FmhaBwd", "FusedAttention", df_times)
 
-    if perf_dir_fused_ck:
-        bwd_pattern = "kernel_func" if use_ck_bwd_v3 else "FmhaBwd"
-        parse_helper(model, perf_dir_fused_ck, "FmhaFwd", bwd_pattern, "FusedAttention CK", df_times)
-
+    if perf_dir_fused_attn:
+        ck_v3_success = False
+        if use_ck_bwd_v3:
+            ck_v3_success = parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "kernel_func", "FusedAttention CK", df_times)
+        if not ck_v3_success:
+            parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "FmhaBwd", "FusedAttention CK", df_times)
+    
     if perf_dir_fused_aotriton:
         parse_helper(model, perf_dir_fused_aotriton, "attn_fwd", "bwd", "FusedAttention AOTriton", df_times)
 
@@ -176,14 +188,83 @@ def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, per
             / df_times.loc[model, "FusedAttention Kernels (fwd+bwd)"]
         )
 
+###############################################################################
+# Post-benchmark sanity checks
+###############################################################################
+def sanity_checks(
+    profiler_root: str = "profiler_outputs",
+    csv_path: str = "times.csv",
+    tolerance_pct: float = 5.0,
+):
+    """
+    • Verifies that every model/backend that *should* have run produced
+        profiler_root/<dir>/results.stats.csv
+    • Checks FusedAttention vs FusedAttention-CK timing within ±tolerance_pct
+    • Non-zero exit code on any failure (CI friendly)
+    """
+    df = pd.read_csv(os.path.join(cwd, csv_path), index_col=0)
+    ok_overall = True
+    tol = tolerance_pct / 100.0
+    profiler_root = os.path.join(cwd, profiler_root)
 
-def main():
+    dir_pattern = {
+        "FlashAttention":           "prof_flash_{model}",
+        "FusedAttention":           "prof_fused_{model}",
+        "FusedAttention CK":        "prof_fused_ck_{model}",
+        "FusedAttention AOTriton":  "prof_fused_aotriton_{model}",
+    }
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--use_ck_bwd_v3", action="store_true", help="Use NVTE_CK_USES_BWD_V3=1 for CK bwd kernels")
-    args = parser.parse_args()
+    print("\n========== Sanity-check results ==========")
+    for model, cfg in model_configs.items():
+        avail, fused_bes = _get_attention_backends(
+            cfg,
+            qkv_dtype=dtype,
+            qkv_layout=qkv_layout,
+            window_size=cfg.window_size,
+            pad_between_seqs=pad_between_seqs,
+        )
+        flash_ok, fused_ok, _ = avail
 
-    cwd = os.getcwd()
+        expected = {}
+        if flash_ok:
+            expected["FlashAttention"] = dir_pattern["FlashAttention"]
+        if fused_ok:
+            expected["FusedAttention"] = dir_pattern["FusedAttention"]
+            if NVTE_Fused_Attn_Backend.NVTE_CK in fused_bes:
+                expected["FusedAttention CK"] = dir_pattern["FusedAttention CK"]
+            if NVTE_Fused_Attn_Backend.NVTE_AOTriton in fused_bes:
+                expected["FusedAttention AOTriton"] = dir_pattern["FusedAttention AOTriton"]
+
+        print(f"{model}:")
+        # Rocprof run status
+        for be, pat in expected.items():
+            stats = os.path.join(profiler_root, pat.format(model=model), "results.stats.csv")
+            if os.path.isfile(stats):
+                print(f"  [{be:<22}] Profiling successful")
+            else:
+                ok_overall = False
+                print(f"  [Error] {be:<16} error in profiling, results.stats.csv not found")
+
+        # Fused Vs Fused CK trace
+        if "FusedAttention" in expected and "FusedAttention CK" in expected:
+            f_fwd, f_bwd = df.loc[model, ["FusedAttention Kernels (fwd)",
+                                          "FusedAttention Kernels (bwd)"]]
+            c_fwd, c_bwd = df.loc[model, ["FusedAttention CK Kernels (fwd)",
+                                          "FusedAttention CK Kernels (bwd)"]]
+            if min(f_fwd, f_bwd, c_fwd, c_bwd) > 0:
+                rel_fwd = abs(f_fwd - c_fwd) / max(f_fwd, c_fwd)
+                rel_bwd = abs(f_bwd - c_bwd) / max(f_bwd, c_bwd)
+                if rel_fwd < tol and rel_bwd < tol:
+                    print(f"  [OK ] Fused vs CK diff ≤ {tolerance_pct}% "
+                          f"(fwd {rel_fwd*100:.2f} %, bwd {rel_bwd*100:.2f} %)")
+                else:
+                    ok_overall = False
+                    print(f"  [FAIL] Fused vs CK kernel time diff > {tolerance_pct}% "
+                          f"(fwd {rel_fwd*100:.2f} %, bwd {rel_bwd*100:.2f} %)")
+        print("-" * 60)
+
+
+def main(args):
     output_dir = "profiler_outputs/"
     run_dir = os.path.dirname(__file__)
 
@@ -304,5 +385,12 @@ def main():
         if os.path.exists(final_csv_path):
             os.remove(final_csv_path)
         shutil.move(output_csv, final_csv_path)    
+
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--use_ck_bwd_v3", action="store_true", help="Use NVTE_CK_USES_BWD_V3=1 for CK bwd kernels")
+    parser.add_argument("--run_sanity_checks", action="store_true", help="After benchmarking, verify profiler outputs and Fused vs CK timing parity")
+    args = parser.parse_args()
+    main(args)
+    if args.run_sanity_checks:
+        sanity_checks()

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -5,6 +5,7 @@
 # See LICENSE for license information.
 
 import os, sys, time, shutil
+import argparse
 import subprocess
 import pandas as pd
 import numpy as np
@@ -74,7 +75,7 @@ columns = [
 output_csv="times.csv"
 
 # Runs benchmark with warmup iterations and profiles using rocprof
-def benchmark_dot_product_attention(model, attention, column_name, filename):
+def benchmark_dot_product_attention(model, attention, column_name, dirname):
     config = model_configs[model]
 
     warmup_iters = 3
@@ -89,8 +90,11 @@ def benchmark_dot_product_attention(model, attention, column_name, filename):
                 pad_between_seqs,
                 is_training,
             )
+    os.makedirs(dirname)
+    before_files = set(os.listdir("."))
     # Profiling command using rocprof
     prof_cmd = [
+            "env | grep NVTE; "
             "rocprof",
             "--hip-trace",
             "--basenames off",
@@ -102,11 +106,11 @@ def benchmark_dot_product_attention(model, attention, column_name, filename):
         ]
     prof_cmd = " ".join(prof_cmd)
     subprocess.call(prof_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+    after_files = set(os.listdir("."))
+    new_files = after_files - before_files
 
-    if os.path.exists("results.stats.csv"):
-        shutil.move("results.stats.csv", filename)
-    else:
-        print("Error: results.stats.csv not found!")
+    for f in new_files:
+        shutil.move(f, os.path.join(dirname, f))
     torch.cuda.empty_cache()
     
 # Runs profiler and records timing information
@@ -135,8 +139,8 @@ def benchmark_dot_product_attention_profiler(model, attention, column_name):
     torch.cuda.empty_cache()
 
 # Helper function to extract timing results from profiler logs
-def parse_helper(model, filename, fwd_search_pattern, bwd_search_pattern, column_name, df_times):
-    df = pd.read_csv(filename)
+def parse_helper(model, dirname, fwd_search_pattern, bwd_search_pattern, column_name, df_times):
+    df = pd.read_csv(os.path.join(dirname,"results.stats.csv"))
 
     # Extract kernel timing values    
     fwd_values = df[df["Name"].str.contains(fwd_search_pattern)]["AverageNs"].to_numpy()
@@ -151,20 +155,20 @@ def parse_helper(model, filename, fwd_search_pattern, bwd_search_pattern, column
     df_times.loc[model, f"{column_name} Kernels (fwd+bwd)"] = t_attn_avg.sum() / 1e6
 
 # Parses profiler logs for different attention backends
-def parse_results(model, df_times, filename_flash_attn, filename_fused_attn, filename_fused_ck, filename_fused_aotriton):
-    if filename_flash_attn:
-        parse_helper(model, filename_flash_attn, "FmhaFwd", "FmhaBwd", "FlashAttention", df_times)
+def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton):
+    if perf_dir_flash_attn:
+        parse_helper(model, perf_dir_flash_attn, "FmhaFwd", "FmhaBwd", "FlashAttention", df_times)
 
-    if filename_fused_attn:
-        parse_helper(model, filename_fused_attn, "FmhaFwd", "FmhaBwd", "FusedAttention", df_times)
+    if perf_dir_fused_attn:
+        parse_helper(model, perf_dir_fused_attn, "FmhaFwd", "FmhaBwd", "FusedAttention", df_times)
 
-    if filename_fused_ck:
-        parse_helper(model, filename_fused_ck, "FmhaFwd", "FmhaBwd", "FusedAttention CK", df_times)
+    if perf_dir_fused_ck:
+        parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "FmhaBwd", "FusedAttention CK", df_times)
 
-    if filename_fused_aotriton:
-        parse_helper(model, filename_fused_aotriton, "attn_fwd", "bwd", "FusedAttention AOTriton", df_times)
+    if perf_dir_fused_aotriton:
+        parse_helper(model, perf_dir_fused_aotriton, "attn_fwd", "bwd", "FusedAttention AOTriton", df_times)
 
-    if filename_flash_attn and filename_fused_attn:
+    if perf_dir_flash_attn and perf_dir_fused_attn:
         df_times.loc[model, "Fused vs Flash Kernels Speedup (fwd+bwd)"] = (
             df_times.loc[model, "FlashAttention Kernels (fwd+bwd)"]
             / df_times.loc[model, "FusedAttention Kernels (fwd+bwd)"]
@@ -172,15 +176,29 @@ def parse_results(model, df_times, filename_flash_attn, filename_fused_attn, fil
 
 
 def main():
-    cwd = os.path.dirname(__file__)
-    os.chdir(cwd)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--use_ck_bwd_v3", action="store_true", help="Use NVTE_CK_USES_BWD_V3=1 for CK bwd kernels")
+    args = parser.parse_args()
+
+    cwd = os.getcwd()
     output_dir = "profiler_outputs/"
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
+    run_dir = os.path.dirname(__file__)
+
+    # Remove from current working directory
+    if os.path.exists(os.path.join(cwd, output_dir)):
+        shutil.rmtree(os.path.join(cwd, output_dir))
+    if os.path.exists(os.path.join(cwd, output_csv)):
+        os.remove(os.path.join(cwd, output_csv))
+
+    # Remove from run directory
+    if os.path.exists(os.path.join(run_dir, output_dir)):
+        shutil.rmtree(os.path.join(run_dir, output_dir))
+    if os.path.exists(os.path.join(run_dir, output_csv)):
+        os.remove(os.path.join(run_dir, output_csv))
+
+    os.chdir(run_dir)
     os.makedirs(output_dir)
-    
-    if (os.path.exists(output_csv)):
-        os.remove(output_csv)
 
     df_times = pd.DataFrame(index=indices, columns=columns)
     df_times = df_times.infer_objects(copy=False)
@@ -217,41 +235,49 @@ def main():
             f'{" and flash-attention" if flash_attn_supported else ""}...'
         )
 
-        filename_flash_attn, filename_fused_attn, filename_fused_ck, filename_fused_aotriton = None, None, None, None
+        perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton = None, None, None, None
+        
         # Benchmark for each attention backend
         if flash_attn_supported:
-            filename_flash_attn = os.path.join("profiler_outputs/", f"prof_flash_{model}.csv")
-            benchmark_dot_product_attention(model, "FlashAttention", "FlashAttention Module", filename_flash_attn)
+            os.environ.update({
+                "NVTE_FUSED_ATTN": "0", "NVTE_FLASH_ATTN": "1",
+                "NVTE_FUSED_ATTN_AOTRITON": "0", "NVTE_FUSED_ATTN_CK": "0" , "NVTE_UNFUSED_ATTN": "0"
+            })
+            perf_dir_flash_attn = os.path.join("profiler_outputs/", f"prof_flash_{model}")
+            benchmark_dot_product_attention(model, "FlashAttention", "FlashAttention Module", perf_dir_flash_attn)
            
         if fused_attn_supported:
-            filename_fused_attn = os.path.join("profiler_outputs/", f"prof_fused_{model}.csv")
-            benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention Module", filename_fused_attn)
-            
-            if NVTE_Fused_Attn_Backend.NVTE_CK in fused_attn_backends:
-                #CK Backend
-                os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+
+            os.environ.update({
+                "NVTE_FUSED_ATTN": "1", "NVTE_FLASH_ATTN": "0",
+                "NVTE_FUSED_ATTN_AOTRITON": "0", "NVTE_FUSED_ATTN_CK": "1", "NVTE_UNFUSED_ATTN": "0"
+            })
+            if args.use_ck_bwd_v3:
                 os.environ["NVTE_CK_USES_BWD_V3"] = "1"
-                os.environ["NVTE_FUSED_ATTN_CK"] = "1"
-                os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
-                os.environ["NVTE_FUSED_ATTN"] = "0"
-                filename_fused_ck = os.path.join("profiler_outputs/", f"prof_fused_ck_{model}.csv")
-                benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention CK Module", filename_fused_ck)
-            del os.environ["NVTE_CK_USES_BWD_V3"]
+            
+            # FusedAttention run
+            perf_dir_fused_attn = os.path.join("profiler_outputs/", f"prof_fused_{model}")
+            benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention Module", perf_dir_fused_attn)
+            
+            #FusedAttention CK run
+            if NVTE_Fused_Attn_Backend.NVTE_CK in fused_attn_backends:
+                perf_dir_fused_ck = os.path.join("profiler_outputs/", f"prof_fused_ck_{model}")
+                benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention CK Module", perf_dir_fused_ck)
 
             if NVTE_Fused_Attn_Backend.NVTE_AOTriton in fused_attn_backends:
                 #AOTRITON Backend
-                os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
-                os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
-                os.environ["NVTE_FUSED_ATTN_CK"] = "0"
-                filename_fused_aotriton = os.path.join("profiler_outputs/", f"prof_fused_aotriton_{model}.csv")
-                benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention AOTriton Module", filename_fused_aotriton)
+                os.environ.update({
+                    "NVTE_FUSED_ATTN_AOTRITON": "1", "NVTE_FUSED_ATTN_CK": "0",
+                    "NVTE_CK_USES_BWD_V3": "0", "NVTE_UNFUSED_ATTN": "0"
+                })
+                perf_dir_fused_aotriton = os.path.join("profiler_outputs/", f"prof_fused_aotriton_{model}")
+                benchmark_dot_product_attention(model, "FusedAttention", "FusedAttention AOTriton Module", perf_dir_fused_aotriton)
 
-            del os.environ["NVTE_FUSED_ATTN_CK"]
-            del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
-            del os.environ["NVTE_FUSED_ATTN"]
+            for var in ["NVTE_CK_USES_BWD_V3", "NVTE_FUSED_ATTN_AOTRITON", "NVTE_FUSED_ATTN_CK", "NVTE_FUSED_ATTN", "NVTE_FLASH_ATTN", "NVTE_UNFUSED_ATTN"]:
+                os.environ.pop(var, None)
 
         df_times = pd.read_csv("times.csv", index_col=0)
-        parse_results(model, df_times, filename_flash_attn, filename_fused_attn, filename_fused_ck, filename_fused_aotriton)
+        parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton)
         df_times.to_csv("times.csv")
 
     df_times = pd.read_csv("times.csv")
@@ -266,7 +292,15 @@ def main():
     a.columns = ["cuDNN fwd+bwd (ms)", "flash-attn fwd+bwd (ms)", "cuDNN vs flash speedup"]
     print()
     print(a)
+    if cwd != run_dir:
+        final_profiler_dir = os.path.join(cwd, "profiler_outputs")
+        if os.path.exists(final_profiler_dir):
+            shutil.rmtree(final_profiler_dir)
+        shutil.move("profiler_outputs", final_profiler_dir)
 
-
+        final_csv_path = os.path.join(cwd, output_csv)
+        if os.path.exists(final_csv_path):
+            os.remove(final_csv_path)
+        shutil.move(output_csv, final_csv_path)    
 if __name__ == "__main__":
     main()

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -9,18 +9,16 @@ import subprocess
 import pandas as pd
 import numpy as np
 import torch
-import nvtx
 import transformer_engine
 from transformer_engine_torch import NVTE_Fused_Attn_Backend
 
-# Ensure the working directory includes TransformerEngine in sys.path
-cwd = os.getcwd()
-if "TransformerEngine" in cwd:
-    index = cwd.index("TransformerEngine") + len("TransformerEngine")
-    trimmed_path = cwd[:index]
-    sys.path.append(trimmed_path)
+# Add test_fused_attn to the sys path 
+tests_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../tests/pytorch/fused_attn")
+)
+sys.path.append(tests_path)
 
-from tests.pytorch.fused_attn.test_fused_attn import (
+from test_fused_attn import (
     ModelConfig,
     _get_attention_backends,
     _run_dot_product_attention,
@@ -174,7 +172,8 @@ def parse_results(model, df_times, filename_flash_attn, filename_fused_attn, fil
 
 
 def main():
-    
+    cwd = os.path.dirname(__file__)
+    os.chdir(cwd)
     output_dir = "profiler_outputs/"
     if os.path.exists(output_dir):
         shutil.rmtree(output_dir)

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -202,8 +202,11 @@ def sanity_checks(
     • Checks FusedAttention vs FusedAttention-CK timing within ±tolerance_pct
     • Non-zero exit code on any failure (CI friendly)
     """
-    df = pd.read_csv(os.path.join(cwd, csv_path), index_col=0)
+    print("\n============= Sanity-check results =============")
     ok_overall = True
+    times_csv_path = os.path.join(cwd, csv_path)
+    df = pd.read_csv(times_csv_path, index_col=0)
+    
     tol = tolerance_pct / 100.0
     profiler_root = os.path.join(cwd, profiler_root)
 
@@ -214,7 +217,6 @@ def sanity_checks(
         "FusedAttention AOTriton":  "prof_fused_aotriton_{model}",
     }
 
-    print("\n========== Sanity-check results ==========")
     for model, cfg in model_configs.items():
         avail, fused_bes = _get_attention_backends(
             cfg,
@@ -243,7 +245,7 @@ def sanity_checks(
                 print(f"  [{be:<22}] Profiling successful")
             else:
                 ok_overall = False
-                print(f"  [Error] {be:<16} error in profiling, results.stats.csv not found")
+                raise FileNotFoundError(f"Error while profiling {model} [{be}], results.stats.csv not found")
 
         # Fused Vs Fused CK trace
         if "FusedAttention" in expected and "FusedAttention CK" in expected:
@@ -259,9 +261,10 @@ def sanity_checks(
                           f"(fwd {rel_fwd*100:.2f} %, bwd {rel_bwd*100:.2f} %)")
                 else:
                     ok_overall = False
-                    print(f"  [FAIL] Fused vs CK kernel time diff > {tolerance_pct}% "
+                    raise AssertionError(f" Fused vs CK kernel time diff > {tolerance_pct}% "
                           f"(fwd {rel_fwd*100:.2f} %, bwd {rel_bwd*100:.2f} %)")
         print("-" * 60)
+    return ok_overall
 
 
 def main(args):

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -155,7 +155,7 @@ def parse_helper(model, dirname, fwd_search_pattern, bwd_search_pattern, column_
     df_times.loc[model, f"{column_name} Kernels (fwd+bwd)"] = t_attn_avg.sum() / 1e6
 
 # Parses profiler logs for different attention backends
-def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton):
+def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton, use_ck_bwd_v3):
     if perf_dir_flash_attn:
         parse_helper(model, perf_dir_flash_attn, "FmhaFwd", "FmhaBwd", "FlashAttention", df_times)
 
@@ -163,7 +163,8 @@ def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, per
         parse_helper(model, perf_dir_fused_attn, "FmhaFwd", "FmhaBwd", "FusedAttention", df_times)
 
     if perf_dir_fused_ck:
-        parse_helper(model, perf_dir_fused_ck, "FmhaFwd", "FmhaBwd", "FusedAttention CK", df_times)
+        bwd_pattern = "kernel_func" if use_ck_bwd_v3 else "FmhaBwd"
+        parse_helper(model, perf_dir_fused_ck, "FmhaFwd", bwd_pattern, "FusedAttention CK", df_times)
 
     if perf_dir_fused_aotriton:
         parse_helper(model, perf_dir_fused_aotriton, "attn_fwd", "bwd", "FusedAttention AOTriton", df_times)
@@ -277,7 +278,7 @@ def main():
                 os.environ.pop(var, None)
 
         df_times = pd.read_csv("times.csv", index_col=0)
-        parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton)
+        parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, perf_dir_fused_ck, perf_dir_fused_aotriton, args.use_ck_bwd_v3)
         df_times.to_csv("times.csv")
 
     df_times = pd.read_csv("times.csv")

--- a/benchmarks/attention/benchmark_attention_rocm.py
+++ b/benchmarks/attention/benchmark_attention_rocm.py
@@ -160,7 +160,8 @@ def parse_results(model, df_times, perf_dir_flash_attn, perf_dir_fused_attn, per
         parse_helper(model, perf_dir_flash_attn, "FmhaFwd", "FmhaBwd", "FlashAttention", df_times)
 
     if perf_dir_fused_attn:
-        parse_helper(model, perf_dir_fused_attn, "FmhaFwd", "FmhaBwd", "FusedAttention", df_times)
+        bwd_pattern = "kernel_func" if use_ck_bwd_v3 else "FmhaBwd"
+        parse_helper(model, perf_dir_fused_attn, "FmhaFwd", bwd_pattern, "FusedAttention", df_times)
 
     if perf_dir_fused_ck:
         bwd_pattern = "kernel_func" if use_ck_bwd_v3 else "FmhaBwd"

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -90,7 +90,7 @@ run_benchmark() {
         return
     fi
 
-    python "$BENCH_SCRIPT" --use_ck_bwd_v3
+    python "$BENCH_SCRIPT" --use_ck_bwd_v3 --run_sanity_checks
     echo "================================================================\n"
 }
 

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -106,8 +106,6 @@ fi
 #Master script mode: prepare testing prerequisites first
 start_message
 install_prerequisites
-# Run benchmark
-run_benchmark
 pip list | egrep "flash|ml_dtypes|numpy|onnx|torch|transformer_e|typing_ext"
 #check_test_jobs_requested && init_test_jobs `python -c "import torch; print(torch.cuda.device_count())"`
 
@@ -148,4 +146,10 @@ if [ -n "$TEST_JOBS_MODE" -a -n "$TEST_MGPU" ]; then
         configure_gemm_env $_gemm && configure_fused_attn_env $_fus_attn && run_test_config_mgpu;
     done
 fi
+
+#run benchmark script
+if [ $TEST_LEVEL -ge 3 ]; then
+    run_benchmark
+fi
+
 return_run_results

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -81,6 +81,19 @@ run_test_config_mgpu(){
     fi
 }
 
+run_benchmark() {
+    echo "\n============= Running benchmarks attention script ============="
+    BENCH_SCRIPT="$DIR/../benchmarks/attention/benchmark_attention_rocm.py"
+
+    if [ ! -f "$BENCH_SCRIPT" ]; then
+        echo "Benchmark script not found: $BENCH_SCRIPT"
+        return
+    fi
+
+    python "$BENCH_SCRIPT" --use_ck_bwd_v3
+    echo "================================================================\n"
+}
+
 # Single config mode, run it and return result
 if [ -n "$SINGLE_CONFIG" ]; then
     _gemm=`echo $SINGLE_CONFIG | cut -d- -f1`
@@ -93,6 +106,8 @@ fi
 #Master script mode: prepare testing prerequisites first
 start_message
 install_prerequisites
+# Run benchmark
+run_benchmark
 pip list | egrep "flash|ml_dtypes|numpy|onnx|torch|transformer_e|typing_ext"
 #check_test_jobs_requested && init_test_jobs `python -c "import torch; print(torch.cuda.device_count())"`
 

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -82,16 +82,20 @@ run_test_config_mgpu(){
 }
 
 run_benchmark() {
+    check_test_filter benchmark || return
     echo "\n============= Running benchmarks attention script ============="
     BENCH_SCRIPT="$DIR/../benchmarks/attention/benchmark_attention_rocm.py"
+    
+    if command -v realpath >/dev/null 2>&1; then
+        BENCH_SCRIPT=$(realpath "$DIR/../benchmarks/attention/benchmark_attention_rocm.py")
+    fi
 
     if [ ! -f "$BENCH_SCRIPT" ]; then
         echo "Benchmark script not found: $BENCH_SCRIPT"
         return
     fi
 
-    python "$BENCH_SCRIPT" --use_ck_bwd_v3 --run_sanity_checks
-    echo "================================================================\n"
+    python "$BENCH_SCRIPT" --use_ck_bwd_v3 --run_sanity_checks || test_run_error $BENCH_SCRIPT
 }
 
 # Single config mode, run it and return result


### PR DESCRIPTION
# Description

**Added --use_ck_bwd_v3**
- Enables CK backward-v3 kernels only when the flag is passed.
- parse_results() now looks for kernel_func when v3 is active, ensuring the correct fwd/bwd kernel times are captured in times.csv.

**Added --run_sanity_checks**
Opt-in verification new  flag post-processes profiler output, ensuring every backend that should have run produced a valid results.stats.csv, and that fused vs CK kernel timings agree within a configurable tolerance.

**ci/pytorch.sh** calls the benchmark with both --use_ck_bwd_v3 and --run_sanity_checks when TEST_LEVEL ≥ 3, automatically gating performance regressions.
Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
