### PR TITLE
Initial implementation of FP8 RMSNorm support

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
+# Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
 # See LICENSE for license information.
 
 from __future__ import annotations
@@ -16,9 +16,6 @@ import transformer_engine.common.recipe
 import transformer_engine.pytorch as te
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
-from transformer_engine.pytorch.triton_kernels.common import (
-    te_dtype_to_torch_dtype,
-)
 from transformer_engine.pytorch.ops.fused import (
     BackwardLinearAdd,
     ForwardLinearBiasActivation,

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -23,6 +23,7 @@ from transformer_engine.pytorch.ops.fused import (
 )
 from transformer_engine.pytorch.tensor import QuantizedTensor
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor, Float8Quantizer
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor, MXFP8Quantizer
 from transformer_engine.pytorch.utils import is_bf16_compatible
 import transformer_engine_torch as tex
 
@@ -1252,11 +1253,16 @@ class TestBasicOps:
         assert y_test.dtype == dtype
         # Expected numerical error
         tols = dtype_tols(dtype)
+
+        # Explicit checks for quantization
         if quantized_compute:
             tols = dtype_tols(y_test._quantizer.dtype)
-            assert isinstance(y_test, Float8Tensor)
+            expected_tensor_cls = {
+                Float8Quantizer:Float8Tensor,
+                MXFP8Quantizer:MXFP8Tensor
+            }[type(y_test._quantizer)]
+            assert isinstance(y_test, expected_tensor_cls)
             y_test = y_test.dequantize(dtype=torch.float32)
-            y_test = y_test.to(device="cpu")
 
         # Check results
         y_test = y_test.to(dtype=torch.float64, device="cpu")

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1,5 +1,7 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# This file was modified for portability to AMDGPU
 # Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
 # See LICENSE for license information.
 
 from __future__ import annotations

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -7,18 +7,18 @@ from __future__ import annotations
 from collections.abc import Iterable
 import math
 from typing import Optional
-import os
 
 import pytest
 import torch
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import transformer_engine
 import transformer_engine.common.recipe
 import transformer_engine.pytorch as te
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
-from transformer_engine.pytorch.ops._common import is_float8_tensor
+from transformer_engine.pytorch.triton_kernels.common import (
+    te_dtype_to_torch_dtype,
+)
 from transformer_engine.pytorch.ops.fused import (
     BackwardLinearAdd,
     ForwardLinearBiasActivation,
@@ -1256,7 +1256,7 @@ class TestBasicOps:
         # Expected numerical error
         tols = dtype_tols(dtype)
         if quantized_compute:
-            tols = dtype_tols(tex.DType.kFloat8E4M3)
+            tols = dtype_tols(y_test._quantizer.dtype)
             assert isinstance(y_test, Float8Tensor)
             y_test = y_test.dequantize(dtype=torch.float32)
             y_test = y_test.to(device="cpu")

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1252,14 +1252,16 @@ class TestBasicOps:
             y_test = forward(x_test)
         y_test.backward(dy_test)
 
+        assert y_test.dtype == dtype
         # Expected numerical error
         tols = dtype_tols(dtype)
         if quantized_compute:
             tols = dtype_tols(tex.DType.kFloat8E4M3)
             assert isinstance(y_test, Float8Tensor)
+            y_test = y_test.dequantize(dtype=torch.float32)
+            y_test = y_test.to(device="cpu")
 
         # Check results
-        assert y_test.dtype == dtype
         y_test = y_test.to(dtype=torch.float64, device="cpu")
         dx_test = x_test.grad.to(dtype=torch.float64, device="cpu")
         dw_test = op.weight.grad.to(dtype=torch.float64, device="cpu")

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1249,28 +1249,17 @@ class TestBasicOps:
             te_ops.Quantize(forward=quantized_compute, backward=False),
         )
         with te.fp8_autocast(enabled=quantized_compute, fp8_recipe=recipe):
-            # TODO: Remove when we support FP8 quantization in the rmsnorm
-            # triton kernels natively
-            if (
-                IS_HIP_EXTENSION
-                and bool(int(os.environ.get('NVTE_USE_RMSNORM_TRITON', '0')))
-                and quantization
-            ):
-                with pytest.warns(
-                    RuntimeWarning,
-                    match="FP8 is not yet supported in our RMSNorm Triton kernel"
-                ):
-                    y_test = forward(x_test)
-            else:
-                y_test = forward(x_test)
+            y_test = forward(x_test)
         y_test.backward(dy_test)
 
         # Expected numerical error
         tols = dtype_tols(dtype)
         if quantized_compute:
             tols = dtype_tols(tex.DType.kFloat8E4M3)
+            assert isinstance(y_test, Float8Tensor)
 
         # Check results
+        assert y_test.dtype == dtype
         y_test = y_test.to(dtype=torch.float64, device="cpu")
         dx_test = x_test.grad.to(dtype=torch.float64, device="cpu")
         dw_test = op.weight.grad.to(dtype=torch.float64, device="cpu")

--- a/tests/pytorch/triton_kernels/test_common.py
+++ b/tests/pytorch/triton_kernels/test_common.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # License for AMD contributions = MIT. See LICENSE for more information
-
+from __future__ import annotations
 
 import types
+from typing import Optional
+from collections.abc import Iterable
 
 import numpy as np
 import pytest
 import torch
+import math
 
 from transformer_engine.pytorch import cpp_extensions as tex
+from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 
 from transformer_engine.pytorch.triton_kernels.common import (
     torch_e4m3_type,
@@ -145,3 +149,40 @@ def skip_mixed_16bit_float_types(in_dtype, out_dtype):
         in_dtype == torch.bfloat16 and out_dtype == torch.float16
     ):
         pytest.skip("hipified implementation does not support mixing fp16 and bf16")
+
+
+# Check if FP8 is supported
+fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()
+mxfp8_available, reason_for_no_mxfp8 = FP8GlobalStateManager.is_mxfp8_available()
+
+
+def maybe_skip_quantization(
+    quantization: Optional[str],
+    *,
+    dims: Optional[Iterable[int] | int] = None,
+    device: Optional[torch.device | str] = None,
+) -> None:
+
+    # Don't skip if there is no quantization
+    if quantization is None:
+        return
+
+    # Check if quantization scheme is supported
+    if quantization == "fp8" and not fp8_available:
+        pytest.skip(reason_for_no_fp8)
+    if quantization == "mxfp8" and not mxfp8_available:
+        pytest.skip(reason_for_no_mxfp8)
+
+    if dims is not None:
+        if not isinstance(dims, Iterable):
+            dims = (dims,)
+        if quantization == "fp8":
+            if math.prod(dims[:-1]) % 16 != 0 or dims[-1] % 16 != 0:
+                pytest.skip("FP8 GEMMs require dims that are divisible by 16")
+        elif quantization == "mxfp8":
+            if math.prod(dims[:-1]) % 32 != 0 or dims[-1] % 32 != 0:
+                pytest.skip("MXFP8 GEMMs require dims that are divisible by 32")
+
+    # Check if device is supported
+    if device is not None and torch.device(device).type != "cuda":
+        pytest.skip("Quantization is only supported on CUDA devices")

--- a/tests/pytorch/triton_kernels/test_common.py
+++ b/tests/pytorch/triton_kernels/test_common.py
@@ -47,6 +47,38 @@ def get_tolerances(dtype):
     else:
         raise RuntimeError("Invalid type")
 
+def dtype_tols(dtype: torch.dtype | tex.DType) -> dict[str, float]:
+    """Estimated numerical error for a datatype
+
+    Based on tolerances for torch.testing.assert_close.
+
+    """
+
+    # Transformer Engine dtypes
+    if isinstance(dtype, tex.DType):
+        if dtype == tex.DType.kFloat8E4M3:
+            return dict(rtol=0.125, atol=0.0675)  # epsilon = 0.0625
+        if dtype == tex.DType.kFloat8E5M2:
+            return dict(rtol=0.25, atol=0.125)  # epsilon = 0.152
+        dtype = {
+            tex.DType.kByte: torch.uint8,
+            tex.DType.kInt32: torch.int32,
+            tex.DType.kFloat32: torch.float32,
+            tex.DType.kFloat16: torch.half,
+            tex.DType.kBFloat16: torch.bfloat16,
+        }[dtype]
+
+    # PyTorch dtypes
+    if dtype == torch.float16:
+        return dict(rtol=1e-3, atol=1e-5)
+    if dtype == torch.bfloat16:
+        return dict(rtol=1.6e-2, atol=1e-5)
+    if dtype == torch.float32:
+        return dict(rtol=1.3e-6, atol=1e-5)
+    if dtype == torch.float64:
+        return dict(rtol=1e-7, atol=1e-7)
+    raise ValueError(f"Unsupported dtype ({dtype})")
+
 
 # PyTorch implementation of `compareResults` C++ function from `tests/cpp/test_common.cu`.
 # Arguments:

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -6,6 +6,8 @@ import pytest
 import torch
 
 from transformer_engine.pytorch.triton_kernels.common import torch_dtype_to_te_dtype
+from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.triton_kernels.norm_common import (
     get_fwd_ln_sm_margin,
     get_bwd_ln_sm_margin,
@@ -24,17 +26,18 @@ from test_common import (
     fill_uniform,
     get_tolerances,
     compare_results,
+    maybe_skip_quantization,
 )
 
 test_shapes = [
     (2048, 4096),
     (768, 2048),
-    (256, 1024),
-    (128, 768),
-    (64, 512),
-    (173, 409),
-    (71, 3571),
-    (29, 17389),
+    # (256, 1024),
+    # (128, 768),
+    # (64, 512),
+    # (173, 409),
+    # (71, 3571),
+    # (29, 17389),
 ]
 
 test_types_str = ["fp32", "fp16", "bf16"]
@@ -113,15 +116,39 @@ def test_rmsnorm_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
 
 @pytest.mark.parametrize("M, N", test_shapes)
 @pytest.mark.parametrize("in_dtype", test_idtypes_str)
-# TODO: add fp8/bf8 once fp8 triton kernels are available
+@pytest.mark.parametrize("out_dtype", test_odtypes_str)
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
-def test_rmsnorm_fwd_triton(M, N, in_dtype, zero_centered_gamma):
+@pytest.mark.parametrize("quantization", (None, 'fp8', 'mxfp8'))
+@pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
+def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quantization, fp8_dtype):
     in_dtype = str_to_torch_dtype(in_dtype)
+    out_dtype = str_to_torch_dtype(out_dtype)
     input_tensor = fill_uniform((M, N), in_dtype)
     gamma_tensor = fill_uniform(N, in_dtype)
 
+    maybe_skip_quantization(quantization, dims=(M, N), device="cuda")
+    skip_in_dtype_gt_out_dtype(in_dtype, out_dtype)
+    skip_mixed_16bit_float_types(in_dtype, out_dtype)
+
     epsilon = 1e-5
     fwd_ln_sm_margin = get_fwd_ln_sm_margin()
+
+    if quantization == "fp8":
+        scale_triton=torch.full([1], 1, dtype=torch.float32, device="cuda")
+        amax_triton=torch.empty([1], dtype=torch.float32, device="cuda")
+
+        scale_hip = scale_triton.clone()
+        amax_hip = amax_triton.clone()
+
+        quantizer_triton = Float8Quantizer(scale_triton, amax_triton, fp8_dtype)
+        quantizer_hip = Float8Quantizer(scale_hip, amax_hip, fp8_dtype)
+    elif quantization == "mxfp8":
+        quantizer_triton = MXFP8Quantizer(fp8_dtype)
+        quantizer_hip = MXFP8Quantizer(fp8_dtype)
+    else:
+        quantizer_triton = None
+        quantizer_hip = None
+
 
     # run the triton path
     ln_out_triton = torch.empty(M, N, dtype=in_dtype, device='cuda')
@@ -130,7 +157,7 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, zero_centered_gamma):
         gamma_tensor,
         epsilon,
         ln_out_triton,
