### PR TITLE
Fix te_fp8_fnuz undefined when ROCm version is 6.2

### DIFF
--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -185,13 +185,21 @@ inline at::ScalarType GetATenDType(transformer_engine::DType t) {
 #ifndef USE_ROCM
       return at::kFloat8_e4m3fn;
 #else
+  #if HIP_VERSION >= 60300000
       return te_fp8_fnuz()? at::kFloat8_e4m3fnuz : at::kFloat8_e4m3fn;
+  #else
+      return at::kFloat8_e4m3fnuz;
+  #endif
 #endif // USE_ROCM
     case transformer_engine::DType::kFloat8E5M2:
 #ifndef USE_ROCM
       return at::kFloat8_e5m2;
 #else
+  #if HIP_VERSION >= 60300000
       return te_fp8_fnuz()? at::kFloat8_e5m2fnuz : at::kFloat8_e5m2;
+  #else
+      return at::kFloat8_e5m2fnuz;
+  #endif
 #endif // USE_ROCM
     default:
       NVTE_ERROR("Invalid type");


### PR DESCRIPTION
# Description

Before https://github.com/ROCm/clr/commit/353f15afa6cfb0fc1eebbc618be47e0cb639c321 (In ROCm6.2), FP8 OCP is not added and the code implementation is in FNUZ, so we define `te_fp8_fnuz()` to return true, to fix the following error:

```log
  In file included from TransformerEngine/transformer_engine/pytorch/csrc/extensions_hip.h:15:
  TransformerEngine/transformer_engine/pytorch/csrc/common_hip.h:189:14: error: use of undeclared identifier 'te_fp8_fnuz'
    189 |       return te_fp8_fnuz()? at::kFloat8_e4m3fnuz : at::kFloat8_e4m3fn;
        |              ^
  TransformerEngine/transformer_engine/pytorch/csrc/common_hip.h:195:14: error: use of undeclared identifier 'te_fp8_fnuz'
    195 |       return te_fp8_fnuz()? at::kFloat8_e5m2fnuz : at::kFloat8_e5m2;
        |              ^
  2 errors generated when compiling for gfx90a.
```
## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- No use of `te_fp8_fnuz` for ROCm below 6.3

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes