### PR TITLE
Remove filtering of supported cudagraph tests

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1818,8 +1818,6 @@ def test_gpt_cuda_graph(dtype, bs, model):
             use_fa, use_aotriton, use_ck = rocm_attn_backend()
             if use_fa:
                 pytest.skip(f"ROCm flash attention does not support cuda graph with {dtype}")
-            if use_aotriton and not use_ck:
-                pytest.skip(f"AOTriton attention backend does not support cuda graph with {dtype}")
 
     config = model_configs[model]
 

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -940,9 +940,6 @@ def test_sanity_gradient_accumulation_fusion(
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
 @pytest.mark.parametrize("normalization", all_normalizations)
 def test_gpt_cuda_graph(dtype, fp8_recipe, model, skip_wgrad, zero_centered_gamma, normalization):
-    if IS_HIP_EXTENSION:
-        if dtype in (torch.float16, torch.bfloat16):
-            pytest.skip(f"ROCm fused attention backends do not support cuda graph with {dtype}")
 
     config = model_configs[model]
 


### PR DESCRIPTION
# Description

Supported cuda_graph test has been enabled. Some filters, including in test_gpt_cuda_graph in test_numerics.py still apply.

Fixes #12672


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Enabled test_gpt_cuda_graph in test_sanity.py for fp16 and bf16.
- Enabled test_gpt_cuda_graph in test_numerics.py for fp16 and bf16 for everything but flash attention.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
