### PR TITLE
keep_fp8_weight_transpose_cache default=True, integrates into megatron

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -424,7 +424,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         self.fsdp_group = None
         self._fp8_workspaces: Dict[str, QuantizedTensor] = {}
         self.activation_dtype: Optional[torch.dtype] = None
-        self.keep_fp8_weight_transpose_cache: bool = False
 
     # Names of attributes that can be set quickly (see __setattr__
     # method)
@@ -924,7 +923,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                     quantizer is not None
                 )  # to use primary fp8 weight one needs to use FP8 autocast with specific recipe.
                 quantizer.internal = False
-                # TODO @sarora to move all instances of this to base class. 
                 if not self.keep_fp8_weight_transpose_cache:
                     quantizer.columnwise_usage=False
                 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1016,7 +1016,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
         ub_bulk_wgrad: bool = False,
         ub_bulk_dgrad: bool = False,
         ub_name: Optional[str] = None,
-        keep_fp8_weight_transpose_cache: bool = False,
+        keep_fp8_weight_transpose_cache: bool = True,
     ) -> None:
         super().__init__()
 

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1240,7 +1240,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
         ub_overlap_rs_dgrad: bool = False,
         ub_bulk_dgrad: bool = False,
         ub_bulk_wgrad: bool = False,
-        keep_fp8_weight_transpose_cache: bool = False,
+        keep_fp8_weight_transpose_cache: bool = True,
     ) -> None:
         super().__init__()
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -831,7 +831,7 @@ class Linear(TransformerEngineBaseModule):
         ub_bulk_dgrad: bool = False,
         ub_bulk_wgrad: bool = False,
         ub_name: Optional[str] = None,
-        keep_fp8_weight_transpose_cache: bool = False,
+        keep_fp8_weight_transpose_cache: bool = True,
     ) -> None:
         super().__init__()
 


### PR DESCRIPTION
# Description
FP8 Weight Tranpose occupy signiifacnt memory during checkpoint loading and run-time. The memory are essentially doubled for linear, layernorm_linear and layernorm_mlp. 

Fixes # ([SWDEV-547033](https://github.com/ROCm/Megatron-LM/tree/SWDEV-547033/feature/fp8-weight-transpose-cache))

## Type of change

- [X ] New feature (non-breaking change which adds functionality)


## Changes

Please list the changes introduced in this PR:
Adds a new parameter `keep_fp8_weight_transpose_cache default=True`. Default value of True will not affect pre-existing optimization. The user may override these default via megatron-lm (see https://github.com/ROCm/Megatron-LM/pull/86)

