### PR TITLE
Added quantize/dequantize for mxfp8, integration with layernorm

### DIFF
--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -62,8 +62,10 @@ run_test_config(){
     run_default_fa 1 fused_attn/test_fused_attn.py # Backend selection is controlled by the test
     # TODO: bring back cast transpose kernels after triton kernels for transformer_engine::pytorch::quantize
     run_default_fa 1 triton_kernels/test_cast.py
+    run_default_fa 1 triton_kernels/test_cast_mxfp8.py
     run_default_fa 1 triton_kernels/test_rmsnorm.py
     run_default_fa 1 triton_kernels/test_layernorm.py
+    run_default_fa 1 triton_kernels/test_layernorm_mxfp8.py
     run_default_fa 1 triton_kernels/test_norm_common.py
     NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 NVTE_USE_LAYERNORM_TRITON=1 run_default_fa 3 test_numerics.py
     NVTE_USE_RMSNORM_TRITON=1 run_default_fa 1 test_fusible_ops.py

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -60,7 +60,6 @@ run_test_config(){
     run_default_fa 1 test_recipe.py
     run 1 test_sanity.py
     run_default_fa 1 fused_attn/test_fused_attn.py # Backend selection is controlled by the test
-    # TODO: bring back cast transpose kernels after triton kernels for transformer_engine::pytorch::quantize
     run_default_fa 1 triton_kernels/test_cast.py
     run_default_fa 1 triton_kernels/test_cast_mxfp8.py
     run_default_fa 1 triton_kernels/test_rmsnorm.py

--- a/tests/pytorch/triton_kernels/test_cast_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_cast_mxfp8.py
@@ -203,3 +203,4 @@ def test_quantize_dequantize_mxfp8(shape, in_dtype, out_dtype, block_sizes):
     if colwise:
         compare_results(cmp, quantized_out_triton._columnwise_data.view(torch_out_dtype),  quantized_out_columnwise_ref, atol_fp8, rtol_fp8, "columnwise data doesn't match")
         compare_results("torch", quantized_out_triton._columnwise_scale_inv,  columnwise_scale_inv_ref, 0.0, 0.0, "colwise scale inv doesn't match")
+

--- a/tests/pytorch/triton_kernels/test_cast_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_cast_mxfp8.py
@@ -57,44 +57,46 @@ def scale_block_torch(
     out_dtype: tex.DType
 ):
     #row-wise
-    for i in range(i_min, i_max):
-        block_input = input_tensor[i, j_min:j_max]
-        amax = torch.max(torch.abs(block_input)).item()
+    if j_max - j_min != 1:
+        for i in range(i_min, i_max):
+            block_input = input_tensor[i, j_min:j_max]
+            amax = torch.max(torch.abs(block_input)).item()
 
-        # Calculate scale
-        biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
-        scale_reciprocal = exp2f_rcp(biased_exponent)
+            # Calculate scale
+            biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
+            scale_reciprocal = exp2f_rcp(biased_exponent)
+            
+            # Store the biased exponent in the output_scales tensor
+            # output_scales should be a tensor of appropriate type
+            output_scale_rowwise[i][scale_idx[1]] = biased_exponent
+            block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
+
+            # Apply scaling
+            block_output *= scale_reciprocal
+
+            # Store the results back into the output tensor
+            output_rowwise[i, j_min:j_max] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
         
-        # Store the biased exponent in the output_scales tensor
-        # output_scales should be a tensor of appropriate type
-        output_scale_rowwise[i][scale_idx[1]] = biased_exponent
-        block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
-
-        # Apply scaling
-        block_output *= scale_reciprocal
-
-        # Store the results back into the output tensor
-        output_rowwise[i, j_min:j_max] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
-    
     #column-wise
-    for j in range(j_min, j_max):
-        block_input = input_tensor[i_min:i_max, j]
-        amax = torch.max(torch.abs(block_input)).item() # .item() gets Python scalar from 0-dim tensor
+    if i_max - i_min != 1:
+        for j in range(j_min, j_max):
+            block_input = input_tensor[i_min:i_max, j]
+            amax = torch.max(torch.abs(block_input)).item()
 
-        # Calculate scale
-        biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
-        scale_reciprocal = exp2f_rcp(biased_exponent)
-        
-        # Store the biased exponent in the output_scales tensor
-        # output_scales should be a tensor of appropriate type
-        output_scale_columnwise[scale_idx[0]][j] = biased_exponent
-        block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
+            # Calculate scale
+            biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
+            scale_reciprocal = exp2f_rcp(biased_exponent)
+            
+            # Store the biased exponent in the output_scales tensor
+            # output_scales should be a tensor of appropriate type
+            output_scale_columnwise[scale_idx[0]][j] = biased_exponent
+            block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
 
-        # Apply scaling
-        block_output *= scale_reciprocal
+            # Apply scaling
+            block_output *= scale_reciprocal
 
-        # Store the results back into the output tensor
-        output_columnwise[i_min:i_max, j] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
+            # Store the results back into the output tensor
+            output_columnwise[i_min:i_max, j] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
 
 def compute_ref_x1_torch(
     input_tensor: torch.Tensor, # Input data
@@ -153,7 +155,8 @@ def compute_ref_x1_torch(
                         ])
 @pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
-def test_quantize_dequantize_mxfp8(shape, in_dtype, out_dtype):
+@pytest.mark.parametrize("block_sizes", [[1, 32], [32, 1], [32, 32]])
+def test_quantize_dequantize_mxfp8(shape, in_dtype, out_dtype, block_sizes):
     if ((shape[-1] % MXFP8_BLOCK_SCALING_SIZE != 0) or (math.prod(shape[:-1]) % MXFP8_BLOCK_SCALING_SIZE != 0)):
         pytest.skip(f"Incorrect shape {shape} for MXFP8. Tensor dims must be divisible by {MXFP8_BLOCK_SCALING_SIZE}")
     input_tensor = fill_uniform(shape, dtype=in_dtype)
@@ -177,12 +180,26 @@ def test_quantize_dequantize_mxfp8(shape, in_dtype, out_dtype):
                         quantized_out_rowwise_ref, 
                         quantized_out_columnwise_ref,  
                         rowwise_scale_inv_ref, 
-                        columnwise_scale_inv_ref, 32, 32, out_dtype)
-    quantized_out_triton  = te_quantize_triton(input_tensor, quantizer=triton_quantizer)
+                        columnwise_scale_inv_ref, block_sizes[0], block_sizes[1], out_dtype)
+    rowwise = block_sizes[1] != 1
+    colwise = block_sizes[0] != 1
+    out = None
+    # If either rowwise is 1 or colwise is 1 but not at the same time
+    if rowwise ^ colwise:
+        out = triton_quantizer.make_empty(input_tensor.shape, dtype=in_dtype)
+        # Make columnwise data none, since we won't be calculating that.
+        if rowwise:
+            out._columnwise_data = None
+        # Make rowwise data none, since we won't be calculating that.
+        if colwise:
+            out._rowwise_data = None
+    quantized_out_triton  = te_quantize_triton(input_tensor, quantizer=triton_quantizer, output=out)
 
     cmp = "te"
     atol_fp8, rtol_fp8 = get_tolerances(torch_out_dtype)
-    compare_results(cmp, quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, atol_fp8, rtol_fp8, "rowwise data doesn't match")
-    compare_results(cmp, quantized_out_triton._columnwise_data.view(torch_out_dtype),  quantized_out_columnwise_ref, atol_fp8, rtol_fp8, "columnwise data doesn't match")
-    compare_results("torch", quantized_out_triton._rowwise_scale_inv,  rowwise_scale_inv_ref, 0.0, 0.0, "rowwise scale inv doesn't match")
-    compare_results("torch", quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, 0.0, 0.0, "colwise scale inv doesn't match")
+    if rowwise:
+        compare_results(cmp, quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, atol_fp8, rtol_fp8, "rowwise data doesn't match")
+        compare_results("torch", quantized_out_triton._rowwise_scale_inv,  rowwise_scale_inv_ref, 0.0, 0.0, "rowwise scale inv doesn't match")
+    if colwise:
+        compare_results(cmp, quantized_out_triton._columnwise_data.view(torch_out_dtype),  quantized_out_columnwise_ref, atol_fp8, rtol_fp8, "columnwise data doesn't match")
+        compare_results("torch", quantized_out_triton._columnwise_scale_inv,  columnwise_scale_inv_ref, 0.0, 0.0, "colwise scale inv doesn't match")

--- a/tests/pytorch/triton_kernels/test_cast_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_cast_mxfp8.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # License for AMD contributions = MIT. See LICENSE for more information
 
 import math
