### PR TITLE
FIX Accumulate `int` overflow in workspace memory calculation

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -266,6 +266,8 @@ def test_dot_product_mem_calc(workspace_opt):
         pytest.skip("This test requires the CK fused attention backend.")
 
     os.environ["NVTE_CK_USES_FWD_V3"] = "1"
+    os.environ["NVTE_FUSED_ATTN_CK"] = "0"
+    os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
     _, _ = _run_dot_product_attention(
         dtype,
         config,
@@ -277,6 +279,8 @@ def test_dot_product_mem_calc(workspace_opt):
         is_training,
     )
     del os.environ["NVTE_CK_USES_FWD_V3"]
+    del os.environ["NVTE_FUSED_ATTN_CK"]
+    del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -241,6 +241,48 @@ if is_bf16_compatible():  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 param_types_lean = [torch.bfloat16]
 
+@pytest.mark.parametrize("workspace_opt", [True, False])
+def test_dot_product_mem_calc(workspace_opt):
+    """
+    Non-regression test for memory workspace calculation integer overflow issue.
+    """
+    ckpt_attn = False
+    pad_between_seqs = False
+    if not is_bf16_compatible():
+        pytest.skip("This test requires bf16 support.")
+    dtype = torch.bfloat16
+    config = ModelConfig(16, 128, 8, 128, 8192, 8192, 0.0, "causal", "no_bias")
+    qkv_layout = "sbhd_sbhd_sbhd"
+    available_backends, _ = _get_attention_backends(
+        config,
+        qkv_dtype=dtype,
+        qkv_layout=qkv_layout,
+        window_size=config.window_size,
+        pad_between_seqs=pad_between_seqs,
+    )
+    _, fused_attn_supported, _ = available_backends
+    if not fused_attn_supported:
+        pytest.skip("This test requires the CK fused attention backend.")
+    is_training = config.head_dim_qk <= 128 and config.head_dim_v <= 128
+    # FusedAttention backend
+    os.environ["NVTE_CK_USES_FWD_V3"] = "1"
+    os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
+    os.environ["NVTE_FUSED_ATTN_CK"] = "1"
+    os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+    _, _ = _run_dot_product_attention(
+        dtype,
+        config,
+        "FusedAttention",
+        ckpt_attn,
+        qkv_layout,
+        workspace_opt,
+        pad_between_seqs,
+        is_training,
+    )
+    del os.environ["NVTE_FUSED_ATTN_CK"]
+    del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
+    del os.environ["NVTE_CK_USES_FWD_V3"]
+
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")
 @pytest.mark.parametrize("dtype", param_types)

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -241,6 +241,7 @@ if is_bf16_compatible():  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 param_types_lean = [torch.bfloat16]
 
