### PR TITLE
Fix dropout when using a new-style rng

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -388,10 +388,15 @@ class FusedAttnRunner:
         self.cp_size = self.mesh.shape.get(self.mesh_resource.cp_resource, 1)
         self.tp_size = self.mesh.shape.get(self.mesh_resource.tp_resource, 1)
 
-        if self.use_old_rng:
-            key = jax.random.PRNGKey(0)
+        # only support new-style RNGs on AMD hardware since they will crash otherwise
+        if is_hip_extension():
+            if self.use_old_rng:
+                key = jax.random.PRNGKey(0)
+            else:
+                key = jax.random.key(0)
         else:
             key = jax.random.key(0)
+
         q_key, k_key, v_key, bias_key, dropout_key = jax.random.split(key, 5)
 
         q_shape = (self.batch_size, self.max_seqlen_q, self.num_heads_q, self.head_dim)
@@ -587,7 +592,7 @@ class FusedAttnRunner:
                 case _:
                     raise ValueError(f"Unknown {self.seq_desc_format=}")
 
-        self.dropout_rng = dropout_key
+        self.dropout_rng = dropout_key if self.dropout_prob > 0 else None
         self.scaling_factor = 1.0 / sqrt(self.head_dim)
 
         # Setup distributed sharding specs
@@ -630,10 +635,15 @@ class FusedAttnRunner:
             self.bias_pspec = PartitionSpec()
         self.bias_sharding = NamedSharding(self.mesh, self.bias_pspec)
 
-        if jnp.issubdtype(self.dropout_rng.dtype, jax.dtypes.prng_key):
-            self.dropout_rng_pspec = PartitionSpec()
+        # New-style RNG fix is only applied for AMD GPUs
+        if is_hip_extension():
+            if self.dropout_rng is not None and jnp.issubdtype(self.dropout_rng.dtype, jax.dtypes.prng_key):
+                self.dropout_rng_pspec = PartitionSpec()
+            else:
+                self.dropout_rng_pspec = PartitionSpec(None,)
         else:
             self.dropout_rng_pspec = PartitionSpec(None,)
+
         self.dropout_rng_sharding = NamedSharding(self.mesh, self.dropout_rng_pspec)
 
         self.logit_scale_pspec = PartitionSpec(None, None, self.mesh_resource.cp_resource, None)
@@ -863,7 +873,7 @@ class FusedAttnRunner:
 
             # Assume all batch has the same actual_seqlen, probably needs to extend the tests
             bias_mask = self.mask[0, 0]
-
+            
             # Assert all masked dbias are 0s
             assert_allclose(
                 jnp.where(bias_mask, primitive_dbias, 0),
@@ -936,11 +946,11 @@ class FusedAttnRunner:
         pytest.param(0.1, id="DROP_0.1"),
     ],
 )