@@ -59,7 +59,7 @@ def scale_block_torch(
     #row-wise
     for i in range(i_min, i_max):
         block_input = input_tensor[i, j_min:j_max]
-        amax = torch.max(torch.abs(block_input)).item() # .item() gets Python scalar from 0-dim tensor
+        amax = torch.max(torch.abs(block_input)).item()
 
         # Calculate scale
         biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
@@ -121,7 +121,7 @@ def compute_ref_x1_torch(
             j_min = jj * block_size_X
             j_max = min((jj + 1) * block_size_X, cols)
             scale_idx = (ii, jj)
-            scale_block_torch (
+            scale_block_torch(
                 input_tensor=input_tensor_2d_view,
                 output_rowwise=output_rowwise_2d_view,
                 output_columnwise=output_columnwise_2d_view,
@@ -152,8 +152,8 @@ def compute_ref_x1_torch(
                         (16, 8, 4, 512),
                         ])
 @pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3])
-def test_quantize(shape, in_dtype, out_dtype):
+@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
+def test_quantize_dequantize_mxfp8(shape, in_dtype, out_dtype):
     if ((shape[-1] % MXFP8_BLOCK_SCALING_SIZE != 0) or (math.prod(shape[:-1]) % MXFP8_BLOCK_SCALING_SIZE != 0)):
         pytest.skip(f"Incorrect shape {shape} for MXFP8. Tensor dims must be divisible by {MXFP8_BLOCK_SCALING_SIZE}")
     input_tensor = fill_uniform(shape, dtype=in_dtype)
@@ -178,15 +178,11 @@ def test_quantize(shape, in_dtype, out_dtype):
                         quantized_out_columnwise_ref,  
                         rowwise_scale_inv_ref, 
                         columnwise_scale_inv_ref, 32, 32, out_dtype)
-    
     quantized_out_triton  = te_quantize_triton(input_tensor, quantizer=triton_quantizer)
-    dequantized_out_triton = te_dequantize_triton(quantized_out_triton, dtype=in_dtype)
-    dequantized_out_colwise_triton = te_dequantize_triton(quantized_out_triton, dtype=in_dtype, use_rowwise_scaling=False)
-    atol_fp8, rtol_fp8 = get_tolerances(torch_out_dtype)
+
     cmp = "te"
+    atol_fp8, rtol_fp8 = get_tolerances(torch_out_dtype)
     compare_results(cmp, quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, atol_fp8, rtol_fp8, "rowwise data doesn't match")
     compare_results(cmp, quantized_out_triton._columnwise_data.view(torch_out_dtype),  quantized_out_columnwise_ref, atol_fp8, rtol_fp8, "columnwise data doesn't match")
     compare_results("torch", quantized_out_triton._rowwise_scale_inv,  rowwise_scale_inv_ref, 0.0, 0.0, "rowwise scale inv doesn't match")
     compare_results("torch", quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, 0.0, 0.0, "colwise scale inv doesn't match")
-    compare_results("te", dequantized_out_triton, input_tensor,  6.25e-2, 6.25e-2, 'Dequantized and original results do not match!')
-    compare_results("te", dequantized_out_colwise_triton, dequantized_out_triton, 6.25e-2, 6.25e-2, 'Dequantized colwise and dequantized rowwise results do not match!')