+@pytest.mark.skipif(not IS_HIP_EXTENSION, reason="ROCm TE specific pytests.")
 @pytest.mark.parametrize("workspace_opt", [True, False])
 def test_dot_product_mem_calc(workspace_opt):
     """
@@ -252,23 +253,19 @@ def test_dot_product_mem_calc(workspace_opt):
         pytest.skip("This test requires bf16 support.")
     dtype = torch.bfloat16
     config = ModelConfig(16, 128, 8, 128, 8192, 8192, 0.0, "causal", "no_bias")
+    is_training = config.head_dim_qk <= 128 and config.head_dim_v <= 128
     qkv_layout = "sbhd_sbhd_sbhd"
-    available_backends, _ = _get_attention_backends(
+    _, fused_attn_backends = _get_attention_backends(
         config,
         qkv_dtype=dtype,
         qkv_layout=qkv_layout,
         window_size=config.window_size,
         pad_between_seqs=pad_between_seqs,
     )
-    _, fused_attn_supported, _ = available_backends
-    if not fused_attn_supported:
+    if FusedAttnBackend["CK"] not in fused_attn_backends:
         pytest.skip("This test requires the CK fused attention backend.")
-    is_training = config.head_dim_qk <= 128 and config.head_dim_v <= 128
-    # FusedAttention backend
+
     os.environ["NVTE_CK_USES_FWD_V3"] = "1"
-    os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
-    os.environ["NVTE_FUSED_ATTN_CK"] = "1"
-    os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
     _, _ = _run_dot_product_attention(
         dtype,
         config,
@@ -279,8 +276,6 @@ def test_dot_product_mem_calc(workspace_opt):
         pad_between_seqs,
         is_training,
     )
-    del os.environ["NVTE_FUSED_ATTN_CK"]
-    del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
     del os.environ["NVTE_CK_USES_FWD_V3"]
 
 

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -1241,7 +1241,7 @@ void fused_attn_ck_fwd_qkvpacked(
   void *devPtrCuSeqlens = input_cu_seqlens->data.dptr;
   void *devPtrSeqOffsets = input_cu_seqlens_padded->data.dptr;
 
-  size_t max_tokens = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), 1, std::multiplies<size_t>())/h/d/3;
+  size_t max_tokens = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h/d/3;
   bool is_ragged = nvte_get_qkv_format(qkv_layout)==NVTE_QKV_Format::NVTE_THD; 
 
   if (Aux_CTX_Tensors->size == 0) {
@@ -1405,7 +1405,7 @@ void fused_attn_ck_bwd_qkvpacked(
   bool pad_between_seqs = (is_ragged && !(input_cu_seqlens_padded->data.shape.empty())) || (!is_ragged && is_padding && !(input_cu_seqlens->data.shape.empty()));
   // extract the max_tokens for padding/unpadding and softmax_lse buffer
   // b from cu_seqlen and max_seqlen are not the actual storage batch and seqlen for pad_between_seqs case
-  size_t max_tokens = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), 1, std::multiplies<size_t>())/h/d/3;
+  size_t max_tokens = std::accumulate((input_QKV->data).shape.begin(), (input_QKV->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h/d/3;
 
   // in qkvpacked layouts, o is of the same max_tokens as q
   // dqkv has the same shape as qkv
@@ -1495,8 +1495,8 @@ void fused_attn_ck_fwd_kvpacked(
   void *devPtrSeqOffsetsQ = input_cu_seqlens_q_padded->data.dptr;
   void *devPtrSeqOffsetsKV = input_cu_seqlens_kv_padded->data.dptr;
 
-  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())/h_q/d;
-  size_t max_tokens_kv = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), 1, std::multiplies<size_t>())/h_kv/d/2;
+  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_q/d;
+  size_t max_tokens_kv = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_kv/d/2;
 
   bool is_ragged = nvte_get_qkv_format(qkv_layout)==NVTE_QKV_Format::NVTE_THD; 
 
@@ -1660,8 +1660,8 @@ void fused_attn_ck_bwd_kvpacked(
   
   // extract the max_tokens for padding/unpadding and softmax_lse buffer
   // b from cu_seqlen and max_seqlen are not the actual storage batch and seqlen for pad_between_seqs case
-  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())/h_q/d;
-  size_t max_tokens_kv = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), 1, std::multiplies<size_t>())/h_kv/d/2;
+  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_q/d;
+  size_t max_tokens_kv = std::accumulate((input_KV->data).shape.begin(), (input_KV->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_kv/d/2;
   
   fused_attn_ck_bwd_impl(
     b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d, d, bias_b, bias_h,
@@ -1739,8 +1739,8 @@ void fused_attn_ck_fwd(
   void *devPtrSeqOffsetsQ = input_cu_seqlens_q_padded->data.dptr;
   void *devPtrSeqOffsetsKV = input_cu_seqlens_kv_padded->data.dptr;
 
-  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())/h_q/d_qk;
-  size_t max_tokens_kv = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), 1, std::multiplies<size_t>())/h_kv/d_qk;
+  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_q/d_qk;
+  size_t max_tokens_kv = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_kv/d_qk;
 
   bool is_ragged = nvte_get_qkv_format(qkv_layout)==NVTE_QKV_Format::NVTE_THD; 
   if (Aux_CTX_Tensors->size == 0) {
@@ -1891,8 +1891,8 @@ void fused_attn_ck_bwd(
   
   // extract the max_tokens for padding/unpadding and softmax_lse buffer
   // b from cu_seqlen and max_seqlen are not the actual storage batch and seqlen for pad_between_seqs case
-  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), 1, std::multiplies<size_t>())/h_q/d_qk;
-  size_t max_tokens_kv = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), 1, std::multiplies<size_t>())/h_kv/d_qk;
+  size_t max_tokens_q = std::accumulate((input_Q->data).shape.begin(), (input_Q->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_q/d_qk;
+  size_t max_tokens_kv = std::accumulate((input_K->data).shape.begin(), (input_K->data).shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())/h_kv/d_qk;
 
   fused_attn_ck_bwd_impl(
     b, h_q, h_kv, max_seqlen_q, max_seqlen_kv, d_qk, d_v, bias_b, bias_h,


### PR DESCRIPTION
# Description

Adds static cast to `std::accumulate` arg to ensure correct templating to prevent integer overflow. Includes non-regression test.

Fixes https://github.com/ROCm/frameworks-internal/issues/13179?reload=1?reload=1

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
