### PR TITLE
Fix missing make_transpose declaration in _rmsnorm_fwd_triton

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -52,6 +52,7 @@ def _rmsnorm_fwd_triton(
     # tl.assume(output_row_stride >= 0)
     # tl.assume(row_start >= 0)
     output_type = output_ptr.type.element_ty
+    make_transpose = out_transpose_ptr is not None
     if IS_FP8:
         scale = tl.load(q_scale_ptr)
         amax = 0.0


### PR DESCRIPTION
# Description

Fixes missing declaration of make_transpose in _rmsnorm_fwd_triton

Fixes the following runtime error:
```bash
[rank7]: triton.compiler.errors.CompilationError: at 137:19:
[rank7]:             if (ZERO_CENTERED_GAMMA):
[rank7]:                 g += 1
[rank7]:             rms_norm = row * norm_factor * g

[rank7]:             output_ptrs = output_ptr + row_idx * output_row_stride + col_offsets
[rank7]:             output_ptrs = tl.multiple_of(output_ptrs, (16, ))
[rank7]:             if IS_FP8:
[rank7]:                 amax_temp = tl.max(tl.abs(rms_norm), axis=-1)
[rank7]:                 amax = tl.maximum(amax, amax_temp)
[rank7]:                 rms_norm = rms_norm * scale
[rank7]:                 rms_norm = tl.clamp(rms_norm, -FP8_MAX, FP8_MAX)
[rank7]:                 if make_transpose:
[rank7]:                    ^
[rank7]: NameError('make_transpose is not defined')
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

Please list the changes introduced in this PR:

Fixes a semantic error in the rmsnorm triton kernel introduced in this commit: https://github.com/ROCm/TransformerEngine/commit/d60f858e6dd5c76d65c85bf379c2215485a038fb

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
