### PR TITLE
Run core tests with threads = cores

### DIFF
--- a/ci/_utils.sh
+++ b/ci/_utils.sh
@@ -202,3 +202,17 @@ start_message() {
     echo "ROCm: `ls -d /opt/rocm-*`"
     python --version
 }
+
+configure_omp_threads() {
+    n_vcpus=$(lscpu | grep "^CPU(s):" | awk '{print $2}')
+    cpus_per_core=$(lscpu | grep "Thread(s) per core:" | awk '{print $NF}')
+
+    n_physical_cores=$((n_vcpus / cpus_per_core))
+
+    if [ -z ${OMP_NUM_THREADS} ]; then
+        export OMP_NUM_THREADS=$n_physical_cores
+	echo "Setting OMP_NUM_THREADS=${OMP_NUM_THREADS}"
+    else
+        echo "Using OMP_NUM_THREADS=${OMP_NUM_THREADS}"
+    fi
+}

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -13,6 +13,8 @@ if [ -z "$TEST_SGPU" ]; then
     exit 0
 fi
 
+configure_omp_threads()
+
 TEST_DIR=${TE_PATH}tests/cpp
 
 cd $TEST_DIR

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -13,7 +13,7 @@ if [ -z "$TEST_SGPU" ]; then
     exit 0
 fi
 
-configure_omp_threads()
+configure_omp_threads
 
 TEST_DIR=${TE_PATH}tests/cpp
 


### PR DESCRIPTION
# Description

Changes core.sh to run cpp unit tests with # of physical cores by default. This improves test performance for clusters with hyperthreading.

Fixes #13024

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added configure_omp_threads() to ci/_util.sh

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