-        None, torch_dtype_to_te_dtype(in_dtype),
+        quantizer_triton, torch_dtype_to_te_dtype(out_dtype),
         fwd_ln_sm_margin,
         zero_centered_gamma
     )
@@ -142,13 +169,13 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, zero_centered_gamma):
         gamma_tensor,
         epsilon,
         ln_out_hipified,
-        None, torch_dtype_to_te_dtype(in_dtype),
+        quantizer_hip, torch_dtype_to_te_dtype(out_dtype),
         fwd_ln_sm_margin,
         zero_centered_gamma
     )
     atol, rtol = get_tolerances(in_dtype)
     compare_results(
-        "torch",
+        "te",
         ln_out_triton,
         ln_out_hipified,
         atol,
@@ -157,10 +184,35 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, zero_centered_gamma):
     )
     # rsigma is of type fp32
     compare_results(
-        "torch",
+        "te",
         rsigma_triton,
         rsigma_hipified,
         1e-6,
         5e-5,
         lambda msg: f"rsigma does not match triton <-> hip\n\n{msg}\n",
     )
+    if quantization == "fp8":
+        compare_results(
+            "te",
+            quantizer_triton.scale,
+            quantizer_hip.scale,
+            1e-6,
+            5e-5,
+            lambda msg: f"Quantizer scale does not match triton <-> hip\n\n{msg}\n",
+        )
+        compare_results(
+            "te",
+            quantizer_triton.amax,
+            quantizer_hip.amax,
+            1e-6,
+            5e-5,
+            lambda msg: f"Quantizer amax does not match triton <-> hip\n\n{msg}\n",
+        )
+        compare_results(
+            "te",
+            ln_out_triton._scale_inv,
+            ln_out_hipified._scale_inv,
+            1e-6,
+            5e-5,
+            lambda msg: f"Quantizer amax does not match triton <-> hip\n\n{msg}\n",
+        )

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 
-from transformer_engine.pytorch.triton_kernels.common import torch_dtype_to_te_dtype
+from transformer_engine.pytorch.triton_kernels.common import torch_dtype_to_te_dtype, te_dtype_to_torch_dtype
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.triton_kernels.norm_common import (
@@ -24,6 +24,7 @@ from test_common import (
     skip_in_dtype_gt_out_dtype,
     skip_mixed_16bit_float_types,
     fill_uniform,
+    get_tolerances,
     compare_results,
     maybe_skip_quantization,
     dtype_tols,
@@ -119,8 +120,8 @@ def test_rmsnorm_bwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma):
 @pytest.mark.parametrize("out_dtype", test_odtypes_str)
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
 @pytest.mark.parametrize("quantization", (None, 'fp8', 'mxfp8'))
-@pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
-def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quantization, fp8_dtype):
+def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quantization):
+    fp8_dtype = tex.DType.kFloat8E4M3
     in_dtype = str_to_torch_dtype(in_dtype)
     out_dtype = str_to_torch_dtype(out_dtype)
     input_tensor = fill_uniform((M, N), in_dtype)
