### PR TITLE
[release1.14] Fixed hipblaslt precision issue with mi300 on rocm6.4 & hipblaslt12 d…

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1972,7 +1972,7 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
     if IS_HIP_EXTENSION:
         if use_hipblaslt():
             tols = dtype_tols(dtype)
-            if dtype in (torch.float16, torch.bfloat16) and is_mi308():
+            if dtype in (torch.float16, torch.bfloat16):
                 # mi308 hipblaslt precision issue
                 tols["atol"] = 2e-3
                 _, use_aotriton, use_ck = rocm_attn_backend()


### PR DESCRIPTION
…ocker

# Description

Relax tolerance due to hipblaslt change on rocm6.4 rocm6.4 hipblaslt12 docker image for mi300 in test_numerics.py
test_transformer_layer_hidden_states_format[126m-2-dtype2]
test_transformer_layer_hidden_states_format[126m-2-dtype1]

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adjusted tolerances for mi300

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
