### PR TITLE
Fix NCCL error in test_torch_fsdp2

### DIFF
--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -83,6 +83,7 @@ run_test_config_mgpu(){
         run 3 distributed/test_fusible_ops.py
         run 3 distributed/test_numerics.py
         run 3 fused_attn/test_fused_attn_with_cp.py
+        run 3 distributed/test_torch_fsdp2.py
     fi
 }
 

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -82,8 +82,8 @@ run_test_config_mgpu(){
         run 3 test_sanity_import.py
         run 3 distributed/test_fusible_ops.py
         run 3 distributed/test_numerics.py
-        run 3 fused_attn/test_fused_attn_with_cp.py
         run 3 distributed/test_torch_fsdp2.py
+        run 3 fused_attn/test_fused_attn_with_cp.py
     fi
 }
 

--- a/tests/pytorch/distributed/run_fsdp2_model.py
+++ b/tests/pytorch/distributed/run_fsdp2_model.py
@@ -171,11 +171,7 @@ def _train(args):
         if LOCAL_RANK == 0:
             print(f"Rank {LOCAL_RANK}: Iteration {iteration} completed.")
 
-    # Sync all ranks before clean up
-    if isinstance(mesh, torch.distributed.device_mesh.DeviceMesh):
-        for dim in range(mesh.ndim - 1, -1, -1):
-            dist.barrier(group=mesh.get_group(dim))
-
+    dist.barrier(device_ids=[torch.cuda.current_device()])
     dist.destroy_process_group()
     if LOCAL_RANK == 0:
         print(f"Rank {LOCAL_RANK}: Done...")

--- a/tests/pytorch/distributed/run_fsdp2_model.py
+++ b/tests/pytorch/distributed/run_fsdp2_model.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # This file was modified for portability to AMDGPU
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
@@ -172,6 +173,10 @@ def _train(args):
         if LOCAL_RANK == 0:
             print(f"Rank {LOCAL_RANK}: Iteration {iteration} completed.")
 
+    # NOTE: In PyTorch < 2.6 there’s a teardown race where one rank may call
+    # destroy_process_group() while other ranks still have in-flight NCCL ops,
+    # which can trigger a NCCL/RCCL comm error. Newer releases (>= 2.6) fixed
+    # this, but we kept a version-guarded barrier on older Torch for stability.
     if torch_version() < (2, 6, 0):
         dist.barrier(device_ids=[torch.cuda.current_device()])
     dist.destroy_process_group()

--- a/tests/pytorch/distributed/run_fsdp2_model.py
+++ b/tests/pytorch/distributed/run_fsdp2_model.py
@@ -171,6 +171,11 @@ def _train(args):
         if LOCAL_RANK == 0:
             print(f"Rank {LOCAL_RANK}: Iteration {iteration} completed.")
 
+    # Sync all ranks before clean up
+    if isinstance(mesh, torch.distributed.device_mesh.DeviceMesh):
+        for dim in range(mesh.ndim - 1, -1, -1):
+            dist.barrier(group=mesh.get_group(dim))
+
     dist.destroy_process_group()
     if LOCAL_RANK == 0:
         print(f"Rank {LOCAL_RANK}: Done...")

--- a/tests/pytorch/distributed/run_fsdp2_model.py
+++ b/tests/pytorch/distributed/run_fsdp2_model.py
@@ -1,8 +1,9 @@
-#!/usr/bin/python3
-
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
+
 
 import os
 import sys
@@ -19,7 +20,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.device_mesh import init_device_mesh
 from contextlib import nullcontext
-
+from transformer_engine.pytorch import torch_version
 
 class SimpleNet(nn.Module):
     def __init__(self, input_size, hidden_size, output_size):
@@ -171,7 +172,8 @@ def _train(args):
         if LOCAL_RANK == 0:
             print(f"Rank {LOCAL_RANK}: Iteration {iteration} completed.")
 
-    dist.barrier(device_ids=[torch.cuda.current_device()])
+    if torch_version() < (2, 6, 0):
+        dist.barrier(device_ids=[torch.cuda.current_device()])
     dist.destroy_process_group()
     if LOCAL_RANK == 0:
         print(f"Rank {LOCAL_RANK}: Done...")

--- a/tests/pytorch/distributed/test_torch_fsdp2.py
+++ b/tests/pytorch/distributed/test_torch_fsdp2.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.

--- a/tests/pytorch/distributed/test_torch_fsdp2.py
+++ b/tests/pytorch/distributed/test_torch_fsdp2.py
@@ -1,5 +1,3 @@
-# This file was modified for portability to AMDGPU
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.


### PR DESCRIPTION
# Description

Synchronize all ranks (and all DeviceMesh subgroups) before teardown to fix intermittent NCCL/RCCL async exceptions at exit.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add per-axis barriers: iterate mesh.ndim - 1 … 0 and call dist.barrier(group=mesh.get_group(dim)) to drain collectives on each DeviceMesh dimension.
- Ensure dist.destroy_process_group() is called by all ranks.

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
