### PR TITLE
Avoid early call of `is_cdna4`

### DIFF
--- a/tests/pytorch/triton_kernels/test_common.py
+++ b/tests/pytorch/triton_kernels/test_common.py
@@ -8,11 +8,9 @@ import numpy as np
 import pytest
 import torch
 
-from transformer_engine.pytorch import cpp_extensions as tex
-
 from transformer_engine.pytorch.triton_kernels.common import (
-    torch_e4m3_type,
-    torch_e5m2_type,
+    get_torch_e4m3_type,
+    get_torch_e5m2_type,
 )
 
 # Mimics behavior of `fillUniform` from `tests/cpp/test_common.cu`.
@@ -37,7 +35,7 @@ def get_tolerances(dtype):
         return 1e-5, 1e-3
     elif dtype == torch.bfloat16:
         return 1e-5, 1e-2
-    elif dtype == torch_e4m3_type or dtype == torch_e5m2_type:
+    elif dtype == get_torch_e4m3_type() or dtype == get_torch_e5m2_type():
         # TODO: different tolerances for FNUZ and OCP
         return 1e-2, 1e-2
     else:
@@ -129,8 +127,8 @@ def str_to_torch_dtype(dtype_str):
         "fp16": torch.float16,
         "bf16": torch.bfloat16,
         "fp32": torch.float32,
-        "fp8e4": torch_e4m3_type,
-        "fp8e5": torch_e5m2_type,
+        "fp8e4": get_torch_e4m3_type(),
+        "fp8e5": get_torch_e5m2_type(),
     }[dtype_str[1:] if dtype_str[0] in {"i", "o"} else dtype_str]
 
 # Common pytest skip conditions:

--- a/transformer_engine/pytorch/triton_kernels/common.py
+++ b/transformer_engine/pytorch/triton_kernels/common.py
@@ -1,19 +1,16 @@
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # License for AMD contributions = MIT. See LICENSE for more information
 
-import os
 import torch
 import triton
 import triton.language as tl
-from transformer_engine import pytorch as te
 import transformer_engine_torch as tex
-from ..utils import is_fp8_fnuz
 
 def is_cdna4():
     return triton.runtime.driver.active.get_current_target().arch == "gfx950"
 
-torch_e4m3_type = torch.float8_e4m3fn if is_cdna4() else torch.float8_e4m3fnuz
-torch_e5m2_type = torch.float8_e5m2 if is_cdna4() else torch.float8_e5m2fnuz
+get_torch_e4m3_type = lambda: torch.float8_e4m3fn if is_cdna4() else torch.float8_e4m3fnuz
+get_torch_e5m2_type = lambda: torch.float8_e5m2 if is_cdna4() else torch.float8_e5m2fnuz
 
 # Convert te dtype to torch type.
 def te_dtype_to_torch_dtype(te_dtype):
@@ -23,8 +20,8 @@ def te_dtype_to_torch_dtype(te_dtype):
         tex.DType.kFloat32: torch.float32, 
         tex.DType.kFloat16: torch.float16, 
         tex.DType.kBFloat16: torch.bfloat16, 
-        tex.DType.kFloat8E4M3: torch_e4m3_type, 
-        tex.DType.kFloat8E5M2: torch_e5m2_type, 
+        tex.DType.kFloat8E4M3: get_torch_e4m3_type(), 
+        tex.DType.kFloat8E5M2: get_torch_e5m2_type(), 
     }[te_dtype]
 
 # Convert PyTorch type to TE type.
@@ -81,17 +78,17 @@ def enum_value_to_te_dtype(te_dtype_enum):
     }[te_dtype_enum]
 
 def is_fp8_torch_dtype(dtype):
-    return (dtype == torch_e4m3_type) or (dtype == torch_e5m2_type)
+    return dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz)
 
 def te_dtype_to_triton_dtype(dtype: tex.DType):
     if dtype == tex.DType.kFloat8E4M3:
-        return tl.float8e4b8 if is_fp8_fnuz() else tl.float8e4nv
+        return tl.float8e4b8 if not is_cdna4() else tl.float8e4nv
     if dtype == tex.DType.kFloat8E5M2:
-        return tl.float8e5b16 if is_fp8_fnuz() else tl.float8e5
+        return tl.float8e5b16 if not is_cdna4() else tl.float8e5
 
 def get_fp8_max(dtype: tex.DType):
     if dtype == tex.DType.kFloat8E4M3:
-        return 240.0 if is_fp8_fnuz() else 448.0
+        return 240.0 if not is_cdna4() else 448.0
     if dtype == tex.DType.kFloat8E5M2:
         return 57344.0
 


### PR DESCRIPTION
# Description

Similar to #183, Let's not call `is_fp8_fnuz` outside any function, as that will call `triton.runtime.driver.active.get_current_target()` as soon as importing, and that might be too early to call, since the `CUDA/HIP/ROCM_VISIBLE_DEVICES` may not be set properly at this stage.


```log
  File "megatron/core/__init__.py", line 3, in <module>
    import megatron.core.tensor_parallel
  File "megatron/core/tensor_parallel/__init__.py", line 4, in <module>
    from .layers import (
  File "megatron/core/tensor_parallel/layers.py", line 27, in <module>
    from ..transformer.utils import make_sharded_tensors_for_checkpoint
  File "megatron/core/transformer/__init__.py", line 6, in <module>
    from .transformer_layer import TransformerLayer, TransformerLayerSubmodules
  File "megatron/core/transformer/transformer_layer.py", line 16, in <module>
    from megatron.core.transformer.cuda_graphs import CudaGraphManager
  File "megatron/core/transformer/cuda_graphs.py", line 15, in <module>
    from megatron.core.tensor_parallel.random import (
  File "megatron/core/tensor_parallel/random.py", line 26, in <module>
    import transformer_engine  # pylint: disable=unused-import
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "transformer_engine/__init__.py", line 32, in <module>
    if _use_pytorch: from . import pytorch
                     ^^^^^^^^^^^^^^^^^^^^^
  File "transformer_engine/pytorch/__init__.py", line 69, in <module>
    from transformer_engine.pytorch.module import LayerNormLinear
  File "transformer_engine/pytorch/module/__init__.py", line 6, in <module>
    from .layernorm_linear import LayerNormLinear
  File "transformer_engine/pytorch/module/layernorm_linear.py", line 21, in <module>
    from .base import (
  File "transformer_engine/pytorch/module/base.py", line 26, in <module>
    from ._common import _ParameterInitMeta
  File "transformer_engine/pytorch/module/_common.py", line 27, in <module>
    from ..triton_kernels.layernorm import te_layernorm_bwd_triton
  File "transformer_engine/pytorch/triton_kernels/layernorm.py", line 12, in <module>
    from .common import (
  File "transformer_engine/pytorch/triton_kernels/common.py", line 15, in <module>
    torch_e4m3_type = torch.float8_e4m3fn if is_cdna4() else torch.float8_e4m3fnuz
                                             ^^^^^^^^^^
  File "transformer_engine/pytorch/triton_kernels/common.py", line 13, in is_cdna4
    return triton.runtime.driver.active.get_current_target().arch == "gfx950"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "triton/runtime/driver.py", line 23, in __getattr__
    self._initialize_obj()
  File "triton/runtime/driver.py", line 20, in _initialize_obj
    self._obj = self._init_fn()
                ^^^^^^^^^^^^^^^
  File "triton/runtime/driver.py", line 8, in _create_driver
    raise RuntimeError(f"{len(actives)} active drivers ({actives}). There should only be one.")
RuntimeError: 0 active drivers ([]). There should only be one.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- make get_torch_e4m3_type as a lambda function
- make get_torch_e5m2_type as a lambda function

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