--- a/tests/pytorch/triton_kernels/test_cast_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_cast_mxfp8.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+import math
+import os
+import struct
+import pytest
+import torch
+
+from transformer_engine.pytorch.constants import MXFP8_BLOCK_SCALING_SIZE
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+from transformer_engine.pytorch.triton_kernels.cast import te_dequantize_triton, te_quantize_triton
+from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+from transformer_engine.pytorch.triton_kernels.common import get_fp8_max, te_dtype_to_torch_dtype
+from transformer_engine.pytorch.utils import round_up_to_nearest_multiple
+import transformer_engine_torch as tex
+from test_common import compare_results, fill_uniform, get_tolerances
+
+
+FP32_MANTISSA_BITS = 23
+FP32_EXPONENT_BIAS = 127
+
+def float_to_e8m0(val: float) -> int:
+    if math.isnan(val):
+        return 0xFF
+    if math.isinf(val):
+        return 0xFE
+    if val == 0.0:
+        return 0x00
+
+    val_u32 = struct.unpack('<I', struct.pack('<f', val))[0]
+    exponent = (val_u32 >> FP32_MANTISSA_BITS) & 0xFF
+    mantissa = val_u32 & 0x7FFFFF
+
+    if (mantissa > 0 and exponent != 0xFE) and not (exponent == 0 and mantissa <= 0x400000):
+        exponent += 1
+    
+    return exponent
+
+def exp2f_rcp(biased_exp: int) -> float:
+    if biased_exp == 0:
+        return 1.0
+    return math.pow(2.0, FP32_EXPONENT_BIAS - float(biased_exp))
+ 
+
+def scale_block_torch(
+    input_tensor: torch.Tensor,
+    output_rowwise: torch.Tensor,
+    output_columnwise: torch.Tensor,
+    output_scale_rowwise: torch.Tensor,
+    output_scale_columnwise: torch.Tensor,
+    scale_idx: int,
+    i_min: int,
+    i_max: int,
+    j_min: int,
+    j_max: int,
+    out_dtype: tex.DType
+):
+    #row-wise
+    for i in range(i_min, i_max):
+        block_input = input_tensor[i, j_min:j_max]
+        amax = torch.max(torch.abs(block_input)).item() # .item() gets Python scalar from 0-dim tensor
+
+        # Calculate scale
+        biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
+        scale_reciprocal = exp2f_rcp(biased_exponent)
+        
+        # Store the biased exponent in the output_scales tensor
+        # output_scales should be a tensor of appropriate type
+        output_scale_rowwise[i][scale_idx[1]] = biased_exponent
+        block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
+
+        # Apply scaling
+        block_output *= scale_reciprocal
+
+        # Store the results back into the output tensor
+        output_rowwise[i, j_min:j_max] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
+    
+    #column-wise
+    for j in range(j_min, j_max):
+        block_input = input_tensor[i_min:i_max, j]
+        amax = torch.max(torch.abs(block_input)).item() # .item() gets Python scalar from 0-dim tensor
+
+        # Calculate scale
+        biased_exponent = float_to_e8m0(amax * 1/get_fp8_max(out_dtype))
+        scale_reciprocal = exp2f_rcp(biased_exponent)
+        
+        # Store the biased exponent in the output_scales tensor
+        # output_scales should be a tensor of appropriate type
+        output_scale_columnwise[scale_idx[0]][j] = biased_exponent
+        block_output = block_input.clone() # Work on a clone to avoid modifying input_tensor directly
+
+        # Apply scaling
+        block_output *= scale_reciprocal
+
+        # Store the results back into the output tensor
+        output_columnwise[i_min:i_max, j] = block_output.to(te_dtype_to_torch_dtype(out_dtype))
+
+def compute_ref_x1_torch(
+    input_tensor: torch.Tensor, # Input data
+    output_rowwise: torch.Tensor,     # Main quantized output
+    output_columnwise: torch.Tensor,     # Main quantized output
+    output_scale_rowwise: torch.Tensor, # Scales for each block
+    output_scale_columnwise: torch.Tensor, # Scales for each block
+    block_size_Y: int,
+    block_size_X: int,
+    out_dtype: tex.DType
+):
+    cols = input_tensor.shape[-1] if len(input_tensor.shape) > 0 else 1
+    rows = input_tensor.numel() // cols
+    input_tensor_2d_view = input_tensor.reshape(rows, cols)
+    output_rowwise_2d_view = output_rowwise.reshape(rows, cols)
+    output_columnwise_2d_view = output_columnwise.reshape(rows, cols)
+    blocks_Y = (rows + block_size_Y - 1) // block_size_Y
+    blocks_X = (cols + block_size_X - 1) // block_size_X
+
+    for ii in range(blocks_Y):
+        i_min = ii * block_size_Y
+        i_max = min((ii + 1) * block_size_Y, rows)
+        for jj in range(blocks_X):
+            j_min = jj * block_size_X
+            j_max = min((jj + 1) * block_size_X, cols)
+            scale_idx = (ii, jj)
+            scale_block_torch (
+                input_tensor=input_tensor_2d_view,
+                output_rowwise=output_rowwise_2d_view,
+                output_columnwise=output_columnwise_2d_view,
+                output_scale_rowwise=output_scale_rowwise,
+                output_scale_columnwise=output_scale_columnwise,
+                scale_idx=scale_idx,
+                i_min=i_min,
+                i_max=i_max,
+                j_min=j_min,
+                j_max=j_max,
+                out_dtype=out_dtype
+            )
+
+@pytest.mark.parametrize("shape", 
+                         [
+                        (1, 16),
+                        (16, 48),
+                        (65, 96),
+                        (128, 128),
+                        (256, 256),
+                        (993, 512),
+                        (256, 65536),
+                        (2048, 6144),
+                        (16384, 128),
+                        (32768, 160),
+                        (4096, 1632),
+                        (8, 32, 1024),
+                        (16, 8, 4, 512),
+                        ])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3])
+def test_quantize(shape, in_dtype, out_dtype):
+    if ((shape[-1] % MXFP8_BLOCK_SCALING_SIZE != 0) or (math.prod(shape[:-1]) % MXFP8_BLOCK_SCALING_SIZE != 0)):
+        pytest.skip(f"Incorrect shape {shape} for MXFP8. Tensor dims must be divisible by {MXFP8_BLOCK_SCALING_SIZE}")
+    input_tensor = fill_uniform(shape, dtype=in_dtype)
+    triton_quantizer = MXFP8Quantizer(out_dtype)
+    rowwise_scale_inv_ref = torch.zeros(
+            round_up_to_nearest_multiple(math.prod(shape[:-1]), 128),
+            round_up_to_nearest_multiple(shape[-1] // MXFP8_BLOCK_SCALING_SIZE, 4),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+    columnwise_scale_inv_ref = torch.zeros(
+                round_up_to_nearest_multiple(math.prod(shape[:-1]) // MXFP8_BLOCK_SCALING_SIZE, 4),
+                round_up_to_nearest_multiple(shape[-1], 128),
+                dtype=torch.uint8,
+                device="cuda",
+            )
+    torch_out_dtype = te_dtype_to_torch_dtype(out_dtype)
+    quantized_out_rowwise_ref = torch.empty(shape, dtype=torch_out_dtype, device="cuda")
+    quantized_out_columnwise_ref = torch.empty_like(quantized_out_rowwise_ref)
+    compute_ref_x1_torch(input_tensor, 
+                        quantized_out_rowwise_ref, 
+                        quantized_out_columnwise_ref,  
+                        rowwise_scale_inv_ref, 
+                        columnwise_scale_inv_ref, 32, 32, out_dtype)
+    
+    quantized_out_triton  = te_quantize_triton(input_tensor, quantizer=triton_quantizer)
+    dequantized_out_triton = te_dequantize_triton(quantized_out_triton, dtype=in_dtype)
+    dequantized_out_colwise_triton = te_dequantize_triton(quantized_out_triton, dtype=in_dtype, use_rowwise_scaling=False)
+    atol_fp8, rtol_fp8 = get_tolerances(torch_out_dtype)
+    cmp = "te"
+    compare_results(cmp, quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, atol_fp8, rtol_fp8, "rowwise data doesn't match")
+    compare_results(cmp, quantized_out_triton._columnwise_data.view(torch_out_dtype),  quantized_out_columnwise_ref, atol_fp8, rtol_fp8, "columnwise data doesn't match")
+    compare_results("torch", quantized_out_triton._rowwise_scale_inv,  rowwise_scale_inv_ref, 0.0, 0.0, "rowwise scale inv doesn't match")
+    compare_results("torch", quantized_out_triton._rowwise_data.view(torch_out_dtype),  quantized_out_rowwise_ref, 0.0, 0.0, "colwise scale inv doesn't match")
+    compare_results("te", dequantized_out_triton, input_tensor,  6.25e-2, 6.25e-2, 'Dequantized and original results do not match!')
+    compare_results("te", dequantized_out_colwise_triton, dequantized_out_triton, 6.25e-2, 6.25e-2, 'Dequantized colwise and dequantized rowwise results do not match!')

--- a/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
@@ -8,15 +8,9 @@ import torch
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.triton_kernels.cast import te_dequantize_triton
 import transformer_engine_torch as tex
-from transformer_engine.pytorch.triton_kernels.common import (
-    torch_dtype_to_te_dtype,
-)
-from transformer_engine.pytorch.triton_kernels.norm_common import (
-    get_fwd_ln_sm_margin,
-)
-from transformer_engine.pytorch.triton_kernels.layernorm import (
-    te_layernorm_fwd_triton,
-)
+from transformer_engine.pytorch.triton_kernels.common import torch_dtype_to_te_dtype
+from transformer_engine.pytorch.triton_kernels.norm_common import get_fwd_ln_sm_margin
+from transformer_engine.pytorch.triton_kernels.layernorm import te_layernorm_fwd_triton
 from test_common import (
     get_tolerances,
     input_dtypes_str,
@@ -61,7 +55,7 @@ def compute_ref_output(data: torch.Tensor, gamma: torch.Tensor, beta: torch.Tens
         raise ValueError("amax must be a 1-element torch.Tensor.")
 
 test_idtypes_str = input_dtypes_str(["fp32", "fp16", "bf16"])
-test_odtypes_str = output_dtypes_str(["fp8e4"])
+test_odtypes_str = output_dtypes_str(["fp8e4", "fp8e5"])
 
 test_shapes = [
         (32, 32),
@@ -75,7 +69,7 @@ all_boolean = [False, True]
 @pytest.mark.parametrize("out_dtype", test_odtypes_str)
 @pytest.mark.parametrize("M, N", test_shapes)
 @pytest.mark.parametrize("zero_centered_gamma", all_boolean)
-def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
+def test_layernorm_fwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
 
     # Get Torch data types:
     in_dtype = str_to_torch_dtype(in_dtype)
@@ -110,8 +104,9 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         sm_margin=get_fwd_ln_sm_margin(),
         zero_centered_gamma=zero_centered_gamma, 
         )
-    dequantized_out_triton = te_dequantize_triton(y_triton, dtype=in_dtype)
-    dequantized_out_colwise_triton = te_dequantize_triton(y_triton, dtype=in_dtype, use_rowwise_scaling=False)
+    dequantized_out_rowwise_triton = te_dequantize_triton(y_triton, dtype=in_dtype)
+    y_triton._rowwise_data = None
+    dequantized_out_colwise_triton = te_dequantize_triton(y_triton, dtype=in_dtype)
 
     if te_out_dtype == tex.DType.kFloat8E5M2:
         atol = 1.25e-1
@@ -129,7 +124,7 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
     
     compare_results(
         fwd_cmp,
-        dequantized_out_triton,
+        dequantized_out_rowwise_triton,
         y_ref,
         atol,
         rtol,

--- a/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+
+import pytest
+import torch
+
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+from transformer_engine.pytorch.triton_kernels.cast import te_dequantize_triton
+import transformer_engine_torch as tex
+from transformer_engine.pytorch.triton_kernels.common import (
+    torch_dtype_to_te_dtype,
+)
+from transformer_engine.pytorch.triton_kernels.norm_common import (
+    get_fwd_ln_sm_margin,
+)
+from transformer_engine.pytorch.triton_kernels.layernorm import (
+    te_layernorm_fwd_triton,
+)
+from test_common import (
+    get_tolerances,
+    input_dtypes_str,
+    output_dtypes_str,
+    str_to_torch_dtype,
+    skip_in_dtype_gt_out_dtype,
+    skip_mixed_16bit_float_types,
+    fill_uniform,
+    compare_results,
+)
+
+def compute_ref_stats(data: torch.Tensor, epsilon: float):
+    mu_computed = torch.mean(data.to(torch.float32), dim=1, keepdim=True)
+    variance = torch.mean((data.to(torch.float32) - mu_computed).pow(2), dim=1, keepdim=True)
+    rsigma_computed = 1.0 / torch.sqrt(variance + epsilon)
+    return mu_computed.squeeze(1), rsigma_computed.squeeze(1)
+
+def compute_gamma_py(g_val, zero_centered_gamma):
+    if zero_centered_gamma:
+        return g_val + 1.0
+    else:
+        return g_val
+        
+def compute_ref_output(data: torch.Tensor, gamma: torch.Tensor, beta: torch.Tensor,
+                       output: torch.Tensor,
+                       mu: torch.Tensor, rsigma: torch.Tensor,
+                       amax: torch.Tensor, scale: torch.Tensor, zero_centered_gamma: bool):
+    data_float = data.to(torch.float32)
+    mu_float = mu.unsqueeze(1).to(torch.float32)
+    rsigma_float = rsigma.unsqueeze(1).to(torch.float32)
+    gamma_float = gamma.to(torch.float32) # N
+    beta_float = beta.to(torch.float32)   # N
+    g_tensor = compute_gamma_py(gamma_float, zero_centered_gamma)
+    tmp_unscaled = (data_float - mu_float) * rsigma_float * g_tensor + beta_float
+    output.copy_((tmp_unscaled * scale).to(output.dtype))
+
+    current_max = torch.max(torch.abs(tmp_unscaled))
+
+    if amax.numel() == 1:
+        amax.fill_(current_max)
+    else:
+        raise ValueError("amax must be a 1-element torch.Tensor.")
+
+test_idtypes_str = input_dtypes_str(["fp32", "fp16", "bf16"])
+test_odtypes_str = output_dtypes_str(["fp8e4"])
+
+test_shapes = [
+        (32, 32),
+        (768, 2304),
+        (2048, 12288),
+]
+
+all_boolean = [False, True]
+
+@pytest.mark.parametrize("in_dtype", test_idtypes_str)
+@pytest.mark.parametrize("out_dtype", test_odtypes_str)
+@pytest.mark.parametrize("M, N", test_shapes)
+@pytest.mark.parametrize("zero_centered_gamma", all_boolean)
+def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
+
+    # Get Torch data types:
+    in_dtype = str_to_torch_dtype(in_dtype)
+    out_dtype = str_to_torch_dtype(out_dtype)
+    te_out_dtype = torch_dtype_to_te_dtype(out_dtype)
+
+    # Skip conditions:
+    skip_in_dtype_gt_out_dtype(in_dtype, out_dtype)
+    skip_mixed_16bit_float_types(in_dtype, out_dtype)
+
+    # Generate tensors:
+    x = fill_uniform((M, N), in_dtype)
+    gamma = fill_uniform(N, in_dtype)
+    beta = fill_uniform(N, in_dtype)
+    scale_ref, amax_ref = torch.tensor(1.0), torch.zeros(1, dtype=torch.float32, device='cuda')
+    epsilon = 1e-5
+
+    # Run Hipified forward reference.
+    quantizer_triton = MXFP8Quantizer(te_out_dtype)
+    
+    y_ref = torch.empty(M, N, dtype=in_dtype, device="cuda")
+    mu_ref, rsigma_ref = compute_ref_stats(x, epsilon)
+    compute_ref_output(x, gamma, beta, y_ref, mu_ref, rsigma_ref, amax_ref, scale_ref, zero_centered_gamma)
+    y_triton, mu_triton, rsigma_triton = te_layernorm_fwd_triton(
+        input=x, 
+        weight=gamma, 
+        bias=beta,
+        eps=epsilon, 
+        ln_out=None,
+        quantizer=quantizer_triton,
+        out_dtype=torch_dtype_to_te_dtype(out_dtype),
+        sm_margin=get_fwd_ln_sm_margin(),
+        zero_centered_gamma=zero_centered_gamma, 
+        )
+    dequantized_out_triton = te_dequantize_triton(y_triton, dtype=in_dtype)
+    dequantized_out_colwise_triton = te_dequantize_triton(y_triton, dtype=in_dtype, use_rowwise_scaling=False)
+
+    if te_out_dtype == tex.DType.kFloat8E5M2:
+        atol = 1.25e-1
+        rtol = 1.25e-1
+    elif te_out_dtype == tex.DType.kFloat8E4M3:
+        if in_dtype == torch.float16:
+            atol = 7e-2
+            rtol = 7e-2
+        else:
+            atol = 6.25e-2
+            rtol = 6.25e-2
+    
+    # Run forward
+    fwd_cmp = "te"
+    
+    compare_results(
+        fwd_cmp,
+        dequantized_out_triton,
+        y_ref,
+        atol,
+        rtol,
+        lambda msg: f"rowwise dequantized output doesn't match reference output\n{msg}\n",
+    )
+    
+    compare_results(
+        fwd_cmp,
+        dequantized_out_colwise_triton,
+        y_ref,
+        atol,
+        rtol,
+        lambda msg: f"colwise dequantized output doesn't match reference output\n{msg}\n",
+    )
+
+    atol_stats, _ = get_tolerances(torch.float32)
+    rtol_stats = 5e-5
+
+    compare_results(
+        fwd_cmp,
+        mu_triton,
+        mu_ref,
+        atol_stats,
+        rtol_stats,
+        lambda msg: f"mu does not match triton <-> ref\n\n{msg}\n",
+    )
+    compare_results(
+        fwd_cmp,
+        rsigma_triton,
+        rsigma_ref,
+        atol_stats,
+        rtol_stats,
+        lambda msg: f"rsigma does not match triton <-> ref\n\n{msg}\n",
+    )

--- a/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
@@ -159,3 +159,4 @@ def test_layernorm_fwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
         rtol_stats,
         lambda msg: f"rsigma does not match triton <-> ref\n\n{msg}\n",
     )
+

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -8,9 +8,12 @@ from collections.abc import Iterable
 import math
 import os
 from typing import Optional, Tuple
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import torch
-from ..triton_kernels.cast import te_quantize_triton
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.cast import te_quantize_triton
+
 import transformer_engine_torch as tex
 
 from transformer_engine_torch import DType as TE_DType
@@ -61,9 +64,12 @@ class MXFP8Quantizer(Quantizer):
             src = src.contiguous()
 
         # Launch cast kernel
-        use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
-        quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
-        quantize_func(src, self, dst, noop_flag)
+        if IS_HIP_EXTENSION:
+            use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
+            quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
+            quantize_func(src, self, dst, noop_flag)
+        else:
+            tex.quantize(src, self, dst, noop_flag)
 
         # Update FP8 dtype
         dst._fp8_dtype = self.dtype

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 from collections.abc import Iterable
 import math
+import os
 from typing import Optional, Tuple
 
 import torch
+from ..triton_kernels.cast import te_quantize_triton
 import transformer_engine_torch as tex
 
 from transformer_engine_torch import DType as TE_DType
@@ -59,7 +61,9 @@ class MXFP8Quantizer(Quantizer):
             src = src.contiguous()
 
         # Launch cast kernel
-        tex.quantize(src, self, dst, noop_flag)
+        use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
+        quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
+        quantize_func(src, self, dst, noop_flag)
 
         # Update FP8 dtype
         dst._fp8_dtype = self.dtype

--- a/transformer_engine/pytorch/triton_kernels/cast.py
+++ b/transformer_engine/pytorch/triton_kernels/cast.py
@@ -81,8 +81,8 @@ def te_quantize_triton(
     # Construct no-op flag if needed
     if noop_flag is None:
         noop_flag = _empty_tensor()
-
-    if out.size().numel() == 0:
+    # if it's mxfp8, we'll check if both rowwise and columnwise data are none
+    if (isinstance(out, MXFP8TensorBase) and out._rowwise_data is None and out._columnwise_data is None) or (not isinstance(out, MXFP8TensorBase) and out.size().numel() == 0):
         # Return empty output if the quantized tensor has no elements
         return out
     

--- a/transformer_engine/pytorch/triton_kernels/cast.py
+++ b/transformer_engine/pytorch/triton_kernels/cast.py
@@ -123,3 +123,4 @@ def te_dequantize_triton(input, dtype=torch.float32):
         return tex.dequantize(input, dtype)
     else:
         raise NotImplementedError(f"Not implemented for tensor type: '{type(input).__name__}'")
+

--- a/transformer_engine/pytorch/triton_kernels/cast.py
+++ b/transformer_engine/pytorch/triton_kernels/cast.py
@@ -11,7 +11,7 @@ import warnings
 from ..utils import non_tn_fp8_gemm_supported
 
 from ..tensor._internal.float8_tensor_base import Float8TensorBase
-from .cast_transpose import te_cast_transpose_noop_triton
+from .cast_transpose import te_cast_transpose_mxfp8_triton, te_cast_transpose_noop_triton, te_dequantize_mxfp8_triton
 import transformer_engine_torch as tex
 from ..tensor.quantized_tensor import QuantizedTensor, Quantizer
 from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
@@ -72,7 +72,8 @@ def te_quantize_triton(
             _setup_conditional_transpose_storage(out)
         else:
             out = quantizer.make_empty(input_tensor.shape, dtype=fake_tensor_type)
-            _setup_conditional_transpose_storage(out)
+            if isinstance(out, Float8TensorBase):
+                _setup_conditional_transpose_storage(out)
     else:
         # Create a QuantizedTensor from the provided output tensor
         out = output
@@ -109,8 +110,16 @@ def te_quantize_triton(
             else:
                 out = tex.quantize(input_tensor, quantizer, out, noop_flag)
     elif isinstance(out, MXFP8TensorBase):
-        out = tex.quantize(input_tensor, quantizer, out, noop_flag)
+        te_cast_transpose_mxfp8_triton(input_tensor, out)
     else:
         raise NotImplementedError(f"Not implemented for tensor type: '{type(out).__name__}'")
 
     return out
+
+def te_dequantize_triton(input, dtype=torch.float32, use_rowwise_scaling=True):
+    if isinstance(input, MXFP8TensorBase):
+        return te_dequantize_mxfp8_triton(input, dtype, use_rowwise_scaling)
+    elif isinstance(input, Float8TensorBase):
+        return tex.dequantize(input, dtype)
+    else:
+        raise NotImplementedError(f"Not implemented for tensor type: '{type(input).__name__}'")

--- a/transformer_engine/pytorch/triton_kernels/cast.py
+++ b/transformer_engine/pytorch/triton_kernels/cast.py
@@ -116,9 +116,9 @@ def te_quantize_triton(
 
     return out
 
-def te_dequantize_triton(input, dtype=torch.float32, use_rowwise_scaling=True):
+def te_dequantize_triton(input, dtype=torch.float32):
     if isinstance(input, MXFP8TensorBase):
-        return te_dequantize_mxfp8_triton(input, dtype, use_rowwise_scaling)
+        return te_dequantize_mxfp8_triton(input, dtype)
     elif isinstance(input, Float8TensorBase):
         return tex.dequantize(input, dtype)
     else:

--- a/transformer_engine/pytorch/triton_kernels/cast_transpose.py
+++ b/transformer_engine/pytorch/triton_kernels/cast_transpose.py
@@ -119,7 +119,7 @@ def _cast_transpose_triton_mxfp8(
     rowwise_scale_M, rowwise_scale_N,
     colwise_scale_inv_ptr, stride_colwise_scale_inv_row, stride_colwise_scale_inv_col,
     colwise_scale_M, colwise_scale_N,
-    max_fp8: tl.constexpr, BLOCK_X: tl.constexpr, BLOCK_Y: tl.constexpr, GROUP_Y: tl.constexpr, MXFP8_BLOCK_SCALING_SIZE: tl.constexpr):
+    max_fp8: tl.constexpr, BLOCK_X: tl.constexpr, BLOCK_Y: tl.constexpr, GROUP_Y: tl.constexpr, MXFP8_BLOCK_SCALING_SIZE: tl.constexpr,  USE_ROWWISE_SCALING: tl.constexpr, USE_COLWISE_SCALING: tl.constexpr):
    
     pid = tl.program_id(0)
 
@@ -137,7 +137,7 @@ def _cast_transpose_triton_mxfp8(
     
     num_chunks_in_block_Y = BLOCK_Y // MXFP8_BLOCK_SCALING_SIZE
     num_chunks_in_block_X = BLOCK_X // MXFP8_BLOCK_SCALING_SIZE
-    max_norm_rcp = 1.0/max_fp8
+    max_norm_rcp = 1.0 / max_fp8
 
     for chunk_id_y in range(0, num_chunks_in_block_Y):
         offsets_Y = global_offset_Y_base + chunk_id_y * MXFP8_BLOCK_SCALING_SIZE + tl.arange(0, MXFP8_BLOCK_SCALING_SIZE)
@@ -149,32 +149,34 @@ def _cast_transpose_triton_mxfp8(
             x_chunk = tl.load(x_ptr_current_chunk, mask=mask, other=0.0).to(tl.float32)
 
             # Rowwise
-            subwarp_amax_rowwise = tl.max(tl.abs(x_chunk), axis=-1, keep_dims=True)
-            biased_exponent_rowwise = float_to_e8m0_triton(subwarp_amax_rowwise * max_norm_rcp)
-            
-            scale_offset_X = (pid_n * num_chunks_in_block_X) + chunk_id_x
-            rowwise_scale_inv_store_offsets = (offsets_Y[:, None] * stride_rowwise_scale_inv_row) + scale_offset_X * stride_rowwise_scale_inv_col 
-            rowwise_scale_inv_store_mask = (offsets_Y < rowwise_scale_M)[:, None] & (scale_offset_X < rowwise_scale_N)
-            tl.store(rowwise_scale_inv_ptr + rowwise_scale_inv_store_offsets, biased_exponent_rowwise, mask = rowwise_scale_inv_store_mask)
-            
-            block_inverse_scale_rowwise = exp2f_rcp_triton(biased_exponent_rowwise)
-            y_chunk_rowwise_scaled = x_chunk * block_inverse_scale_rowwise
-            rowwise_y_ptr_current_chunk = rowwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
-            tl.store(rowwise_y_ptr_current_chunk, y_chunk_rowwise_scaled.to(rowwise_y_ptr.type.element_ty), mask=mask)
+            if USE_ROWWISE_SCALING:
+                subwarp_amax_rowwise = tl.max(tl.abs(x_chunk), axis=-1, keep_dims=True)
+                biased_exponent_rowwise = float_to_e8m0_triton(subwarp_amax_rowwise * max_norm_rcp)
+                
+                scale_offset_X = (pid_n * num_chunks_in_block_X) + chunk_id_x
+                rowwise_scale_inv_store_offsets = (offsets_Y[:, None] * stride_rowwise_scale_inv_row) + scale_offset_X * stride_rowwise_scale_inv_col 
+                rowwise_scale_inv_store_mask = (offsets_Y < rowwise_scale_M)[:, None] & (scale_offset_X < rowwise_scale_N)
+                tl.store(rowwise_scale_inv_ptr + rowwise_scale_inv_store_offsets, biased_exponent_rowwise, mask = rowwise_scale_inv_store_mask)
+                
+                block_inverse_scale_rowwise = exp2f_rcp_triton(biased_exponent_rowwise)
+                y_chunk_rowwise_scaled = x_chunk * block_inverse_scale_rowwise
+                rowwise_y_ptr_current_chunk = rowwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
+                tl.store(rowwise_y_ptr_current_chunk, y_chunk_rowwise_scaled.to(rowwise_y_ptr.type.element_ty), mask=mask)
 
             # Colwise
-            subwarp_amax_colwise = tl.max(tl.abs(x_chunk), axis=0, keep_dims=True)
-            biased_exponent_colwise = float_to_e8m0_triton(subwarp_amax_colwise * max_norm_rcp)
+            if USE_COLWISE_SCALING:
+                subwarp_amax_colwise = tl.max(tl.abs(x_chunk), axis=0, keep_dims=True)
+                biased_exponent_colwise = float_to_e8m0_triton(subwarp_amax_colwise * max_norm_rcp)
 
-            scale_offset_Y = (pid_m * num_chunks_in_block_Y) + chunk_id_y
-            colwise_scale_inv_store_offsets = scale_offset_Y * stride_colwise_scale_inv_row + (offsets_X[None, :] * stride_colwise_scale_inv_col) 
-            colwise_scale_inv_store_mask = (scale_offset_Y < colwise_scale_M) & (offsets_X < colwise_scale_N)[None, :]
-            tl.store(colwise_scale_inv_ptr + colwise_scale_inv_store_offsets, biased_exponent_colwise, mask = colwise_scale_inv_store_mask)
-            
-            block_inverse_scale_colwise = exp2f_rcp_triton(biased_exponent_colwise)
-            y_chunk_colwise_scaled = x_chunk * block_inverse_scale_colwise
-            colwise_y_ptr_current_chunk = colwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
-            tl.store(colwise_y_ptr_current_chunk, y_chunk_colwise_scaled.to(colwise_y_ptr.type.element_ty), mask=mask)
+                scale_offset_Y = (pid_m * num_chunks_in_block_Y) + chunk_id_y
+                colwise_scale_inv_store_offsets = scale_offset_Y * stride_colwise_scale_inv_row + (offsets_X[None, :] * stride_colwise_scale_inv_col) 
+                colwise_scale_inv_store_mask = (scale_offset_Y < colwise_scale_M) & (offsets_X < colwise_scale_N)[None, :]
+                tl.store(colwise_scale_inv_ptr + colwise_scale_inv_store_offsets, biased_exponent_colwise, mask = colwise_scale_inv_store_mask)
+                
+                block_inverse_scale_colwise = exp2f_rcp_triton(biased_exponent_colwise)
+                y_chunk_colwise_scaled = x_chunk * block_inverse_scale_colwise
+                colwise_y_ptr_current_chunk = colwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
+                tl.store(colwise_y_ptr_current_chunk, y_chunk_colwise_scaled.to(colwise_y_ptr.type.element_ty), mask=mask)
 
 @triton.jit
 def _dequantize_mxfp8_triton(
@@ -255,21 +257,31 @@ def te_cast_transpose_mxfp8_triton(input, out, noop_flag=None):
     row_length = input.shape[-1] if len(input.shape) > 0 else 1
     num_rows = input.numel() // row_length
     input_2d_view = input.reshape(num_rows, row_length)
-
     out_metadata = out.get_metadata()
-    rowwise_y_ptr = out_metadata["rowwise_data"].reshape(num_rows, row_length)
-    colwise_y_ptr = out_metadata["columnwise_data"].reshape(num_rows, row_length)
 
-    rowwise_scale_inv_ptr = out_metadata["rowwise_scale_inv"]
-    colwise_scale_inv_ptr = out_metadata["columnwise_scale_inv"]
+    USE_ROWWISE_SCALING = out_metadata["rowwise_data"] is not None
+    USE_COLWISE_SCALING = out_metadata["columnwise_data"] is not None
+
+    rowwise_y_ptr, rowwise_scale_inv_ptr = None, None
+    rowwise_scale_M, rowwise_scale_N = 1, 1
+    if USE_ROWWISE_SCALING:
+        rowwise_y_ptr = out_metadata["rowwise_data"].reshape(num_rows, row_length)
+        rowwise_scale_inv_ptr = out_metadata["rowwise_scale_inv"]
+        rowwise_scale_M, rowwise_scale_N = rowwise_scale_inv_ptr.shape
+
+    colwise_y_ptr, colwise_scale_inv_ptr = None, None
+    colwise_scale_M, colwise_scale_N = 1, 1
+    if USE_COLWISE_SCALING:
+        colwise_y_ptr = out_metadata["columnwise_data"].reshape(num_rows, row_length)
+        colwise_scale_inv_ptr = out_metadata["columnwise_scale_inv"]
+        colwise_scale_M, colwise_scale_N = colwise_scale_inv_ptr.shape
+    
     fp8_dtype = out_metadata["fp8_dtype"]
     BLOCK_X = 64
     BLOCK_Y = 64
     GROUP_Y = MXFP8_BLOCK_SCALING_SIZE
     max_fp8 = get_fp8_max(fp8_dtype)
     tl_dtype = te_dtype_to_triton_dtype(fp8_dtype)
-    rowwise_scale_M, rowwise_scale_N = rowwise_scale_inv_ptr.shape
-    colwise_scale_M, colwise_scale_N = colwise_scale_inv_ptr.shape
     grid = lambda META: (triton.cdiv(num_rows, META['BLOCK_Y']) * triton.cdiv(row_length, META['BLOCK_X']),)
     _cast_transpose_triton_mxfp8[grid](
         input_2d_view, triton.reinterpret(rowwise_y_ptr, tl_dtype), triton.reinterpret(colwise_y_ptr, tl_dtype), 
@@ -279,30 +291,32 @@ def te_cast_transpose_mxfp8_triton(input, out, noop_flag=None):
         rowwise_scale_M, rowwise_scale_N,
         colwise_scale_inv_ptr, colwise_scale_inv_ptr.stride(0), colwise_scale_inv_ptr.stride(1),
         colwise_scale_M, colwise_scale_N,
-        max_fp8, BLOCK_X, BLOCK_Y, GROUP_Y, MXFP8_BLOCK_SCALING_SIZE)
+        max_fp8, BLOCK_X, BLOCK_Y, GROUP_Y, MXFP8_BLOCK_SCALING_SIZE, USE_ROWWISE_SCALING, USE_COLWISE_SCALING)
 
-def te_dequantize_mxfp8_triton(input, dtype, use_rowwise_scaling=True):
+def te_dequantize_mxfp8_triton(input, dtype):
     input_metadata = input.get_metadata()
-    rowwise_x_ptr = input_metadata["rowwise_data"]
-
-    row_length = rowwise_x_ptr.shape[-1] if len(rowwise_x_ptr.shape) > 0 else 1
-    num_rows = rowwise_x_ptr.numel() // row_length
-    rowwise_x_ptr_2d_view = rowwise_x_ptr.reshape(num_rows, row_length)
-
-    colwise_x_ptr = input_metadata["columnwise_data"]
-    colwise_x_ptr_2d_view = colwise_x_ptr.reshape(num_rows, row_length)
-
-    rowwise_scale_inv_ptr = input_metadata["rowwise_scale_inv"]
-    colwise_scale_inv_ptr = input_metadata["columnwise_scale_inv"]
-    fp8_dtype = input_metadata["fp8_dtype"]
-
-    out = torch.zeros(input.shape, dtype=dtype, device=rowwise_x_ptr.device)
-
-    # use_rowwise_scaling = rowwise_x_ptr is not None
-    x_ptr = rowwise_x_ptr_2d_view if use_rowwise_scaling else colwise_x_ptr_2d_view
-    scale_inv_ptr = rowwise_scale_inv_ptr if use_rowwise_scaling else colwise_scale_inv_ptr
-    scale_M, scale_N = rowwise_scale_inv_ptr.shape if use_rowwise_scaling else colwise_scale_inv_ptr.shape
+    use_rowwise_scaling = input_metadata["rowwise_data"] is not None
+    x_ptr = None
+    scale_inv_ptr = None
     
+    if use_rowwise_scaling:
+        x_ptr = input_metadata["rowwise_data"]
+        row_length = x_ptr.shape[-1] if len(x_ptr.shape) > 0 else 1
+        num_rows = x_ptr.numel() // row_length
+        x_ptr = x_ptr.reshape(num_rows, row_length)
+        scale_inv_ptr = input_metadata["rowwise_scale_inv"]
+    else:
+        x_ptr = input_metadata["columnwise_data"]
+        row_length = x_ptr.shape[-1] if len(x_ptr.shape) > 0 else 1
+        num_rows = x_ptr.numel() // row_length
+        x_ptr = x_ptr.reshape(num_rows, row_length)
+        scale_inv_ptr = input_metadata["columnwise_scale_inv"]
+    
+    fp8_dtype = input_metadata["fp8_dtype"]
+    scale_M, scale_N = scale_inv_ptr.shape
+
+    out = torch.zeros(input.shape, dtype=dtype, device=x_ptr.device)
+
     BLOCK_X = 64
     BLOCK_Y = 64
     GROUP_Y = 4

--- a/transformer_engine/pytorch/triton_kernels/cast_transpose.py
+++ b/transformer_engine/pytorch/triton_kernels/cast_transpose.py
@@ -3,6 +3,7 @@
 
 import torch
 
+from ..constants import MXFP8_BLOCK_SCALING_SIZE
 import transformer_engine_torch as tex
 import triton
 import triton.language as tl
@@ -67,6 +68,163 @@ def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, s
         scale_inv_out = tl.fdiv(1.0, scale)
         tl.store(scale_inv_ptr, scale_inv_out)
 
+@triton.jit
+def exp2f_rcp_triton(biased_exp: tl.uint8, FP32_EXPONENT_BIAS: tl.constexpr = 127) -> tl.float32:
+    biased_exp_f32 = biased_exp.to(tl.float32)
+    exp_val = FP32_EXPONENT_BIAS - biased_exp_f32
+    result = tl.exp2(exp_val)
+    final_result = tl.where(biased_exp == 0, 1.0, result)
+    return final_result
+
+@triton.jit
+def float_to_e8m0_triton(val: tl.float32, FP32_MANTISSA_BITS: tl.constexpr = 23) -> tl.uint8:
+    is_nan = (val != val)
+    is_inf = (tl.abs(val) == float('inf'))
+    is_zero = val == 0.0
+
+    result_e8m0 = tl.zeros(val.shape, dtype=tl.uint8) # Placeholder
+    val_u32 = tl.cast(val, tl.uint32, bitcast=True)
+
+    # Extract exponent and mantissa
+    exponent_raw = (val_u32 >> FP32_MANTISSA_BITS) & 0xFF 
+    mantissa = val_u32 & 0x7FFFFF
+
+    # Round up exponent and deal with satfinite.
+    # (mantissa > 0 && exponent != 0xFE) && !(exponent == 0 && mantissa <= 0x400000)
+    cond1 = mantissa > 0
+    cond2 = exponent_raw != 0xFE 
+    cond3_part1 = exponent_raw == 0
+    cond3_part2 = mantissa <= 0x400000
+    cond3 = cond3_part1 & cond3_part2 
+    
+    round_up_condition = (cond1 & cond2) & ~cond3
+
+    # Increment exponent if the condition is true
+    calculated_exponent = tl.where(round_up_condition, exponent_raw + 1, exponent_raw)
+    
+    # Priority: NaN -> Inf -> Zero -> Calculated Exponent
+    result_e8m0 = tl.where(is_nan, tl.full(val.shape, 0xFF, dtype=tl.uint8), result_e8m0)
+    result_e8m0 = tl.where(~is_nan & is_inf, tl.full(val.shape, 0xFE, dtype=tl.uint8), result_e8m0)
+    result_e8m0 = tl.where(~is_nan & ~is_inf & is_zero, tl.full(val.shape, 0x00, dtype=tl.uint8), result_e8m0)
+    result_e8m0 = tl.where(~is_nan & ~is_inf & ~is_zero, calculated_exponent, result_e8m0)
+
+    return result_e8m0
+
+@triton.jit
+def _cast_transpose_triton_mxfp8(
+    x_ptr, rowwise_y_ptr, colwise_y_ptr, 
+    stride_rowwise_row, stride_rowwise_col, 
+    n_rows, n_cols, 
+    rowwise_scale_inv_ptr, stride_rowwise_scale_inv_row, stride_rowwise_scale_inv_col,
+    rowwise_scale_M, rowwise_scale_N,
+    colwise_scale_inv_ptr, stride_colwise_scale_inv_row, stride_colwise_scale_inv_col,
+    colwise_scale_M, colwise_scale_N,
+    max_fp8: tl.constexpr, BLOCK_X: tl.constexpr, BLOCK_Y: tl.constexpr, GROUP_Y: tl.constexpr, MXFP8_BLOCK_SCALING_SIZE: tl.constexpr):
+   
+    pid = tl.program_id(0)
+
+    num_pid_along_Y = tl.cdiv(n_rows, BLOCK_Y)
+    num_pid_along_X = tl.cdiv(n_cols, BLOCK_X)
+    num_pid_in_group = GROUP_Y * num_pid_along_X
+
+    group_id = pid // num_pid_in_group
+    group_size = min(num_pid_along_Y - group_id * GROUP_Y, GROUP_Y)
+    pid_m = group_id * GROUP_Y + ((pid % num_pid_in_group) % group_size)
+    pid_n = (pid % num_pid_in_group) // group_size
+
+    global_offset_Y_base = pid_m.to(tl.int64) * BLOCK_Y
+    global_offset_X_base = pid_n.to(tl.int64) * BLOCK_X
+    
+    num_chunks_in_block_Y = BLOCK_Y // MXFP8_BLOCK_SCALING_SIZE
+    num_chunks_in_block_X = BLOCK_X // MXFP8_BLOCK_SCALING_SIZE
+    max_norm_rcp = 1.0/max_fp8
+
+    for chunk_id_y in range(0, num_chunks_in_block_Y):
+        offsets_Y = global_offset_Y_base + chunk_id_y * MXFP8_BLOCK_SCALING_SIZE + tl.arange(0, MXFP8_BLOCK_SCALING_SIZE)
+        for chunk_id_x in range(0, num_chunks_in_block_X):
+            offsets_X = global_offset_X_base  + chunk_id_x * MXFP8_BLOCK_SCALING_SIZE + tl.arange(0, MXFP8_BLOCK_SCALING_SIZE)
+            x_ptr_current_chunk = x_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
+            mask = (offsets_Y < n_rows)[:, None] & (offsets_X < n_cols)[None, :]
+            # (MXFP8_BLOCK_SCALING_SIZE, MXFP8_BLOCK_SCALING_SIZE)
+            x_chunk = tl.load(x_ptr_current_chunk, mask=mask, other=0.0).to(tl.float32)
+
+            # Rowwise
+            subwarp_amax_rowwise = tl.max(tl.abs(x_chunk), axis=-1, keep_dims=True)
+            biased_exponent_rowwise = float_to_e8m0_triton(subwarp_amax_rowwise * max_norm_rcp)
+            
+            scale_offset_X = (pid_n * num_chunks_in_block_X) + chunk_id_x
+            rowwise_scale_inv_store_offsets = (offsets_Y[:, None] * stride_rowwise_scale_inv_row) + scale_offset_X * stride_rowwise_scale_inv_col 
+            rowwise_scale_inv_store_mask = (offsets_Y < rowwise_scale_M)[:, None] & (scale_offset_X < rowwise_scale_N)
+            tl.store(rowwise_scale_inv_ptr + rowwise_scale_inv_store_offsets, biased_exponent_rowwise, mask = rowwise_scale_inv_store_mask)
+            
+            block_inverse_scale_rowwise = exp2f_rcp_triton(biased_exponent_rowwise)
+            y_chunk_rowwise_scaled = x_chunk * block_inverse_scale_rowwise
+            rowwise_y_ptr_current_chunk = rowwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
+            tl.store(rowwise_y_ptr_current_chunk, y_chunk_rowwise_scaled.to(rowwise_y_ptr.type.element_ty), mask=mask)
+
+            # Colwise
+            subwarp_amax_colwise = tl.max(tl.abs(x_chunk), axis=0, keep_dims=True)
+            biased_exponent_colwise = float_to_e8m0_triton(subwarp_amax_colwise * max_norm_rcp)
+
+            scale_offset_Y = (pid_m * num_chunks_in_block_Y) + chunk_id_y
+            colwise_scale_inv_store_offsets = scale_offset_Y * stride_colwise_scale_inv_row + (offsets_X[None, :] * stride_colwise_scale_inv_col) 
+            colwise_scale_inv_store_mask = (scale_offset_Y < colwise_scale_M) & (offsets_X < colwise_scale_N)[None, :]
+            tl.store(colwise_scale_inv_ptr + colwise_scale_inv_store_offsets, biased_exponent_colwise, mask = colwise_scale_inv_store_mask)
+            
+            block_inverse_scale_colwise = exp2f_rcp_triton(biased_exponent_colwise)
+            y_chunk_colwise_scaled = x_chunk * block_inverse_scale_colwise
+            colwise_y_ptr_current_chunk = colwise_y_ptr + offsets_Y[:, None] * stride_rowwise_row + offsets_X[None, :] * stride_rowwise_col
+            tl.store(colwise_y_ptr_current_chunk, y_chunk_colwise_scaled.to(colwise_y_ptr.type.element_ty), mask=mask)
+
+@triton.jit
+def _dequantize_mxfp8_triton(
+    x_ptr, y_ptr,
+    stride_row, stride_col, 
+    n_rows, n_cols, 
+    scale_inv_ptr, stride_scale_inv_row, stride_scale_inv_col,
+    scale_n_rows, scale_n_cols,
+    BLOCK_X: tl.constexpr, BLOCK_Y: tl.constexpr, GROUP_Y: tl.constexpr, USE_ROWWISE_SCALING: tl.constexpr, MXFP8_BLOCK_SCALING_SIZE: tl.constexpr):
+   
+    pid = tl.program_id(0)
+
+    num_pid_along_Y = tl.cdiv(n_rows, BLOCK_Y)
+    num_pid_along_X = tl.cdiv(n_cols, BLOCK_X)
+    num_pid_in_group = GROUP_Y * num_pid_along_X
+
+    group_id = pid // num_pid_in_group
+    group_size = min(num_pid_along_Y - group_id * GROUP_Y, GROUP_Y)
+    pid_m = group_id * GROUP_Y + ((pid % num_pid_in_group) % group_size)
+    pid_n = (pid % num_pid_in_group) // group_size
+
+    global_offset_Y_base = pid_m.to(tl.int64) * BLOCK_Y
+    global_offset_X_base = pid_n.to(tl.int64) * BLOCK_X
+    
+    num_chunks_in_block_Y = BLOCK_Y // MXFP8_BLOCK_SCALING_SIZE
+    num_chunks_in_block_X = BLOCK_X // MXFP8_BLOCK_SCALING_SIZE
+
+    for chunk_id_y in range(0, num_chunks_in_block_Y):
+        offsets_Y = global_offset_Y_base + chunk_id_y * MXFP8_BLOCK_SCALING_SIZE + tl.arange(0, MXFP8_BLOCK_SCALING_SIZE)
+        for chunk_id_x in range(0, num_chunks_in_block_X):
+            offsets_X = global_offset_X_base  + chunk_id_x * MXFP8_BLOCK_SCALING_SIZE + tl.arange(0, MXFP8_BLOCK_SCALING_SIZE)
+            x_ptr_current_chunk = x_ptr + offsets_Y[:, None] * stride_row + offsets_X[None, :] * stride_col
+            mask = (offsets_Y < n_rows)[:, None] & (offsets_X < n_cols)[None, :]
+            x_chunk = tl.load(x_ptr_current_chunk, mask=mask)
+
+            if USE_ROWWISE_SCALING:
+                scale_offset_X = (pid_n * num_chunks_in_block_X) + chunk_id_x
+                scale_inv_store_offsets = (offsets_Y[:, None] * stride_scale_inv_row) + scale_offset_X * stride_scale_inv_col 
+                scale_inv_store_mask = (offsets_Y < scale_n_rows)[:, None] & (scale_offset_X < scale_n_cols)
+            else:
+                scale_offset_Y = (pid_m * num_chunks_in_block_Y) + chunk_id_y
+                scale_inv_store_offsets = scale_offset_Y * stride_scale_inv_row + (offsets_X[None, :] * stride_scale_inv_col) 
+                scale_inv_store_mask = (scale_offset_Y < scale_n_rows) & (offsets_X < scale_n_cols)[None, :]
+                
+            biased_exponent = tl.load(scale_inv_ptr + scale_inv_store_offsets, mask=scale_inv_store_mask, other=127)
+            block_scale = tl.exp2(biased_exponent.to(tl.float32) - 127)
+            y_chunk_scaled = x_chunk.to(tl.float32) * block_scale
+            y_ptr_current_chunk = y_ptr + offsets_Y[:, None] * stride_row + offsets_X[None, :] * stride_col
+            tl.store(y_ptr_current_chunk, y_chunk_scaled.to(y_ptr.type.element_ty), mask=mask)
+
 # Reshapes input of any given shape to 2D for processing, 
 # then uses the Triton kernel to perform casting and transposition efficiently.
 def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans_out, amax_out, scale_inv_out, otype):
@@ -92,6 +250,74 @@ def te_cast_transpose_noop_triton(input, noop_flag, input_scale, cast_out, trans
     
     grid = lambda META: (triton.cdiv(num_rows, META['BLOCK_M']) * triton.cdiv(row_length, META['BLOCK_N']),)
     _cast_transpose_triton[grid](input_2d_view, noop_flag, triton.reinterpret(cast_out_2d_view, tl_dtype), triton.reinterpret(trans_out_2d_view, tl_dtype), input_stride_M, input_stride_N, trans_out_stride_M, trans_out_stride_N, num_rows, row_length, input_scale, amax_out, scale_inv_out, get_fp8_max(otype), use_noop)
+
+def te_cast_transpose_mxfp8_triton(input, out, noop_flag=None):
+    row_length = input.shape[-1] if len(input.shape) > 0 else 1
+    num_rows = input.numel() // row_length
+    input_2d_view = input.reshape(num_rows, row_length)
+
+    out_metadata = out.get_metadata()
+    rowwise_y_ptr = out_metadata["rowwise_data"].reshape(num_rows, row_length)
+    colwise_y_ptr = out_metadata["columnwise_data"].reshape(num_rows, row_length)
+
+    rowwise_scale_inv_ptr = out_metadata["rowwise_scale_inv"]
+    colwise_scale_inv_ptr = out_metadata["columnwise_scale_inv"]
+    fp8_dtype = out_metadata["fp8_dtype"]
+    BLOCK_X = 64
+    BLOCK_Y = 64
+    GROUP_Y = MXFP8_BLOCK_SCALING_SIZE
+    max_fp8 = get_fp8_max(fp8_dtype)
+    tl_dtype = te_dtype_to_triton_dtype(fp8_dtype)
+    rowwise_scale_M, rowwise_scale_N = rowwise_scale_inv_ptr.shape
+    colwise_scale_M, colwise_scale_N = colwise_scale_inv_ptr.shape
+    grid = lambda META: (triton.cdiv(num_rows, META['BLOCK_Y']) * triton.cdiv(row_length, META['BLOCK_X']),)
+    _cast_transpose_triton_mxfp8[grid](
+        input_2d_view, triton.reinterpret(rowwise_y_ptr, tl_dtype), triton.reinterpret(colwise_y_ptr, tl_dtype), 
+        input_2d_view.stride(0), input_2d_view.stride(1), 
+        num_rows, row_length, 
+        rowwise_scale_inv_ptr, rowwise_scale_inv_ptr.stride(0), rowwise_scale_inv_ptr.stride(1),
+        rowwise_scale_M, rowwise_scale_N,
+        colwise_scale_inv_ptr, colwise_scale_inv_ptr.stride(0), colwise_scale_inv_ptr.stride(1),
+        colwise_scale_M, colwise_scale_N,
+        max_fp8, BLOCK_X, BLOCK_Y, GROUP_Y, MXFP8_BLOCK_SCALING_SIZE)
+
+def te_dequantize_mxfp8_triton(input, dtype, use_rowwise_scaling=True):
+    input_metadata = input.get_metadata()
+    rowwise_x_ptr = input_metadata["rowwise_data"]
+
+    row_length = rowwise_x_ptr.shape[-1] if len(rowwise_x_ptr.shape) > 0 else 1
+    num_rows = rowwise_x_ptr.numel() // row_length
+    rowwise_x_ptr_2d_view = rowwise_x_ptr.reshape(num_rows, row_length)
+
+    colwise_x_ptr = input_metadata["columnwise_data"]
+    colwise_x_ptr_2d_view = colwise_x_ptr.reshape(num_rows, row_length)
+
+    rowwise_scale_inv_ptr = input_metadata["rowwise_scale_inv"]
+    colwise_scale_inv_ptr = input_metadata["columnwise_scale_inv"]
+    fp8_dtype = input_metadata["fp8_dtype"]
+
+    out = torch.zeros(input.shape, dtype=dtype, device=rowwise_x_ptr.device)
+
+    # use_rowwise_scaling = rowwise_x_ptr is not None
+    x_ptr = rowwise_x_ptr_2d_view if use_rowwise_scaling else colwise_x_ptr_2d_view
+    scale_inv_ptr = rowwise_scale_inv_ptr if use_rowwise_scaling else colwise_scale_inv_ptr
+    scale_M, scale_N = rowwise_scale_inv_ptr.shape if use_rowwise_scaling else colwise_scale_inv_ptr.shape
+    
+    BLOCK_X = 64
+    BLOCK_Y = 64
+    GROUP_Y = 4
+    tl_dtype = te_dtype_to_triton_dtype(fp8_dtype)
+
+    grid = lambda META: (triton.cdiv(num_rows, META['BLOCK_Y']) * triton.cdiv(row_length, META['BLOCK_X']),)
+    _dequantize_mxfp8_triton[grid](
+    triton.reinterpret(x_ptr, tl_dtype), out,
+    x_ptr.stride(0), x_ptr.stride(1), 
+    num_rows, row_length, 
+    scale_inv_ptr, scale_inv_ptr.stride(0), scale_inv_ptr.stride(1),
+    scale_M, scale_N,
+    BLOCK_X, BLOCK_Y, GROUP_Y, use_rowwise_scaling, MXFP8_BLOCK_SCALING_SIZE)
+
+    return out
 
 ##########################################
 #### cast_transpose_dbias

--- a/transformer_engine/pytorch/triton_kernels/cast_transpose.py
+++ b/transformer_engine/pytorch/triton_kernels/cast_transpose.py
@@ -68,8 +68,8 @@ def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, s
         scale_inv_out = tl.fdiv(1.0, scale)
         tl.store(scale_inv_ptr, scale_inv_out)
 
-FP32_EXPONENT_BIAS: tl.constexpr = 127
-FP32_MANTISSA_BITS: tl.constexpr = 23
+FP32_EXPONENT_BIAS = tl.constexpr(127)
+FP32_MANTISSA_BITS = tl.constexpr(23)
 @triton.jit
 def exp2f_rcp_triton(biased_exp: tl.uint8) -> tl.float32:
     biased_exp_f32 = biased_exp.to(tl.float32)

--- a/transformer_engine/pytorch/triton_kernels/cast_transpose.py
+++ b/transformer_engine/pytorch/triton_kernels/cast_transpose.py
@@ -68,8 +68,10 @@ def _cast_transpose_triton(A, noop_ptr, C, T, stride_am, stride_an, stride_bn, s
         scale_inv_out = tl.fdiv(1.0, scale)
         tl.store(scale_inv_ptr, scale_inv_out)
 
+FP32_EXPONENT_BIAS: tl.constexpr = 127
+FP32_MANTISSA_BITS: tl.constexpr = 23
 @triton.jit
-def exp2f_rcp_triton(biased_exp: tl.uint8, FP32_EXPONENT_BIAS: tl.constexpr = 127) -> tl.float32:
+def exp2f_rcp_triton(biased_exp: tl.uint8) -> tl.float32:
     biased_exp_f32 = biased_exp.to(tl.float32)
     exp_val = FP32_EXPONENT_BIAS - biased_exp_f32
     result = tl.exp2(exp_val)
@@ -77,7 +79,7 @@ def exp2f_rcp_triton(biased_exp: tl.uint8, FP32_EXPONENT_BIAS: tl.constexpr = 12
     return final_result
 
 @triton.jit
-def float_to_e8m0_triton(val: tl.float32, FP32_MANTISSA_BITS: tl.constexpr = 23) -> tl.uint8:
+def float_to_e8m0_triton(val: tl.float32) -> tl.uint8:
     is_nan = (val != val)
     is_inf = (tl.abs(val) == float('inf'))
     is_zero = val == 0.0
@@ -261,35 +263,43 @@ def te_cast_transpose_mxfp8_triton(input, out, noop_flag=None):
 
     USE_ROWWISE_SCALING = out_metadata["rowwise_data"] is not None
     USE_COLWISE_SCALING = out_metadata["columnwise_data"] is not None
-
-    rowwise_y_ptr, rowwise_scale_inv_ptr = None, None
-    rowwise_scale_M, rowwise_scale_N = 1, 1
-    if USE_ROWWISE_SCALING:
-        rowwise_y_ptr = out_metadata["rowwise_data"].reshape(num_rows, row_length)
-        rowwise_scale_inv_ptr = out_metadata["rowwise_scale_inv"]
-        rowwise_scale_M, rowwise_scale_N = rowwise_scale_inv_ptr.shape
-
-    colwise_y_ptr, colwise_scale_inv_ptr = None, None
-    colwise_scale_M, colwise_scale_N = 1, 1
-    if USE_COLWISE_SCALING:
-        colwise_y_ptr = out_metadata["columnwise_data"].reshape(num_rows, row_length)
-        colwise_scale_inv_ptr = out_metadata["columnwise_scale_inv"]
-        colwise_scale_M, colwise_scale_N = colwise_scale_inv_ptr.shape
     
     fp8_dtype = out_metadata["fp8_dtype"]
+    tl_dtype = te_dtype_to_triton_dtype(fp8_dtype)
+    
+    rowwise_y_ptr, rowwise_scale_inv_ptr = None, None
+    rowwise_scale_M, rowwise_scale_N = 1, 1
+    rowwise_scale_stride_M, rowwise_scale_stride_N = 1, 1
+    if USE_ROWWISE_SCALING:
+        rowwise_y_ptr = out_metadata["rowwise_data"].reshape(num_rows, row_length)
+        rowwise_y_ptr = triton.reinterpret(rowwise_y_ptr, tl_dtype)
+        rowwise_scale_inv_ptr = out_metadata["rowwise_scale_inv"]
+        rowwise_scale_M, rowwise_scale_N = rowwise_scale_inv_ptr.shape
+        rowwise_scale_stride_M, rowwise_scale_stride_N = rowwise_scale_inv_ptr.stride(0), rowwise_scale_inv_ptr.stride(1)
+    
+    colwise_y_ptr, colwise_scale_inv_ptr = None, None
+    colwise_scale_M, colwise_scale_N = 1, 1
+    colwise_scale_stride_M, colwise_scale_stride_N = 1, 1
+    if USE_COLWISE_SCALING:
+        colwise_y_ptr = out_metadata["columnwise_data"].reshape(num_rows, row_length)
+        colwise_y_ptr = triton.reinterpret(colwise_y_ptr, tl_dtype)
+        colwise_scale_inv_ptr = out_metadata["columnwise_scale_inv"]
+        colwise_scale_M, colwise_scale_N = colwise_scale_inv_ptr.shape
+        colwise_scale_stride_M, colwise_scale_stride_N = colwise_scale_inv_ptr.stride(0), colwise_scale_inv_ptr.stride(1)
+    
+    
     BLOCK_X = 64
     BLOCK_Y = 64
     GROUP_Y = MXFP8_BLOCK_SCALING_SIZE
     max_fp8 = get_fp8_max(fp8_dtype)
-    tl_dtype = te_dtype_to_triton_dtype(fp8_dtype)
     grid = lambda META: (triton.cdiv(num_rows, META['BLOCK_Y']) * triton.cdiv(row_length, META['BLOCK_X']),)
     _cast_transpose_triton_mxfp8[grid](
-        input_2d_view, triton.reinterpret(rowwise_y_ptr, tl_dtype), triton.reinterpret(colwise_y_ptr, tl_dtype), 
+        input_2d_view, rowwise_y_ptr, colwise_y_ptr, 
         input_2d_view.stride(0), input_2d_view.stride(1), 
         num_rows, row_length, 
-        rowwise_scale_inv_ptr, rowwise_scale_inv_ptr.stride(0), rowwise_scale_inv_ptr.stride(1),
+        rowwise_scale_inv_ptr, rowwise_scale_stride_M, rowwise_scale_stride_N,
         rowwise_scale_M, rowwise_scale_N,
-        colwise_scale_inv_ptr, colwise_scale_inv_ptr.stride(0), colwise_scale_inv_ptr.stride(1),
+        colwise_scale_inv_ptr, colwise_scale_stride_M, colwise_scale_stride_N,
         colwise_scale_M, colwise_scale_N,
         max_fp8, BLOCK_X, BLOCK_Y, GROUP_Y, MXFP8_BLOCK_SCALING_SIZE, USE_ROWWISE_SCALING, USE_COLWISE_SCALING)
 


### PR DESCRIPTION
# Description

Added quantize and dequantize kernels for mxfp8
Added unit tests to test out mxfp8 casting integration with layernorm.

Fixes #[12696](https://github.com/ROCm/frameworks-internal/issues/12696)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- New triton kernel for casting to mxfp8
- New triton kernel for casting from mxfp8
- integrated these kernels to cast.py
- added unit tests for mxfp8 casting
- Added unit tests for normalization mxfp8 casting

# Checklist:

- [x ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ x] The functionality is complete
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