+# Only testing old-style RNGs by default to reduce the # of tests but leaving the hooks in place
 @pytest.mark.parametrize(
     "use_old_rng",
     [
         pytest.param(True, id="Old-style rng"),
-        pytest.param(False, id="New-style rng"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1085,3 +1095,32 @@ class TestFusedAttn:
             if swa and is_padding:
                 pytest.skip("Jax cannot get cu_seqlen correctly from mask with swa")
         runner.test_backward()
+
+# Single test with new-style RNG
+def test_jax_new_rng():
+    """
+    Non-regression test evaluating whether
+    `_FusedAttnRNGStateChecker.check_seed` can correctly handle a new-style
+    JAX PRNG seed.
+    """
+    # Arbitrary args, except `dropout_prob` which needs to be >0
+    kwargs = dict(
+        batch_size = 2,
+        max_seqlen_q = 2048,
+        max_seqlen_kv = 2048,
+        num_heads_q = 12,
+        num_heads_kv = 12,
+        head_dim = 64,
+        attn_bias_type = AttnBiasType.NO_BIAS,
+        attn_mask_type = AttnMaskType.NO_MASK,
+        dropout_prob = 0.1,
+        use_old_rng = False,
+        dtype = jnp.bfloat16,
+        is_training = True,
+        qkv_layout = QKVLayout.BS3HD,
+        bias_shape = BiasShape._1HSS,
+        seq_desc_format = SeqDescFormat.Mask,
+        window_size = None,
+    )
+    runner = FusedAttnRunner(**kwargs)
+    runner.test_forward()

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -298,6 +298,7 @@ class FusedAttnRunner:
     attn_bias_type: AttnBiasType
     attn_mask_type: AttnMaskType
     dropout_prob: float
+    use_old_rng: bool
     dtype: DTypeLike
     is_training: bool
     qkv_layout: QKVLayout
@@ -387,7 +388,10 @@ class FusedAttnRunner:
         self.cp_size = self.mesh.shape.get(self.mesh_resource.cp_resource, 1)
         self.tp_size = self.mesh.shape.get(self.mesh_resource.tp_resource, 1)
 
-        key = jax.random.PRNGKey(0)
+        if self.use_old_rng:
+            key = jax.random.PRNGKey(0)
+        else:
+            key = jax.random.key(0)
         q_key, k_key, v_key, bias_key, dropout_key = jax.random.split(key, 5)
 
         q_shape = (self.batch_size, self.max_seqlen_q, self.num_heads_q, self.head_dim)
@@ -858,7 +862,7 @@ class FusedAttnRunner:
 
             # Assume all batch has the same actual_seqlen, probably needs to extend the tests
             bias_mask = self.mask[0, 0]
-            
+
             # Assert all masked dbias are 0s
             assert_allclose(
                 jnp.where(bias_mask, primitive_dbias, 0),
@@ -932,6 +936,13 @@ class FusedAttnRunner:
     ],
 )
 @pytest.mark.parametrize(
+    "use_old_rng",
+    [
+        pytest.param(True, id="Old-style rng"),
+        pytest.param(False, id="New-style rng"),
+    ],
+)
+@pytest.mark.parametrize(
     "swa",
     [
         pytest.param(False, id="NO_SWA"),
@@ -979,6 +990,7 @@ class TestFusedAttn:
         attn_bias_type,
         attn_mask_type,
         dropout_prob,
+        use_old_rng,
         dtype,
         is_training,
         qkv_layout,
@@ -1004,6 +1016,7 @@ class TestFusedAttn:
             attn_bias_type,
             attn_mask_type,
             dropout_prob,
+            use_old_rng,
             dtype,
             is_training,
             qkv_layout,
@@ -1035,6 +1048,7 @@ class TestFusedAttn:
         attn_bias_type,
         attn_mask_type,
         dropout_prob,
+        use_old_rng,
         dtype,
         qkv_layout,
         bias_shape,
@@ -1057,6 +1071,7 @@ class TestFusedAttn:
             attn_bias_type,
             attn_mask_type,
             dropout_prob,
+            use_old_rng,
             dtype,
             True,
             qkv_layout,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -630,8 +630,11 @@ class FusedAttnRunner:
             self.bias_pspec = PartitionSpec()
         self.bias_sharding = NamedSharding(self.mesh, self.bias_pspec)
 
-        self.dropout_rng_pspec =  (PartitionSpec() if jnp.issubdtype(self.dropout_rng.dtype, jax.dtypes.prng_key)
-                                                    else PartitionSpec(None,))
+        if jnp.issubdtype(self.dropout_rng.dtype, jax.dtypes.prng_key):
+            self.dropout_rng_pspec = PartitionSpec()
+        else:
+            self.dropout_rng_pspec = PartitionSpec(None,)
+
         self.dropout_rng_sharding = NamedSharding(self.mesh, self.dropout_rng_pspec)
 
         self.logit_scale_pspec = PartitionSpec(None, None, self.mesh_resource.cp_resource, None)

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -634,7 +634,6 @@ class FusedAttnRunner:
             self.dropout_rng_pspec = PartitionSpec()
         else:
             self.dropout_rng_pspec = PartitionSpec(None,)
-
         self.dropout_rng_sharding = NamedSharding(self.mesh, self.dropout_rng_pspec)
 
         self.logit_scale_pspec = PartitionSpec(None, None, self.mesh_resource.cp_resource, None)

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -587,8 +587,7 @@ class FusedAttnRunner:
                 case _:
                     raise ValueError(f"Unknown {self.seq_desc_format=}")
 
-        # new-style RNGs need to be split before they are sharded, and this will not break old-style RNGs
-        self.dropout_rng = jax.random.split(dropout_key, len(jax.devices())) if self.dropout_prob > 0 else None
+        self.dropout_rng = dropout_key
         self.scaling_factor = 1.0 / sqrt(self.head_dim)
 
         # Setup distributed sharding specs
@@ -631,9 +630,8 @@ class FusedAttnRunner:
             self.bias_pspec = PartitionSpec()
         self.bias_sharding = NamedSharding(self.mesh, self.bias_pspec)
 
-        self.dropout_rng_pspec = PartitionSpec(
-            None,
-        )
+        self.dropout_rng_pspec =  (PartitionSpec() if jnp.issubdtype(self.dropout_rng.dtype, jax.dtypes.prng_key)
+                                                    else PartitionSpec(None,))
         self.dropout_rng_sharding = NamedSharding(self.mesh, self.dropout_rng_pspec)
 
         self.logit_scale_pspec = PartitionSpec(None, None, self.mesh_resource.cp_resource, None)

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -587,7 +587,8 @@ class FusedAttnRunner:
                 case _:
                     raise ValueError(f"Unknown {self.seq_desc_format=}")
 
-        self.dropout_rng = dropout_key if self.dropout_prob > 0 else None
+        # new-style RNGs need to be split before they are sharded, and this will not break old-style RNGs
+        self.dropout_rng = jax.random.split(dropout_key, len(jax.devices())) if self.dropout_prob > 0 else None
         self.scaling_factor = 1.0 / sqrt(self.head_dim)
 
         # Setup distributed sharding specs

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -206,6 +206,8 @@ class _FusedAttnRNGStateChecker:
                 "Please use threefry/rbg/unsafe_rbg PRNG implementations to remove this warning."
             )
             if (jnp.issubdtype(seed.dtype, jax.dtypes.prng_key)):
+                # New-style RNGs cannot directly be cast to integers
+                # See https://docs.jax.dev/en/latest/jep/9263-typed-keys.html for details
                 seed = jax.random.key_data(seed)
             seed = seed.astype(self.rng_state_dtype)
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -205,7 +205,7 @@ class _FusedAttnRNGStateChecker:
                 f"casted to dtype {self.rng_state_dtype}. "
                 "Please use threefry/rbg/unsafe_rbg PRNG implementations to remove this warning."
             )
-            if (jnp.issubdtype(seed.dtype, jax.dtypes.prng_key)):
+            if jnp.issubdtype(seed.dtype, jax.dtypes.prng_key):
                 # New-style RNGs cannot directly be cast to integers
                 # See https://docs.jax.dev/en/latest/jep/9263-typed-keys.html for details
                 seed = jax.random.key_data(seed)

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -205,7 +205,9 @@ class _FusedAttnRNGStateChecker:
                 f"casted to dtype {self.rng_state_dtype}. "
                 "Please use threefry/rbg/unsafe_rbg PRNG implementations to remove this warning."
             )
-            if jnp.issubdtype(seed.dtype, jax.dtypes.prng_key):
+            # Note that the fix for new-style RNGs is only applied for AMD GPUs
+            # seed = seed.astype(...) will still crash for new-style RNGs on CPU and other GPUs
+            if is_hip_extension() and jnp.issubdtype(seed.dtype, jax.dtypes.prng_key):
                 # New-style RNGs cannot directly be cast to integers
                 # See https://docs.jax.dev/en/latest/jep/9263-typed-keys.html for details
                 seed = jax.random.key_data(seed)

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -205,6 +205,8 @@ class _FusedAttnRNGStateChecker:
                 f"casted to dtype {self.rng_state_dtype}. "
                 "Please use threefry/rbg/unsafe_rbg PRNG implementations to remove this warning."
             )
+            if (jnp.issubdtype(seed.dtype, jax.dtypes.prng_key)):
+                seed = jax.random.key_data(seed)
             seed = seed.astype(self.rng_state_dtype)
 
         assert seed.dtype == self.rng_state_dtype


### PR DESCRIPTION
# Description

Previously TE would crash with a type error [at this line of code](https://github.com/ROCm/TransformerEngine/blob/c97ecae53e8cd1d8b925530eef25036ef43f9181/transformer_engine/jax/cpp_extensions/attention.py#L208) if new-style RNGs were used. This PR fixes the error by converting a new-style RNG to an int properly.

Fixes #244 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Uses Jax's [recommended mechanism](https://docs.jax.dev/en/latest/jep/9263-typed-keys.html) to convert a new-style RNG to int data when a new-style RNG is used
- Includes tests for new-style RNGs

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
