### PR TITLE
Enable and fix crash with fused attn in test_kv_cache

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -197,6 +197,21 @@ def reset_global_fp8_state():
     FP8GlobalStateManager.reset()
 
 
+@pytest.fixture()
+def reset_attn_backend():
+    envs = ["NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN"]
+    flags = {}
+    for env in envs:
+        if env in os.environ:
+            flags[env] = os.environ[env]
+    yield
+    for env in envs:
+        if env in flags:
+            os.environ[env] = flags[env]
+        else:
+            os.environ.pop(env, None)
+
+
 class TorchScaledMaskedSoftmax(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -2292,10 +2307,18 @@ def test_transformer_layer_hidden_states_format(dtype, bs, model):
 @pytest.mark.parametrize("module", module_inference)
 @pytest.mark.parametrize("backend", backends_inference)
 @pytest.mark.parametrize("is_paged", [False, True])
+@pytest.mark.usefixtures("reset_attn_backend")
 def test_kv_cache_accuracy(dtype, bs, model_key, use_RoPE, input_format, module, backend, is_paged):
     if ((backend == "FlashAttention" and os.getenv("NVTE_FLASH_ATTN", "1") == "0") or
         (backend == "FusedAttention" and os.getenv("NVTE_FUSED_ATTN", "1") == "0")):
         pytest.skip(f"{backend} is disabled")
+
+    if backend == "FlashAttention" and not fa_utils.is_installed:
+        pytest.skip("FlashAttention is not installed")
+
+    if IS_HIP_EXTENSION:
+        if is_paged and backend == "FusedAttention":
+            pytest.skip("FusedAttention does not support KV cache with paging on ROCm")
 
     reset_rng_states()
 

--- a/transformer_engine/common/fused_attn_rocm/utils.cpp
+++ b/transformer_engine/common/fused_attn_rocm/utils.cpp
@@ -200,6 +200,24 @@ void generateMatrixStrides(
                     stride[hidden_dim_idx] = 1;
             }
             break;
+        case NVTE_QKV_Layout::NVTE_SBHD_BSHD_BSHD:
+            if ((matrix == NVTE_QKV_Matrix::NVTE_Q_Matrix)
+                || (matrix == NVTE_QKV_Matrix::NVTE_O_Matrix)) {
+                    stride[batch_dim_idx] = h * d;
+                    stride[head_dim_idx] = d;
+                    stride[seqlen_dim_idx] = b * h * d;
+                    stride[hidden_dim_idx] = 1;
+            } else if ((matrix == NVTE_QKV_Matrix::NVTE_K_Matrix)
+                || (matrix == NVTE_QKV_Matrix::NVTE_V_Matrix)) {
+                    stride[batch_dim_idx] = s_kv * h * d;
+                    stride[head_dim_idx] = d;
+                    stride[seqlen_dim_idx] = h * d;
+                    stride[hidden_dim_idx] = 1;
+            }
+            break;
+        default:
+            NVTE_ERROR("Unsupported layout: ", static_cast<int>(layout));
+            break;
     }
 }
 


### PR DESCRIPTION
# Description

Fix running pytorch test_numeric::test_kv_cache with fused attn backend

Fixes [#13372](https://github.com/ROCm/frameworks-internal/issues/13372)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Properly reset env variables in test_kv_cache, controlling attention backend
- Fix crash in test_kv_cache with fused attn
- Gracefully skip unsupported test_kv_cache fused attn configs
- Skip flash attn run if FA is not installed

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