@@ -132,18 +133,6 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
 
     epsilon = 1e-5
     fwd_ln_sm_margin = get_fwd_ln_sm_margin()
-
-    # TODO(micky774): Remove if/when the tex implementation supports kFloat8E5M2
-    if fp8_dtype == tex.DType.kFloat8E5M2:
-        if quantization == None:
-            pytest.skip(
-                "Skipping redundant test."
-            )
-        elif quantization == "fp8":
-            pytest.skip(
-                "The HIP kernel implementation does not "
-                "support FP8 quantization with fp8e5m2."
-            )
 
     if quantization == "fp8":
         scale_triton=torch.full([1], 1, dtype=torch.float32, device="cuda")

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -214,5 +214,5 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
             ln_out_hipified._scale_inv,
             1e-6,
             5e-5,
-            lambda msg: f"Quantizer amax does not match triton <-> hip\n\n{msg}\n",
+            lambda msg: f"Output scale inverse does not match triton <-> hip\n\n{msg}\n",
         )

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -24,20 +24,20 @@ from test_common import (
     skip_in_dtype_gt_out_dtype,
     skip_mixed_16bit_float_types,
     fill_uniform,
-    get_tolerances,
     compare_results,
     maybe_skip_quantization,
+    dtype_tols,
 )
 
 test_shapes = [
     (2048, 4096),
     (768, 2048),
-    # (256, 1024),
-    # (128, 768),
-    # (64, 512),
-    # (173, 409),
-    # (71, 3571),
-    # (29, 17389),
+    (256, 1024),
+    (128, 768),
+    (64, 512),
+    (173, 409),
+    (71, 3571),
+    (29, 17389),
 ]
 
 test_types_str = ["fp32", "fp16", "bf16"]
@@ -133,6 +133,18 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
     epsilon = 1e-5
     fwd_ln_sm_margin = get_fwd_ln_sm_margin()
 
+    # TODO(micky774): Remove if/when the tex implementation supports kFloat8E5M2
+    if fp8_dtype == tex.DType.kFloat8E5M2:
+        if quantization == None:
+            pytest.skip(
+                "Skipping redundant test."
+            )
+        elif quantization == "fp8":
+            pytest.skip(
+                "The HIP kernel implementation does not "
+                "support FP8 quantization with fp8e5m2."
+            )
+
     if quantization == "fp8":
         scale_triton=torch.full([1], 1, dtype=torch.float32, device="cuda")
         amax_triton=torch.empty([1], dtype=torch.float32, device="cuda")
