### PR TITLE
Bug fix for failing RMSNorm transpose cache test

### DIFF
--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -217,3 +217,15 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
             5e-5,
             lambda msg: f"Output scale inverse does not match triton <-> hip\n\n{msg}\n",
         )
+        if quantizer_triton.columnwise_usage:
+            assert not ln_out_triton._transpose_invalid, "Expected a valid transpose buffer."
+            compare_results(
+                "te",
+                ln_out_triton._transpose,
+                ln_out_hipified._transpose,
+                1e-6,
+                5e-5,
+                lambda msg: f"Output transpose does not match triton <-> hip\n\n{msg}\n",
+            )
+        else:
+            assert ln_out_triton._transpose_invalid, "Expected an invalid transpose buffer."

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -217,15 +217,12 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
             5e-5,
             lambda msg: f"Output scale inverse does not match triton <-> hip\n\n{msg}\n",
         )
-        if quantizer_triton.columnwise_usage:
-            assert not ln_out_triton._transpose_invalid, "Expected a valid transpose buffer."
-            compare_results(
-                "te",
-                ln_out_triton._transpose,
-                ln_out_hipified._transpose,
-                atol,
-                rtol,
-                lambda msg: f"Output transpose does not match triton <-> hip\n\n{msg}\n",
-            )
-        else:
-            assert ln_out_triton._transpose_invalid, "Expected an invalid transpose buffer."
+        assert not ln_out_triton._transpose_invalid, "Expected a valid transpose buffer."
+        compare_results(
+            "te",
+            ln_out_triton._transpose,
+            ln_out_hipified._transpose,
+            atol,
+            rtol,
+            lambda msg: f"Output transpose does not match triton <-> hip\n\n{msg}\n",
+        )

