### PR TITLE
hotfix for PR (216): add IS_HIP_EXTENSION guard

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -41,7 +41,8 @@ from ..tensor import QuantizedTensor, Quantizer
 from ..tensor._internal.float8_tensor_base import Float8TensorBase
 from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
 from ..utils import get_device_compute_capability
-from ..triton_kernels.cast import te_quantize_triton
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.cast import te_quantize_triton
 
 from ..utils import non_tn_fp8_gemm_supported
 from ..tensor.float8_tensor import Float8Quantizer 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1071,9 +1071,12 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             if hasattr(out, "quantize_"):
                 out.quantize_(tensor, noop_flag=skip_update_flag)
             else:
-                use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
-                quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
-                quantize_func(tensor, quantizer, out, skip_update_flag)
+                if IS_HIP_EXTENSION:
+                    use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
+                    quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
+                    quantize_func(tensor, quantizer, out, skip_update_flag)
+                else:
+                    tex.quantize(tensor, quantizer, out, skip_update_flag)
 
         return out
 

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -18,7 +18,8 @@ from transformer_engine_torch import DType as TE_DType
 from ..utils import devices_match, non_tn_fp8_gemm_supported
 from ._internal.float8_tensor_base import Float8TensorBase, _FromFloat8Func
 from .quantized_tensor import QuantizedTensor, Quantizer, _IdentityFunc
-from ..triton_kernels.cast import te_quantize_triton
+if IS_HIP_EXTENSION:
+    from ..triton_kernels.cast import te_quantize_triton
 
 aten = torch.ops.aten
 

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -85,11 +85,12 @@ class Float8Quantizer(Quantizer):
             src = src.contiguous()
 
         # Launch cast kernel
-        quantize_func = tex.quantize
         if IS_HIP_EXTENSION:
             use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
             quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
-        quantize_func(src, self, dst, noop_flag)
+            quantize_func(src, self, dst, noop_flag)
+        else:
+            tex.quantize(src, self, dst, noop_flag)
 
         # Update FP8 dtype
         dst._fp8_dtype = self.dtype

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 from typing import Optional, Tuple, Iterable
 import warnings
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import torch
 import transformer_engine_torch as tex
@@ -84,8 +85,10 @@ class Float8Quantizer(Quantizer):
             src = src.contiguous()
 
         # Launch cast kernel
-        use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
-        quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
+        quantize_func = tex.quantize
+        if IS_HIP_EXTENSION:
+            use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
+            quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
         quantize_func(src, self, dst, noop_flag)
 
         # Update FP8 dtype

--- a/transformer_engine/pytorch/tensor/quantized_tensor.py
+++ b/transformer_engine/pytorch/tensor/quantized_tensor.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 """Tensor with quantized data"""
 
 from __future__ import annotations
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 import os
 from typing import Optional, Tuple, Iterable, Any, Dict, Union
 import abc

--- a/transformer_engine/pytorch/tensor/quantized_tensor.py
+++ b/transformer_engine/pytorch/tensor/quantized_tensor.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 """Tensor with quantized data"""
 
@@ -193,9 +194,11 @@ class _QuantizeFunc(torch.autograd.Function):
         quantizer: Quantizer,
     ) -> QuantizedTensor:
         # pylint: disable=missing-function-docstring
-        from ..triton_kernels.cast import te_quantize_triton
-        use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
-        quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
+        quantize_func =  tex.quantize
+        if IS_HIP_EXTENSION:
+            from ..triton_kernels.cast import te_quantize_triton
+            use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
+            quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
         return quantize_func(tensor, quantizer)
 
     @staticmethod

--- a/transformer_engine/pytorch/tensor/quantized_tensor.py
+++ b/transformer_engine/pytorch/tensor/quantized_tensor.py
@@ -194,12 +194,13 @@ class _QuantizeFunc(torch.autograd.Function):
         quantizer: Quantizer,
     ) -> QuantizedTensor:
         # pylint: disable=missing-function-docstring
-        quantize_func =  tex.quantize
         if IS_HIP_EXTENSION:
             from ..triton_kernels.cast import te_quantize_triton
             use_cast_transpose_triton =  bool( int(os.environ.get('NVTE_USE_CAST_TRANSPOSE_TRITON', '0')) )
             quantize_func = te_quantize_triton if use_cast_transpose_triton else tex.quantize
-        return quantize_func(tensor, quantizer)
+            return quantize_func(tensor, quantizer)
+        else:
+            return tex.quantize(tensor, quantizer)
 
     @staticmethod
     def backward(


### PR DESCRIPTION
# Description

Added IS_HIP_EXTENSION guard for float8_tensor.py and quantized_tensor.py

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Added IS_HIP_EXTENSION guard for float8_tensor.py and quantized_tensor.py


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
