### PR TITLE
Fix building on ROCm6.2

### DIFF
--- a/transformer_engine/common/amd_detail/hip_float8.h
+++ b/transformer_engine/common/amd_detail/hip_float8.h
@@ -37,6 +37,10 @@ static inline bool te_fp8_fnuz() {
 
 #include <hip/hip_version.h> //For RTC it should be included explicitly
 
+#if defined(__HIP_DEVICE_COMPILE__) && HIP_VERSION < 60300000
+static constexpr inline bool te_fp8_fnuz() { return true; }
+#endif
+
 #if HIP_VERSION >= 60200000
 #include <hip/hip_fp8.h>
 
@@ -70,11 +74,11 @@ typedef _te_hip_fp8<__hip_fp8_e5m2_fnuz, __hip_fp8_e5m2> _te_hip_fp8_e5m2;
 #elif HIP_FP8_TYPE_FNUZ
 typedef __hip_fp8_e4m3_fnuz _te_hip_fp8_e4m3;
 typedef __hip_fp8_e5m2_fnuz _te_hip_fp8_e5m2;
-static inline bool te_fp8_fnuz() { return true; }
+static constexpr inline bool te_fp8_fnuz() { return true; }
 #elif HIP_FP8_TYPE_OCP
 typedef __hip_fp8_e4m3 _te_hip_fp8_e4m3;
 typedef __hip_fp8_e5m2 _te_hip_fp8_e5m2;
-static inline bool te_fp8_fnuz() { return false; }
+static constexpr inline bool te_fp8_fnuz() { return false; }
 #else
 #error "Unsupported HIP_FP8_TYPE"
 #endif //__HIP_DEVICE_COMPILE__


### PR DESCRIPTION
# Description

Declare te_fp8_fnuz() on ROCm 6.2

Fixes issue from PR https://github.com/ROCm/TransformerEngine/pull/219

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Declare te_fp8_fnuze when compile device path on ROCm < 6.3
Declare immutable te_fp8_fnuz declarations as constexpr

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