--- a/tests/pytorch/triton_kernels/test_rmsnorm.py
+++ b/tests/pytorch/triton_kernels/test_rmsnorm.py
@@ -223,8 +223,8 @@ def test_rmsnorm_fwd_triton(M, N, in_dtype, out_dtype, zero_centered_gamma, quan
                 "te",
                 ln_out_triton._transpose,
                 ln_out_hipified._transpose,
-                1e-6,
-                5e-5,
+                atol,
+                rtol,
                 lambda msg: f"Output transpose does not match triton <-> hip\n\n{msg}\n",
             )
         else:

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -126,7 +126,7 @@ def _rmsnorm_fwd_triton(
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
                 output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + n_cols_blks * BLOCK_SIZE + row_idx
-                tl.store(output_t_ptrs, rms_norm.to(output_type))
+                tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
 
     else:
@@ -155,7 +155,7 @@ def _rmsnorm_fwd_triton(
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
                 output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + row_idx
-                tl.store(output_t_ptrs, rms_norm.to(output_type))
+                tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
     if IS_FP8:
         tl.store(amax_ptr + row_start, amax)

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -422,6 +422,8 @@ def te_rmsnorm_fwd_triton(
         NUM_PRGMS,
         IS_FP8,
     )
+    if IS_FP8:
+        out._create_transpose()
     if IS_MFP8:
         out = quantizer.quantize(out)
 

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -403,11 +403,15 @@ def te_rmsnorm_fwd_triton(
         q_scale = quantizer.scale
         q_amax = quantizer.amax
         out_ptr = triton.reinterpret(out._data, tl_dtype)
-        if quantizer.columnwise_usage and out._transpose_invalid:
-            out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
-            out._transpose_invalid = False
-        out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)
-        out_transpose_stride = out._transpose.stride(0)
+        if quantizer.columnwise_usage:
+            if out._transpose_invalid:
+                out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
+                out._transpose_invalid = False
+            out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)
+            out_transpose_stride = out._transpose.stride(0)
+        else:
+            out_transpose_ptr = None
+            out_transpose_stride = None
     else:
         out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
         amax = None

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -51,6 +51,7 @@ def _rmsnorm_fwd_triton(
     # tl.assume(output_row_stride >= 0)
     # tl.assume(row_start >= 0)
     output_type = output_ptr.type.element_ty
+    make_transpose = out_transpose_ptr is not None
     if IS_FP8:
         scale = tl.load(q_scale_ptr)
         amax = 0.0
@@ -106,8 +107,9 @@ def _rmsnorm_fwd_triton(
                     amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                     amax = tl.maximum(amax, amax_temp)
                     rms_norm = rms_norm * scale
-                    output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + blk_idx * BLOCK_SIZE + row_idx
-                    tl.store(output_t_ptrs, rms_norm.to(output_type))
+                    if make_transpose:
+                        output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + blk_idx * BLOCK_SIZE + row_idx
+                        tl.store(output_t_ptrs, rms_norm.to(output_type))
                 tl.store(output_ptrs, rms_norm.to(output_type))
 
             # Handle remainder
@@ -125,8 +127,9 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
-                output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + n_cols_blks * BLOCK_SIZE + row_idx
-                tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
+                if make_transpose:
+                    output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + n_cols_blks * BLOCK_SIZE + row_idx
+                    tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
 
     else:
@@ -154,8 +157,9 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
-                output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + row_idx
-                tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
+                if make_transpose:
+                    output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + row_idx
+                    tl.store(output_t_ptrs, rms_norm.to(output_type), mask=mask)
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
     if IS_FP8:
         tl.store(amax_ptr + row_start, amax)
@@ -399,7 +403,7 @@ def te_rmsnorm_fwd_triton(
         q_scale = quantizer.scale
         q_amax = quantizer.amax
         out_ptr = triton.reinterpret(out._data, tl_dtype)
-        if out._transpose_invalid:
+        if quantizer.columnwise_usage and out._transpose_invalid:
             out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
             out._transpose_invalid = False
         out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -399,6 +399,9 @@ def te_rmsnorm_fwd_triton(
         q_scale = quantizer.scale
         q_amax = quantizer.amax
         out_ptr = triton.reinterpret(out._data, tl_dtype)
+        if out._transpose_invalid:
+            out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
+            out._transpose_invalid = False
         out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)
         out_transpose_stride = out._transpose.stride(0)
     else:

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -414,13 +414,13 @@ def te_rmsnorm_fwd_triton(
             out_transpose_ptr = None
             out_transpose_stride = None
     else:
+        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
         amax = None
         tl_dtype = None
         scale_inv_ptr = None
         q_scale = None
         q_amax = None
-        out_ptr = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
-        out_stride = out_ptr.stride(0)
+        out_ptr = out
         out_transpose_ptr = None
         out_transpose_stride = None
 
@@ -434,7 +434,7 @@ def te_rmsnorm_fwd_triton(
         weight,
         rsigma,
         input.stride(0),
-        out_stride,
+        out_ptr.stride(0),
         N, H, eps,
         amax,
         q_amax,
@@ -449,6 +449,6 @@ def te_rmsnorm_fwd_triton(
         IS_FP8,
     )
     if IS_MFP8:
-        out_ptr = quantizer.quantize(out_ptr)
+        out = quantizer.quantize(out)
 
-    return out_ptr, None, rsigma
+    return out, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -403,6 +403,7 @@ def te_rmsnorm_fwd_triton(
         q_scale = quantizer.scale
         q_amax = quantizer.amax
         out_ptr = triton.reinterpret(out._data, tl_dtype)
+        out_stride = out._data.stride(0)
         if quantizer.columnwise_usage:
             if out._transpose_invalid:
                 out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
@@ -413,13 +414,13 @@ def te_rmsnorm_fwd_triton(
             out_transpose_ptr = None
             out_transpose_stride = None
     else:
-        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
         amax = None
         tl_dtype = None
         scale_inv_ptr = None
         q_scale = None
         q_amax = None
-        out_ptr = out
+        out_ptr = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
+        out_stride = out_ptr.stride(0)
         out_transpose_ptr = None
         out_transpose_stride = None
 
@@ -433,7 +434,7 @@ def te_rmsnorm_fwd_triton(
         weight,
         rsigma,
         input.stride(0),
-        out.stride(0),
+        out_stride,
         N, H, eps,
         amax,
         q_amax,
@@ -448,6 +449,6 @@ def te_rmsnorm_fwd_triton(
         IS_FP8,
     )
     if IS_MFP8:
-        out = quantizer.quantize(out)
+        out_ptr = quantizer.quantize(out_ptr)
 
-    return out, None, rsigma
+    return out_ptr, None, rsigma

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -36,6 +36,8 @@ def _rmsnorm_fwd_triton(
     q_amax_ptr,
     q_scale_ptr,
     scale_inv_ptr,
+    out_transpose_ptr,
+    transpose_row_stride,
     ZERO_CENTERED_GAMMA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     USE_BLOCKED: tl.constexpr,
@@ -104,6 +106,8 @@ def _rmsnorm_fwd_triton(
                     amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                     amax = tl.maximum(amax, amax_temp)
                     rms_norm = rms_norm * scale
+                    output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + blk_idx * BLOCK_SIZE + row_idx
+                    tl.store(output_t_ptrs, rms_norm.to(output_type))
                 tl.store(output_ptrs, rms_norm.to(output_type))
 
             # Handle remainder
@@ -121,6 +125,8 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
+                output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + n_cols_blks * BLOCK_SIZE + row_idx
+                tl.store(output_t_ptrs, rms_norm.to(output_type))
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
 
     else:
@@ -148,6 +154,8 @@ def _rmsnorm_fwd_triton(
                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
                 amax = tl.maximum(amax, amax_temp)
                 rms_norm = rms_norm * scale
+                output_t_ptrs = out_transpose_ptr + col_offsets * transpose_row_stride + row_idx
+                tl.store(output_t_ptrs, rms_norm.to(output_type))
             tl.store(output_ptrs, rms_norm.to(output_type), mask=mask)
     if IS_FP8:
         tl.store(amax_ptr + row_start, amax)
@@ -391,6 +399,8 @@ def te_rmsnorm_fwd_triton(
         q_scale = quantizer.scale
         q_amax = quantizer.amax
         out_ptr = triton.reinterpret(out._data, tl_dtype)
+        out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)
+        out_transpose_stride = out._transpose.stride(0)
     else:
         out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
         amax = None
@@ -399,6 +409,8 @@ def te_rmsnorm_fwd_triton(
         q_scale = None
         q_amax = None
         out_ptr = out
+        out_transpose_ptr = None
+        out_transpose_stride = None
 
 
     grid_fwd = lambda meta: (NUM_PRGMS, )
@@ -416,14 +428,14 @@ def te_rmsnorm_fwd_triton(
         q_amax,
         q_scale,
         scale_inv_ptr,
+        out_transpose_ptr,
+        out_transpose_stride,
         zero_centered_gamma,
         BLOCK_SIZE,
         USE_BLOCKED,
         NUM_PRGMS,
         IS_FP8,
     )
-    if IS_FP8:
-        out._create_transpose()
     if IS_MFP8:
         out = quantizer.quantize(out)
 


### PR DESCRIPTION
# Description

RMSNorm triton kernel now ensures the creation of the transpose buffer for its fused output.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Ensure creation of transpose buffer for FP8 output.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