@@ -151,29 +163,29 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
 
 
     # run the triton path
-    ln_out_triton = torch.empty(M, N, dtype=in_dtype, device='cuda')
     ln_out_triton, _, rsigma_triton = te_rmsnorm_fwd_triton(
         input_tensor,
         gamma_tensor,
         epsilon,
-        ln_out_triton,
+        None,
         quantizer_triton, torch_dtype_to_te_dtype(out_dtype),
         fwd_ln_sm_margin,
         zero_centered_gamma
     )
 
     # run the reference hipified kernel path
-    ln_out_hipified = torch.empty(M, N, dtype=in_dtype, device='cuda')
     ln_out_hipified, _, rsigma_hipified = tex.rmsnorm_fwd(
         input_tensor,
         gamma_tensor,
         epsilon,
-        ln_out_hipified,
+        None,
         quantizer_hip, torch_dtype_to_te_dtype(out_dtype),
         fwd_ln_sm_margin,
         zero_centered_gamma
     )
-    atol, rtol = get_tolerances(in_dtype)
+    tols = dtype_tols(out_dtype if quantization is None else fp8_dtype)
+    atol = tols["atol"]
+    rtol = tols["rtol"]
     compare_results(
         "te",
         ln_out_triton,

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -2,13 +2,12 @@
 # License for AMD contributions = MIT. See LICENSE for more information
 
 import torch
-import warnings
 import triton
 import triton.language as tl
-from transformer_engine_torch import rmsnorm_fwd
 from itertools import product
 from .norm_common import num_programs, block_size, use_blocked
 from transformer_engine.pytorch.triton_kernels.common import te_dtype_to_torch_dtype
+from transformer_engine.pytorch.tensor.quantized_tensor import QuantizedTensor
 
 
 def dg_tmp_rows(x, sm_margin=None):
@@ -21,15 +20,32 @@ def get_autotune_config():
 
 @triton.autotune(configs=get_autotune_config(), key=['n_rows', 'n_cols'], use_cuda_graph=True)
 @triton.jit
-def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stride, output_row_stride, n_rows, n_cols, epsilon,
-                    ZERO_CENTERED_GAMMA: tl.constexpr, BLOCK_SIZE: tl.constexpr, USE_BLOCKED: tl.constexpr,
-                    NUM_PRGMS: tl.constexpr):
+def _rmsnorm_fwd_triton(
+    output_ptr, input_ptr,
+    g_ptr, rsigma_ptr,
+    input_row_stride,
+    output_row_stride,
+    n_rows, n_cols,
+    epsilon,
+    q_scale_ptr,
+    q_amax_ptr,
+    amax_ptr,
+    scale_inv_ptr,
+    ZERO_CENTERED_GAMMA: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_BLOCKED: tl.constexpr,
+    NUM_PRGMS: tl.constexpr,
+    IS_FP8: tl.constexpr,
+):
     row_start = tl.program_id(0)
     col_offsets = tl.arange(0, BLOCK_SIZE)
     # as older version Triton doesn't support tl.assume and BUFF OPS, comment out for now
     # tl.assume(input_row_stride >= 0)
     # tl.assume(output_row_stride >= 0)
     # tl.assume(row_start >= 0)
+    if IS_FP8:
+        scale = tl.load(q_scale_ptr)
+        amax = 0.0
 
     if USE_BLOCKED:
 
@@ -47,7 +63,7 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (8, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 sum_squares += tl.sum(x * x, axis=0)
 
@@ -55,7 +71,7 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
             cols = n_cols_blks * BLOCK_SIZE + col_offsets
             mask = cols < n_cols
             input_ptrs = row_input_ptr + cols
-            input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (8, ))
             x = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             sum_squares += tl.sum(x * x, axis=0)
 
@@ -70,7 +86,7 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (8, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 g_ptrs = g_ptr + cols
                 g = tl.load(g_ptrs).to(tl.float32)
@@ -78,6 +94,10 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
                     g += 1
                 rms_norm = x * norm_factor * g
                 output_ptrs = row_output_ptr + cols
+                if IS_FP8:
+                    amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
+                    amax = amax_temp if amax_temp > amax else amax
+                    rms_norm = rms_norm * scale
                 tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty))
 
             # Handle remainder
@@ -91,13 +111,17 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
                 g += 1
             rms_norm = x * norm_factor * g
             output_ptrs = row_output_ptr + cols
+            if IS_FP8:
+                amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
+                amax = amax_temp if amax_temp > amax else amax
+                rms_norm = rms_norm * scale
             tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty), mask=mask)
 
     else:
         mask = col_offsets < n_cols
         for row_idx in tl.range(row_start, n_rows, NUM_PRGMS, num_stages=2):
             input_ptrs = input_ptr + row_idx * input_row_stride + col_offsets
