### PR TITLE
Fix wheel building on top of minimal ROCm installation

### DIFF
--- a/build_tools/wheel_utils/Dockerfile.rocm.manylinux.x86
+++ b/build_tools/wheel_utils/Dockerfile.rocm.manylinux.x86
@@ -16,11 +16,12 @@ RUN dnf install -y epel-release elrepo-release
 RUN dnf config-manager --set-enabled build_system powertools extras epel elrepo
 
 # Setup dev packages
-RUN dnf group install -y "Development Tools" && dnf install -y git cmake llvm-toolset
+RUN dnf group install -y "Development Tools" && \
+    dnf install -y git cmake llvm-toolset hipblaslt hipblaslt-devel gcc-toolset-12
 RUN dnf clean all
 RUN rm -rf /var/cache/dnf/*
 
-ENV CMAKE_PREFIX_PATH=${ROCM_PATH}/lib/cmake
+ENV CMAKE_PREFIX_PATH=/opt/rocm/lib/cmake
 ENV NVTE_RELEASE_BUILD=1
 
 ARG GPU_TARGETS="gfx942"

--- a/build_tools/wheel_utils/build_wheels.sh
+++ b/build_tools/wheel_utils/build_wheels.sh
@@ -21,7 +21,7 @@ git config --global --add safe.directory /TransformerEngine
 cd /TransformerEngine
 
 #If there is default Python installation, use it
-PYTHON=`which python`
+PYTHON=`which python || true`
 if [ -z "$PYTHON" ]; then
         PYBINDIR=/opt/python/cp310-cp310/bin/
 else

--- a/build_tools/wheel_utils/build_wheels.sh
+++ b/build_tools/wheel_utils/build_wheels.sh
@@ -50,7 +50,10 @@ if $BUILD_COMMON ; then
         WHL_BASE="transformer_engine-${VERSION}"
         if [ "$ROCM_BUILD" = "1" ]; then
                 TE_CUDA_VERS="rocm"
-                ${PYBINDIR}pip install ninja
+                ${PYBINDIR}pip install ninja dataclasses
+                if [ -n "$PYBINDIR" ]; then
+                        PATH="$PYBINDIR:$PATH" #hipify expects python in PATH
+                fi
         else
                 TE_CUDA_VERS="cu12"
                 PYBINDIR=/opt/python/cp38-cp38/bin/


### PR DESCRIPTION
# Description

Don't fail wheel building if path to python is not set

Hot fix on top of [#12320](https://github.com/ROCm/frameworks-internal/issues/12320)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Suppress error throwing fro which when it fails to find python

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
