### PR TITLE
[ROCm] enable the jax side fused-attn pytests with sequence packing +swa

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1073,10 +1073,6 @@ class TestFusedAttn:
             window_size,
             seq_desc_format,
         )
-        if is_hip_extension():
-            is_padding = attn_mask_type in [AttnMaskType.PADDING_MASK, AttnMaskType.PADDING_CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK]
-            if swa and is_padding:
-                pytest.skip("Jax cannot get cu_seqlen correctly from mask with swa")
         runner.test_forward()
 
     @staticmethod
@@ -1128,8 +1124,4 @@ class TestFusedAttn:
             window_size,
             seq_desc_format,
         )
-        if is_hip_extension():
-            is_padding = attn_mask_type in [AttnMaskType.PADDING_MASK, AttnMaskType.PADDING_CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK]
-            if swa and is_padding:
-                pytest.skip("Jax cannot get cu_seqlen correctly from mask with swa")
         runner.test_backward()


### PR DESCRIPTION
# Description

After v2.2, now jax can calculate sequence packing + swa mask correctly. 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