-            input_ptrs = tl.multiple_of(input_ptrs, (16, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (8, ))
             row = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             g = tl.load(g_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             row_norm = row * row
@@ -113,9 +137,50 @@ def _rmsnorm_fwd_triton(output_ptr, input_ptr, g_ptr, rsigma_ptr, input_row_stri
             rms_norm = row * norm_factor * g
 
             output_ptrs = output_ptr + row_idx * output_row_stride + col_offsets
-            output_ptrs = tl.multiple_of(output_ptrs, (16, ))
+            output_ptrs = tl.multiple_of(output_ptrs, (8, ))
+            if IS_FP8:
+                amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
+                amax = amax_temp if amax_temp > amax else amax
+                rms_norm = rms_norm * scale
             tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty), mask=mask)
 
+    if IS_FP8:
+        # Handle FP8 metadata
+        _rmsnorm_fwd_reduce_triton[tl.cdiv(n_rows, BLOCK_SIZE)](
+            amax,
+            q_amax_ptr,
+            q_scale_ptr,
+            scale_inv_ptr,
+            n_rows, BLOCK_SIZE,
+        )
+        tl.store(amax_ptr + row_start, amax)
+
+@triton.jit
+def _rmsnorm_fwd_reduce_triton(
+    amax_input_ptr,
+    amax_output_ptr,
+    scale_ptr,
+    scale_inv_ptr,
+    n_rows,
+    BLOCK_SIZE: tl.constexpr,
+):
+
+    # program id
+    pid = tl.program_id(0)
+
+    amax_offs = tl.arange(0, BLOCK_SIZE) + (pid * BLOCK_SIZE)
+    amax_input_ptrs = amax_input_ptr + amax_offs
+    amax_mask = amax_offs < n_rows
+    _amax = tl.load(amax_input_ptrs, mask=amax_mask, other=0.0)
+
+    amax = tl.max(_amax, axis=-1)
+
+    tl.atomic_max(amax_output_ptr, amax, sem="relaxed")
+
+    if pid == 0:
+        scale = tl.load(scale_ptr)
+        scale_inv = tl.fdiv(1.0, scale)
+        tl.store(scale_inv_ptr, scale_inv)
 
 @triton.jit
 def _rmsnorm_bwd_triton(grad_output_ptr, input_ptr, g_ptr, rsigma_ptr, dx_ptr, dg_ptr, input_row_stride, output_row_stride,
@@ -322,36 +387,26 @@ def te_rmsnorm_fwd_triton(
             f"The shape of `weight` must be feature-aligned, "
             f"but {weight.shape[0]=} while {input.shape[1]=}"
         )
-
-
-    #TODO: Update to include Triton fp8 quantization.
-    if quantizer is not None:
-        warnings.warn(
-            "FP8 is not yet supported in our RMSNorm Triton kernel. "
-            "Falling back to HIP implementation.",
-            RuntimeWarning
-        )
-        return rmsnorm_fwd(
-            input,
-            weight,
-            eps,
-            ln_out,
-            quantizer,
-            otype,
-            sm_margin,
-            zero_centered_gamma
-        )
-
-    rsigma = torch.empty((N,), dtype=torch.float32, device="cuda")
-    pt_dtype = (
-        otype if isinstance(otype, torch.dtype)
-        else te_dtype_to_torch_dtype(otype)
-    )
-    out = torch.empty_like(input, dtype=pt_dtype) if ln_out is None else ln_out.view(pt_dtype)
-
+    IS_FP8 = quantizer is not None
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)
     NUM_PRGMS = num_programs(input, sm_margin)
+
+    rsigma = torch.empty((N,), dtype=torch.float32, device="cuda")
+    pt_otype = (
+        otype if isinstance(otype, torch.dtype)
+        else te_dtype_to_torch_dtype(otype)
+    )
+    if IS_FP8:
+        out = (
+            quantizer.make_empty(input.shape, dtype=pt_otype)
+            if not isinstance(out, QuantizedTensor)
+            else out
+        )
+    else:
+        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
+    amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda") if IS_FP8 else None
+
     grid_fwd = lambda meta: (NUM_PRGMS, )
     _rmsnorm_fwd_triton[grid_fwd](
         out,
@@ -361,10 +416,15 @@ def te_rmsnorm_fwd_triton(
         input.stride(0),
         out.stride(0),
         N, H, eps,
+        quantizer.scale if IS_FP8 else None,
+        quantizer.amax if IS_FP8 else None,
+        amax,
+        out.fp8_scale_inv if IS_FP8 else None,
         zero_centered_gamma,
         BLOCK_SIZE,
         USE_BLOCKED,
         NUM_PRGMS,
+        IS_FP8,
     )
 
     return out, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -66,7 +66,7 @@ def _rmsnorm_fwd_triton(
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (8, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (64, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 sum_squares += tl.sum(x * x, axis=0)
 
@@ -74,7 +74,7 @@ def _rmsnorm_fwd_triton(
             cols = n_cols_blks * BLOCK_SIZE + col_offsets
             mask = cols < n_cols
             input_ptrs = row_input_ptr + cols
-            input_ptrs = tl.multiple_of(input_ptrs, (8, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (64, ))
             x = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             sum_squares += tl.sum(x * x, axis=0)
 
@@ -89,7 +89,7 @@ def _rmsnorm_fwd_triton(
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (8, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (64, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 g_ptrs = g_ptr + cols
                 g = tl.load(g_ptrs).to(tl.float32)
@@ -124,7 +124,7 @@ def _rmsnorm_fwd_triton(
         mask = col_offsets < n_cols
         for row_idx in tl.range(row_start, n_rows, NUM_PRGMS, num_stages=2):
             input_ptrs = input_ptr + row_idx * input_row_stride + col_offsets
-            input_ptrs = tl.multiple_of(input_ptrs, (8, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (64, ))
             row = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             g = tl.load(g_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             row_norm = row * row
@@ -140,7 +140,7 @@ def _rmsnorm_fwd_triton(
             rms_norm = row * norm_factor * g
 
             output_ptrs = output_ptr + row_idx * output_row_stride + col_offsets
-            output_ptrs = tl.multiple_of(output_ptrs, (8, ))
+            output_ptrs = tl.multiple_of(output_ptrs, (64, ))
             if IS_FP8:
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = amax_temp if amax_temp > amax else amax

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -6,7 +6,10 @@ import triton
 import triton.language as tl
 from itertools import product
 from .norm_common import num_programs, block_size, use_blocked
-from transformer_engine.pytorch.triton_kernels.common import te_dtype_to_torch_dtype
+from transformer_engine.pytorch.triton_kernels.common import (
+    te_dtype_to_torch_dtype,
+    te_dtype_to_triton_dtype,
+)
 from transformer_engine.pytorch.tensor.quantized_tensor import QuantizedTensor
 
 
@@ -396,15 +399,17 @@ def te_rmsnorm_fwd_triton(
                 out = quantizer.create_tensor_from_data(ln_out, fake_dtype=pt_otype)
         else:
             out = quantizer.make_empty(input.shape, dtype=pt_otype)
+            out._transpose = None
+            out._transpose_invalid = True
     else:
         out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
 
     amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda") if IS_FP8 else None
 
+    tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype) if IS_FP8 else None
     grid_fwd = lambda meta: (NUM_PRGMS, )
     _rmsnorm_fwd_triton[grid_fwd](
-        out,
-        out.data if IS_FP8 else None,
+        triton.reinterpret(out._data, tl_dtype) if IS_FP8 else out,
         input,
         weight,
         rsigma,
@@ -421,10 +426,10 @@ def te_rmsnorm_fwd_triton(
     )
     if IS_FP8:
         # Handle FP8 metadata
-        _rmsnorm_fwd_fp8_meta_triton[NUM_PRGMS // BLOCK_SIZE](
+        _rmsnorm_fwd_fp8_meta_triton[(NUM_PRGMS // BLOCK_SIZE, )](
             amax,
-            quantizer.scale,
             quantizer.amax,
+            quantizer.scale,
             out._scale_inv,
             N, BLOCK_SIZE,
         )

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -35,7 +35,9 @@ def _rmsnorm_fwd_triton(
     n_rows, n_cols,
     epsilon,
     amax_ptr,
+    q_amax_ptr,
     q_scale_ptr,
+    scale_inv_ptr,
     ZERO_CENTERED_GAMMA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     USE_BLOCKED: tl.constexpr,
@@ -102,7 +104,7 @@ def _rmsnorm_fwd_triton(
                 output_ptrs = row_output_ptr + cols
                 if IS_FP8:
                     amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
-                    amax = amax_temp if amax_temp > amax else amax
+                    amax = tl.maximum(amax, amax_temp)
                     rms_norm = rms_norm * scale
                 tl.store(output_ptrs, rms_norm.to(output_type))
 
@@ -119,7 +121,7 @@ def _rmsnorm_fwd_triton(
             output_ptrs = row_output_ptr + cols
             if IS_FP8:
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
-                amax = amax_temp if amax_temp > amax else amax
+                amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
 
@@ -146,38 +148,16 @@ def _rmsnorm_fwd_triton(
             output_ptrs = tl.multiple_of(output_ptrs, (16, ))
             if IS_FP8:
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
-                amax = amax_temp if amax_temp > amax else amax
+                amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
     if IS_FP8:
         tl.store(amax_ptr + row_start, amax)
-
-@triton.jit
-def _rmsnorm_fwd_fp8_meta_triton(
-    amax_input_ptr,
-    amax_output_ptr,
-    scale_ptr,
-    scale_inv_ptr,
-    n_programs,
-    BLOCK_SIZE: tl.constexpr,
-):
-
-    # program id
-    pid = tl.program_id(0)
-
-    amax_offs = tl.arange(0, BLOCK_SIZE) + (pid * BLOCK_SIZE)
-    amax_input_ptrs = amax_input_ptr + amax_offs
-    amax_mask = amax_offs < n_programs
-    _amax = tl.load(amax_input_ptrs, mask=amax_mask, other=0.0)
-
-    amax = tl.max(_amax, axis=-1)
-
-    tl.atomic_max(amax_output_ptr, amax, sem="relaxed")
-
-    if pid == 0:
-        scale = tl.load(scale_ptr)
-        scale_inv = tl.fdiv(1.0, scale)
-        tl.store(scale_inv_ptr, scale_inv)
+        tl.atomic_max(q_amax_ptr, amax, sem="relaxed")
+        if row_start == 0:
+            scale = tl.load(q_scale_ptr)
+            scale_inv = tl.fdiv(1.0, scale)
+            tl.store(scale_inv_ptr, scale_inv)
 
 @triton.jit
 def _rmsnorm_bwd_triton(grad_output_ptr, input_ptr, g_ptr, rsigma_ptr, dx_ptr, dg_ptr, input_row_stride, output_row_stride,
@@ -399,20 +379,24 @@ def te_rmsnorm_fwd_triton(
         if ln_out is not None:
             out = (
                 ln_out if isinstance(ln_out, Float8Tensor) else
-                quantizer.create_tensor_from_data(ln_out, fake_dtype=pt_otype)
+                quantizer.create_tensor_from_data(ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)), fake_dtype=pt_otype)
             )
         else:
             out = quantizer.make_empty(input.shape, dtype=pt_otype)
 
         amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda")
         tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
-        out_ptr = triton.reinterpret(out._data, tl_dtype)
+        scale_inv_ptr = out._scale_inv
         q_scale = quantizer.scale
+        q_amax = quantizer.amax
+        out_ptr = triton.reinterpret(out._data, tl_dtype)
     else:
-        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
+        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
         amax = None
         tl_dtype = None
+        scale_inv_ptr = None
         q_scale = None
+        q_amax = None
         out_ptr = out
 
 
@@ -428,23 +412,16 @@ def te_rmsnorm_fwd_triton(
         out.stride(0),
         N, H, eps,
         amax,
+        q_amax,
         q_scale,
+        scale_inv_ptr,
         zero_centered_gamma,
         BLOCK_SIZE,
         USE_BLOCKED,
         NUM_PRGMS,
         IS_FP8,
     )
-    if IS_FP8:
-        # Handle FP8 metadata
-        _rmsnorm_fwd_fp8_meta_triton[(NUM_PRGMS // BLOCK_SIZE, )](
-            amax,
-            quantizer.amax,
-            quantizer.scale,
-            out._scale_inv,
-            N, BLOCK_SIZE,
-        )
-    elif IS_MFP8:
+    if IS_MFP8:
         out = quantizer.quantize(out)
 
     return out, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -66,7 +66,7 @@ def _rmsnorm_fwd_triton(
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (64, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 sum_squares += tl.sum(x * x, axis=0)
 
@@ -74,7 +74,7 @@ def _rmsnorm_fwd_triton(
             cols = n_cols_blks * BLOCK_SIZE + col_offsets
             mask = cols < n_cols
             input_ptrs = row_input_ptr + cols
-            input_ptrs = tl.multiple_of(input_ptrs, (64, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (16, ))
             x = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             sum_squares += tl.sum(x * x, axis=0)
 
@@ -89,7 +89,7 @@ def _rmsnorm_fwd_triton(
             for blk_idx in tl.range(0, n_cols_blks, num_stages=2):
                 cols = blk_idx * BLOCK_SIZE + col_offsets
                 input_ptrs = row_input_ptr + cols
-                input_ptrs = tl.multiple_of(input_ptrs, (64, ))
+                input_ptrs = tl.multiple_of(input_ptrs, (16, ))
                 x = tl.load(input_ptrs).to(tl.float32)
                 g_ptrs = g_ptr + cols
                 g = tl.load(g_ptrs).to(tl.float32)
@@ -124,7 +124,7 @@ def _rmsnorm_fwd_triton(
         mask = col_offsets < n_cols
         for row_idx in tl.range(row_start, n_rows, NUM_PRGMS, num_stages=2):
             input_ptrs = input_ptr + row_idx * input_row_stride + col_offsets
-            input_ptrs = tl.multiple_of(input_ptrs, (64, ))
+            input_ptrs = tl.multiple_of(input_ptrs, (16, ))
             row = tl.load(input_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
             g = tl.load(g_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             row_norm = row * row
@@ -140,7 +140,7 @@ def _rmsnorm_fwd_triton(
             rms_norm = row * norm_factor * g
 
             output_ptrs = output_ptr + row_idx * output_row_stride + col_offsets
-            output_ptrs = tl.multiple_of(output_ptrs, (64, ))
+            output_ptrs = tl.multiple_of(output_ptrs, (16, ))
             if IS_FP8:
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = amax_temp if amax_temp > amax else amax

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -5,7 +5,6 @@ import torch
 import triton
 import triton.language as tl
 from itertools import product
-import warnings
 from .norm_common import num_programs, block_size, use_blocked
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer, Float8Tensor
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
@@ -13,7 +12,6 @@ from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_torch_dtype,
     te_dtype_to_triton_dtype,
 )
-from transformer_engine.pytorch.tensor.quantized_tensor import QuantizedTensor
 
 
 def dg_tmp_rows(x, sm_margin=None):

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -404,12 +404,21 @@ def te_rmsnorm_fwd_triton(
     else:
         out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
 
-    amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda") if IS_FP8 else None
 
-    tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype) if IS_FP8 else None
+    if IS_FP8:
+        amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda")
+        tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
+        out_ptr = triton.reinterpret(out._data, tl_dtype)
+        q_scale = quantizer.scale
+    else:
+        amax = None
+        tl_dtype = None
+        q_scale = None
+        out_ptr = out
+
     grid_fwd = lambda meta: (NUM_PRGMS, )
     _rmsnorm_fwd_triton[grid_fwd](
-        triton.reinterpret(out._data, tl_dtype) if IS_FP8 else out,
+        out_ptr,
         input,
         weight,
         rsigma,
@@ -417,7 +426,7 @@ def te_rmsnorm_fwd_triton(
         out.stride(0),
         N, H, eps,
         amax,
-        quantizer.scale if IS_FP8 else None,
+        q_scale,
         zero_centered_gamma,
         BLOCK_SIZE,
         USE_BLOCKED,

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -21,16 +21,15 @@ def get_autotune_config():
 @triton.autotune(configs=get_autotune_config(), key=['n_rows', 'n_cols'], use_cuda_graph=True)
 @triton.jit
 def _rmsnorm_fwd_triton(
-    output_ptr, input_ptr,
+    output_ptr,
+    input_ptr,
     g_ptr, rsigma_ptr,
     input_row_stride,
     output_row_stride,
     n_rows, n_cols,
     epsilon,
-    q_scale_ptr,
-    q_amax_ptr,
     amax_ptr,
-    scale_inv_ptr,
+    q_scale_ptr,
     ZERO_CENTERED_GAMMA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     USE_BLOCKED: tl.constexpr,
@@ -43,6 +42,7 @@ def _rmsnorm_fwd_triton(
     # tl.assume(input_row_stride >= 0)
     # tl.assume(output_row_stride >= 0)
     # tl.assume(row_start >= 0)
+    output_type = output_ptr.type.element_ty
     if IS_FP8:
         scale = tl.load(q_scale_ptr)
         amax = 0.0
@@ -98,7 +98,7 @@ def _rmsnorm_fwd_triton(
                     amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                     amax = amax_temp if amax_temp > amax else amax
                     rms_norm = rms_norm * scale
-                tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty))
+                tl.store(output_ptrs, rms_norm.to(output_type))
 
             # Handle remainder
             cols = n_cols_blks * BLOCK_SIZE + col_offsets
@@ -115,7 +115,7 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = amax_temp if amax_temp > amax else amax
                 rms_norm = rms_norm * scale
-            tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty), mask=mask)
+            tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
 
     else:
         mask = col_offsets < n_cols
@@ -142,26 +142,17 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = amax_temp if amax_temp > amax else amax
                 rms_norm = rms_norm * scale
-            tl.store(output_ptrs, rms_norm.to(output_ptr.type.element_ty), mask=mask)
-
+            tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
     if IS_FP8:
-        # Handle FP8 metadata
-        _rmsnorm_fwd_reduce_triton[tl.cdiv(n_rows, BLOCK_SIZE)](
-            amax,
-            q_amax_ptr,
-            q_scale_ptr,
-            scale_inv_ptr,
-            n_rows, BLOCK_SIZE,
-        )
         tl.store(amax_ptr + row_start, amax)
 
 @triton.jit
-def _rmsnorm_fwd_reduce_triton(
+def _rmsnorm_fwd_fp8_meta_triton(
     amax_input_ptr,
     amax_output_ptr,
     scale_ptr,
     scale_inv_ptr,
-    n_rows,
+    n_programs,
     BLOCK_SIZE: tl.constexpr,
 ):
 
@@ -170,7 +161,7 @@ def _rmsnorm_fwd_reduce_triton(
 
     amax_offs = tl.arange(0, BLOCK_SIZE) + (pid * BLOCK_SIZE)
     amax_input_ptrs = amax_input_ptr + amax_offs
-    amax_mask = amax_offs < n_rows
+    amax_mask = amax_offs < n_programs
     _amax = tl.load(amax_input_ptrs, mask=amax_mask, other=0.0)
 
     amax = tl.max(_amax, axis=-1)
@@ -398,33 +389,44 @@ def te_rmsnorm_fwd_triton(
         else te_dtype_to_torch_dtype(otype)
     )
     if IS_FP8:
-        out = (
-            quantizer.make_empty(input.shape, dtype=pt_otype)
-            if not isinstance(out, QuantizedTensor)
-            else out
-        )
+        if ln_out is not None:
+            if isinstance(ln_out, QuantizedTensor):
+                out = ln_out
+            else:
+                out = quantizer.create_tensor_from_data(ln_out, fake_dtype=pt_otype)
+        else:
+            out = quantizer.make_empty(input.shape, dtype=pt_otype)
     else:
         out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
+
     amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda") if IS_FP8 else None
 
     grid_fwd = lambda meta: (NUM_PRGMS, )
     _rmsnorm_fwd_triton[grid_fwd](
         out,
+        out.data if IS_FP8 else None,
         input,
         weight,
         rsigma,
         input.stride(0),
         out.stride(0),
         N, H, eps,
-        quantizer.scale if IS_FP8 else None,
-        quantizer.amax if IS_FP8 else None,
         amax,
-        out.fp8_scale_inv if IS_FP8 else None,
+        quantizer.scale if IS_FP8 else None,
         zero_centered_gamma,
         BLOCK_SIZE,
         USE_BLOCKED,
         NUM_PRGMS,
         IS_FP8,
     )
+    if IS_FP8:
+        # Handle FP8 metadata
+        _rmsnorm_fwd_fp8_meta_triton[NUM_PRGMS // BLOCK_SIZE](
+            amax,
+            quantizer.scale,
+            quantizer.amax,
+            out._scale_inv,
+            N, BLOCK_SIZE,
+        )
 
     return out, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -5,7 +5,10 @@ import torch
 import triton
 import triton.language as tl
 from itertools import product
+import warnings
 from .norm_common import num_programs, block_size, use_blocked
+from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer, Float8Tensor
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_torch_dtype,
     te_dtype_to_triton_dtype,
@@ -381,7 +384,8 @@ def te_rmsnorm_fwd_triton(
             f"The shape of `weight` must be feature-aligned, "
             f"but {weight.shape[0]=} while {input.shape[1]=}"
         )
-    IS_FP8 = quantizer is not None
+    IS_FP8 = isinstance(quantizer, Float8Quantizer)
+    IS_MFP8 = isinstance(quantizer, MXFP8Quantizer)
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)
     NUM_PRGMS = num_programs(input, sm_margin)
@@ -393,30 +397,28 @@ def te_rmsnorm_fwd_triton(
     )
     if IS_FP8:
         if ln_out is not None:
-            if isinstance(ln_out, QuantizedTensor):
-                out = ln_out
-            else:
-                out = quantizer.create_tensor_from_data(ln_out, fake_dtype=pt_otype)
+            out = (
+                ln_out if isinstance(ln_out, Float8Tensor) else
+                quantizer.create_tensor_from_data(ln_out, fake_dtype=pt_otype)
+            )
         else:
             out = quantizer.make_empty(input.shape, dtype=pt_otype)
-            out._transpose = None
-            out._transpose_invalid = True
-    else:
-        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
 
-
-    if IS_FP8:
         amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda")
         tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
         out_ptr = triton.reinterpret(out._data, tl_dtype)
         q_scale = quantizer.scale
     else:
+        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out.view(pt_otype)
         amax = None
         tl_dtype = None
         q_scale = None
         out_ptr = out
 
+
     grid_fwd = lambda meta: (NUM_PRGMS, )
+
+    # TODO(micky774) Implement fused MXFP8 quantization within the kernel
     _rmsnorm_fwd_triton[grid_fwd](
         out_ptr,
         input,
@@ -442,5 +444,7 @@ def te_rmsnorm_fwd_triton(
             out._scale_inv,
             N, BLOCK_SIZE,
         )
+    elif IS_MFP8:
+        out = quantizer.quantize(out)
 
     return out, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -379,7 +379,10 @@ def te_rmsnorm_fwd_triton(
         if ln_out is not None:
             out = (
                 ln_out if isinstance(ln_out, Float8Tensor) else
-                quantizer.create_tensor_from_data(ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)), fake_dtype=pt_otype)
+                quantizer.create_tensor_from_data(
+                    ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)),
+                    fake_dtype=pt_otype
+                )
             )
         else:
             out = quantizer.make_empty(input.shape, dtype=pt_otype)


### PR DESCRIPTION
# Description

Implements FP8 support for RMSNorm Triton kernel.

Fixes https://github.com/ROCm/frameworks-internal/issues/12855

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Updates `test_fusible_ops::test_rmsnorm` to more explicitly check quantized results
- Updates `_rmsnorm_fwd_triton` with support for FP8 output quantization
- Updates `te_rmsnorm_fwd_triton` with support for FP8 output quantization

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
