### PR TITLE
[Fix] If 'ninja' is not found, it installs it via pip

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -79,9 +79,10 @@ class CMakeExtension(setuptools.Extension):
 
         # Check whether parallel build is restricted
         max_jobs = get_max_jobs_for_parallel_build()
-        if not found_ninja():
+        if found_ninja():
+            configure_command.append("-GNinja")
+        elif rocm_build():
             raise RuntimeError(f"This project requires the Ninja build system. Install it using 'pip install ninja'.")
-        configure_command.append("-GNinja")
         build_command.append("--parallel")
         if max_jobs > 0:
             build_command.append(str(max_jobs))

--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -79,8 +79,9 @@ class CMakeExtension(setuptools.Extension):
 
         # Check whether parallel build is restricted
         max_jobs = get_max_jobs_for_parallel_build()
-        if found_ninja():
-            configure_command.append("-GNinja")
+        if not found_ninja():
+            raise RuntimeError(f"This project requires the Ninja build system. Install it using 'pip install ninja'.")
+        configure_command.append("-GNinja")
         build_command.append("--parallel")
         if max_jobs > 0:
             build_command.append(str(max_jobs))

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import sys
 import time
 from pathlib import Path
 from typing import List, Tuple
+import subprocess
 
 import setuptools
 from wheel.bdist_wheel import bdist_wheel
@@ -117,6 +118,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
     if not found_cmake():
         setup_reqs.append("cmake>=3.21")
     if not found_ninja():
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "ninja"])
         setup_reqs.append("ninja")
     if not found_pybind11():
         setup_reqs.append("pybind11")

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -32,9 +32,6 @@ else()
   
 endif()
 
-if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
-  message(FATAL_ERROR "This project requires the Ninja build system. Install it using 'pip install ninja'.")
-endif()
 
 # Language options
 if(USE_CUDA)
@@ -78,6 +75,11 @@ if(USE_CUDA)
 else()
   set(CMAKE_CXX_STANDARD 17)
   project(transformer_engine LANGUAGES HIP CXX)
+
+  # If using ROCm, ninja must be installed to build TE.
+  if (NOT CMAKE_GENERATOR STREQUAL "Ninja")
+    message(FATAL_ERROR "This project requires the Ninja build system. Install it using 'pip install ninja'.")
+  endif()
 
   # Disable Asserts In Code (Can't use asserts on HIP stack.)
   add_definitions(-DNDEBUG)

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   
 endif()
 
+if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
+  message(FATAL_ERROR "This project requires the Ninja build system. Install it using 'pip install ninja'.")
+endif()
+
 # Language options
 if(USE_CUDA)
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- If 'ninja' is not found, then 'ninja' will be installed via pup from setup.py
- Added checks with corresponding errors in build_ext.py and CMakeLists.txt

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
