### PR TITLE
Temporary fix for datasets package version

### DIFF
--- a/examples/jax/encoder/requirements.txt
+++ b/examples/jax/encoder/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets<4.0.0
 flax>=0.7.1
 nltk>=3.8.2
 optax

--- a/examples/jax/mnist/requirements.txt
+++ b/examples/jax/mnist/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets<4.0.0
 flax>=0.7.1
 optax
 Pillow


### PR DESCRIPTION
# Description

Datatsets pip package v4.0.0 causes error while doing CI Tests. This is a temporary fix to limit to previous version of v4.0.0.

Fixes # (issue)
[12896](https://github.com/ROCm/frameworks-internal/issues/12896)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
Changed the requirements.txt for limiting the version for the datasets package under the following directories.
`examples/jax/mnist`
`examples/jax/encoder`

# Checklist:

- [x ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
