### PR TITLE
Avoid poisoning process with JAX calls on TE import

### DIFF
--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -3,6 +3,8 @@
 #
 # See LICENSE for license information.
 
+export NVTE_FRAMEWORK=jax
+
 DIR=`dirname $0`
 
 . $DIR/_utils.sh
@@ -80,6 +82,8 @@ run_test_config_mgpu() {
     JAX_DISABLE_JIT=$_JAX_DISABLE_JIT_FLAG run_default_fa 3 test_distributed_layernorm_mlp.py
     run_default_fa 3 test_distributed_softmax.py
     unset XLA_FLAGS
+
+    run_default_fa 3 test_sanity_import.py
 }
 
 # Single config mode, run it synchroniously and return result

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -74,12 +74,13 @@ run_test_config(){
 run_test_config_mgpu(){
     #_WORKERS_COUNT=1
     #test $TEST_WORKERS = 0 && _WORKERS_COUNT=0
-    if [ $_fus_attn = "auto"]; then
+    if [ $_fus_attn = "auto" ]; then
         echo ==== Run mGPU with Fused attention backend: $_fus_attn ====
         run 3 test_fused_optimizer.py
+        run 3 test_sanity_import.py
         run 3 distributed/test_fusible_ops.py
-        run 3 fused_attn/test_fused_attn_with_cp.py
         run 3 distributed/test_numerics.py
+        run 3 fused_attn/test_fused_attn_with_cp.py
     fi
 }
 

--- a/tests/jax/test_sanity_import.py
+++ b/tests/jax/test_sanity_import.py
@@ -1,7 +1,23 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
 
 import transformer_engine.jax
 
-print("OK")
+if __name__ == "__main__":
+    print("OK")
+
+def test_lazy_init():
+    import jax, os, pytest, subprocess, sys
+    dev_count = jax.local_device_count()
+    if dev_count < 2:
+        pytest.skip("Test requires several visible devices")
+    os.environ["NVTE_FRAMEWORK"] = "jax"
+    dev_count_test = subprocess.run([sys.executable, '-c', 
+                                     "import transformer_engine, jax, os; " +
+                                     "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+                                     "exit(jax.local_device_count())"]
+                                     ).returncode
+    assert dev_count_test==1, "Changing visible devices after import did not affect device count"

--- a/tests/pytorch/test_sanity_import.py
+++ b/tests/pytorch/test_sanity_import.py
@@ -1,7 +1,23 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
 
 import transformer_engine.pytorch
 
-print("OK")
+if __name__ == "__main__":
+    print("OK")
+
+def test_lazy_init():
+    import torch, os, pytest, subprocess, sys
+    dev_count = torch.cuda.device_count()
+    if dev_count < 2:
+        pytest.skip("Test requires several visible devices")
+    os.environ["NVTE_FRAMEWORK"] = "pytorch"
+    dev_count_test = subprocess.run([sys.executable, '-c', 
+                                     "import transformer_engine, torch, os; " +
+                                     "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+                                     "exit(torch.cuda.device_count())"]
+                                     ).returncode
+    assert dev_count_test==1, "Changing visible devices after import did not affect device count"

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -7,20 +9,37 @@
 # pylint: disable=unused-import
 
 from importlib import metadata
+import os
 import transformer_engine.common
 
+_use_pytorch = True
+_use_jax = True
+
+if os.getenv("NVTE_FRAMEWORK"):
+    _frameworks=os.getenv("NVTE_FRAMEWORK").split(",")
+
+    # Special framework names
+    if "none" in _frameworks:
+        _use_pytorch = False
+        _use_jax = False
+    elif "all" in _frameworks:
+        pass
+    else:
+        _use_pytorch = "pytorch" in _frameworks
+        _use_jax = "jax" in _frameworks
+
 try:
-    from . import pytorch
+    if _use_pytorch: from . import pytorch
 except (ImportError, StopIteration) as e:
     pass
 
 try:
-    from . import jax
+    if _use_jax: from . import jax
 except (ImportError, StopIteration) as e:
     pass
 
 try:
-    import transformer_engine_jax
+    if _use_jax: import transformer_engine_jax
 except ImportError:
     pass
 

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -6,6 +6,7 @@
 
 """FW agnostic user-end APIs"""
 
+import functools
 import sys
 import glob
 import sysconfig
@@ -118,13 +119,18 @@ def _load_nvrtc():
     return ctypes.CDLL(f"libnvrtc.{_get_sys_extension()}", mode=ctypes.RTLD_GLOBAL)
 
 te_rocm_build = False
-te_uses_fp8_fnuz = False
+
+@functools.cache
+def is_fp8_fnuz():
+    if te_rocm_build:
+        return _TE_LIB_CTYPES.nvte_uses_fp8_fnuz()
+    return False
 
 if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
     try:
         _CUDNN_LIB_CTYPES = _load_cudnn()
         _NVRTC_LIB_CTYPES = _load_nvrtc()
-    except OSError:
+    except (OSError, subprocess.CalledProcessError):
         pass
     _TE_LIB_CTYPES = _load_library()
     try:
@@ -133,7 +139,6 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
         # If the function is not available, we assume it's not a ROCm build
         te_rocm_build = False
     if te_rocm_build:
-        te_uses_fp8_fnuz = _TE_LIB_CTYPES.nvte_uses_fp8_fnuz()
         try:
             # Get installed ROCm version
             with open(os.getenv("ROCM_PATH", "/opt/rocm") + "/.info/version", "r") as f:

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -12,17 +12,30 @@ from enum import Enum
 from typing import Optional, Union, Callable, NamedTuple
 from typing_extensions import Literal
 from pydantic.dataclasses import dataclass
-from transformer_engine.common import te_uses_fp8_fnuz
+from transformer_engine.common import is_fp8_fnuz
 
 
 class _FormatHelper(NamedTuple):
     """
     Stores max FP8 values for fprop and bprop a `Format`.
     """
+    fwd: tuple
+    bwd: tuple
 
-    max_fwd: float
-    max_bwd: float
+    @property
+    def max_fwd(self) -> float: 
+        return self.fwd[is_fp8_fnuz()]
 
+    @property
+    def max_bwd(self) -> float:
+        return self.bwd[is_fp8_fnuz()]
+
+class _FormatMaxVals(Enum):
+    """
+    Tuples of FP8 (OCP, FNUZ) values for different formats.
+    """
+    E4M3 = (448, 240)
+    E5M2 = (57344, 57344)
 
 class Format(Enum):
     """
@@ -38,10 +51,9 @@ class Format(Enum):
             FP8 tensors in the forward pass are in e4m3 format,
             FP8 tensors in the backward pass are in e5m2 format
     """
-    E4M3 = (_FormatHelper(max_fwd=240, max_bwd=240) if te_uses_fp8_fnuz
-            else _FormatHelper(max_fwd=448, max_bwd=448))
-    E5M2 = _FormatHelper(max_fwd=57344, max_bwd=57344)
-    HYBRID = _FormatHelper(max_fwd=E4M3.max_fwd, max_bwd=E5M2.max_bwd)
+    E4M3 = _FormatHelper(fwd=_FormatMaxVals.E4M3.value, bwd=_FormatMaxVals.E4M3.value) 
+    E5M2 = _FormatHelper(fwd=_FormatMaxVals.E5M2.value, bwd=_FormatMaxVals.E5M2.value)
+    HYBRID = _FormatHelper(fwd=E4M3.fwd, bwd=E5M2.bwd)
 
 
 class Recipe:

--- a/transformer_engine/jax/fp8.py
+++ b/transformer_engine/jax/fp8.py
@@ -178,12 +178,19 @@ class FP8Helper:
     """
     FP8 helper to manage the FP8 meta
     """
+    class dtype_getter:
+        def __init__(self, id):
+            self.id = id
+
+        def __get__(self, obj, objtype=None) -> DType:
+            return _format2dtypes(FP8Helper.FP8_FORMAT)[self.id]
+
 
     INITIALIZED = False
     MARGIN: float = 0.0
     FP8_FORMAT: Format = Format.HYBRID
-    FWD_DTYPE: DType = _format2dtypes(Format.HYBRID)[0]
-    BWD_DTYPE: DType = _format2dtypes(Format.HYBRID)[1]
+    FWD_DTYPE = dtype_getter(0)
+    BWD_DTYPE = dtype_getter(1)
     AMAX_HISTORY_LEN: int = 1024
     AMAX_COMPUTE_ALGO: AmaxComputeAlgo = AmaxComputeAlgo.MAX
     FP8_COLLECTION_NAME: str = NVTE_FP8_COLLECTION_NAME
@@ -213,7 +220,6 @@ class FP8Helper:
         FP8Helper.INITIALIZED = True
         FP8Helper.MARGIN = margin
         FP8Helper.FP8_FORMAT = fp8_format
-        FP8Helper.FWD_DTYPE, FP8Helper.BWD_DTYPE = _format2dtypes(FP8Helper.FP8_FORMAT)
         FP8Helper.AMAX_HISTORY_LEN = amax_history_len
         FP8Helper.AMAX_COMPUTE_ALGO = amax_compute_algo
         FP8Helper.FP8_2X_ACC_FPROP = False
@@ -228,7 +234,6 @@ class FP8Helper:
         FP8Helper.INITIALIZED = False
         FP8Helper.MARGIN = 0.0
         FP8Helper.FP8_FORMAT = Format.HYBRID
-        FP8Helper.FWD_DTYPE, FP8Helper.BWD_DTYPE = _format2dtypes(FP8Helper.FP8_FORMAT)
         FP8Helper.AMAX_HISTORY_LEN = 1024
         FP8Helper.AMAX_COMPUTE_ALGO = AmaxComputeAlgo.MAX
 


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes [12251](https://github.com/ROCm/frameworks-internal/issues/12251)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Avoid making JAX device calls when import TE
- Allow skipping framework integration loading based on env variables
- Add test for poisoning for Pytorch and JAX
- Add NV libraries related exception handling when loading TE on ROCm system with CUDNN installed 

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
