### PR TITLE
[Feat] Add transpose cache to LayerNorm kernel

### DIFF
--- a/tests/pytorch/triton_kernels/test_layernorm.py
+++ b/tests/pytorch/triton_kernels/test_layernorm.py
@@ -145,7 +145,7 @@ def test_layernorm_fwd_bwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma
         eps=epsilon, 
         ln_out=None,
         quantizer=quantizer_triton,
-        out_dtype=torch_dtype_to_te_dtype(out_dtype),
+        otype=torch_dtype_to_te_dtype(out_dtype),
         sm_margin=get_fwd_ln_sm_margin(),
         zero_centered_gamma=zero_centered_gamma, 
         )

--- a/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
+++ b/tests/pytorch/triton_kernels/test_layernorm_mxfp8.py
@@ -100,7 +100,7 @@ def test_layernorm_fwd_triton(in_dtype, out_dtype, M, N, zero_centered_gamma):
         eps=epsilon, 
         ln_out=None,
         quantizer=quantizer_triton,
-        out_dtype=torch_dtype_to_te_dtype(out_dtype),
+        otype=torch_dtype_to_te_dtype(out_dtype),
         sm_margin=get_fwd_ln_sm_margin(),
         zero_centered_gamma=zero_centered_gamma, 
         )

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -456,13 +456,13 @@ def _layernorm_bwd_dwdb_triton_v2(
     tl.store(FINAL_DW + cols, sum_dw.to(FINAL_DW.type.element_ty), mask=cols < N)
     tl.store(FINAL_DB + cols, sum_db.to(FINAL_DB.type.element_ty), mask=cols < N)
 
-def te_layernorm_fwd_triton(input: torch.Tensor, 
-                            weight: torch.Tensor, 
-                            bias: torch.Tensor,  
+def te_layernorm_fwd_triton(input: torch.Tensor,
+                            weight: torch.Tensor,
+                            bias: torch.Tensor,
                             eps: float,
-                            ln_out: torch.Tensor, 
-                            quantizer: Quantizer, 
-                            out_dtype: TE_DType,
+                            ln_out: torch.Tensor,
+                            quantizer: Quantizer,
+                            otype: tex.DType,
                             sm_margin: int,
                             zero_centered_gamma: bool):
     if sm_margin is not None and sm_margin > 0:
@@ -473,7 +473,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
     device = input.device
     M, N = input.shape
 
-    IS_MFP8 = isinstance(quantizer, MXFP8Quantizer)
+    IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     MAKE_TRANSPOSE = False
 
     # Create empty tensors for mu and rsigma
@@ -481,11 +481,11 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
     rsigma = torch.empty((M,), dtype=torch.float32, device=device)
 
     torch_out_dtype = (
-        out_dtype if isinstance(out_dtype, torch.dtype)
-        else te_dtype_to_torch_dtype(out_dtype)
+        otype if isinstance(otype, torch.dtype)
+        else te_dtype_to_torch_dtype(otype)
     )
     # Create ln_out
-    if quantizer is None or IS_MFP8:
+    if quantizer is None or IS_MXFP8:
         ln_out = torch.empty(M, N, dtype=torch_out_dtype, device=device)
     else:
         if ln_out is None:
@@ -567,7 +567,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         )
 
     # For MXFP8, we do regular layernorm and then quantize it separately
-    if IS_MFP8:
+    if IS_MXFP8:
         ln_out = te_quantize_triton(ln_out, quantizer)
     
     # Reduce and find amax if "not APPLY_ATOMIC" is True.

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -57,17 +57,21 @@ def _layernorm_fwd_triton(
     n_rows,
     n_cols,
     eps,
+    out_transpose_ptr,
+    out_transpose_stride,
     ZERO_CENTERED_GAMMA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     IS_FP8: tl.constexpr,
     APPLY_ATOMIC: tl.constexpr,
     PERSISTENT: tl.constexpr,
     FP8_MAX: tl.constexpr,
+    MAKE_TRANSPOSE: tl.constexpr
 ):
 
     # program id
     pid = tl.program_id(0)
     num_tiles = tl.num_programs(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
 
     if PERSISTENT:
         rows_per_tile = n_rows // num_tiles
@@ -84,60 +88,52 @@ def _layernorm_fwd_triton(
         scale = tl.load(scale_ptr)
         amax = 0.0
 
-    for row in range(start_row, start_row + rows_per_tile):
-        x_ptr_start = x_ptr + (row * x_row_stride)
-        y_ptr_start = y_ptr + (row * y_row_stride)
+    for row_idx in range(start_row, start_row + rows_per_tile):
+        x_ptr_start = x_ptr + (row_idx * x_row_stride)
+        y_ptr_start = y_ptr + (row_idx * y_row_stride)
 
-        loop_num = tl.cdiv(n_cols, BLOCK_SIZE) - 1
+        n_cols_blks = tl.cdiv(n_cols, BLOCK_SIZE) - 1
 
         # calculate mean
         _mean = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        for b in range(0, loop_num):
-            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            x_block = tl.load(x_ptr_start + col_offsets).to(
-                tl.float32
-            )  # Unmasked loads
+        for blk_idx in range(0, n_cols_blks):
+            cols = blk_idx * BLOCK_SIZE + col_offsets
+            x_block = tl.load(x_ptr_start + cols).to(tl.float32)  # Unmasked loads
             _mean += x_block
 
         # For last iteration, do masked load
-        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        x_block = tl.load(
-            x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
-        ).to(tl.float32)
+        cols = n_cols_blks * BLOCK_SIZE + col_offsets
+        x_block = tl.load(x_ptr_start + cols, mask=cols < n_cols, other=0.0).to(tl.float32)
         _mean += x_block
         mean = tl.sum(_mean, axis=0) / n_cols
 
         # variance
         _var = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        for b in range(0, loop_num):
-            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            x_block = tl.load(x_ptr_start + col_offsets).to(
-                tl.float32
-            )  # Unmasked loads
+        for blk_idx in range(0, n_cols_blks):
+            cols = blk_idx * BLOCK_SIZE + col_offsets
+            x_block = tl.load(x_ptr_start + cols).to(tl.float32)  # Unmasked loads
             x_block = x_block - mean
             _var += x_block * x_block
 
         # For last iteration, do masked load
-        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        x_block = tl.load(
-            x_ptr_start + col_offsets, mask=col_offsets < n_cols, other=0.0
-        ).to(tl.float32)
-        x_block = tl.where(col_offsets < n_cols, x_block - mean, 0.0)
+        cols = n_cols_blks * BLOCK_SIZE + col_offsets
+        x_block = tl.load(x_ptr_start + cols, mask=cols < n_cols, other=0.0).to(tl.float32)
+        x_block = tl.where(cols < n_cols, x_block - mean, 0.0)
         _var += x_block * x_block
 
         var = tl.sum(_var, axis=0) / n_cols
         rstd = tl.rsqrt(var + eps)
 
         # Write mean / rstd
-        tl.store(mean_ptr + row, mean)
-        tl.store(rstd_ptr + row, rstd)
+        tl.store(mean_ptr + row_idx, mean)
+        tl.store(rstd_ptr + row_idx, rstd)
 
         # Normalize and store
-        for b in range(0, loop_num):
-            col_offsets = b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            w_block = tl.load(w_ptr + col_offsets).to(tl.float32)
-            b_block = tl.load(b_ptr + col_offsets).to(tl.float32)
-            x_block = tl.load(x_ptr_start + col_offsets).to(tl.float32)
+        for blk_idx in range(0, n_cols_blks):
+            cols = blk_idx * BLOCK_SIZE + col_offsets
+            w_block = tl.load(w_ptr + cols).to(tl.float32)
+            b_block = tl.load(b_ptr + cols).to(tl.float32)
+            x_block = tl.load(x_ptr_start + cols).to(tl.float32)
             if ZERO_CENTERED_GAMMA:
                 w_block += 1
             y_block = (x_block - mean) * rstd
@@ -147,16 +143,17 @@ def _layernorm_fwd_triton(
                 amax = amax_temp if amax_temp > amax else amax
                 y_block = y_block * scale
                 y_block = tl.clamp(y_block, -FP8_MAX, FP8_MAX)
-            tl.store(y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty))
+            tl.store(y_ptr_start + cols, y_block.to(y_ptr.type.element_ty))
+            if MAKE_TRANSPOSE:
+                output_t_ptrs = out_transpose_ptr + cols * out_transpose_stride + row_idx
+                tl.store(output_t_ptrs, y_block.to(y_ptr.type.element_ty))
 
         # For last iteration, do masked load and store
-        col_offsets = loop_num * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-        mask = col_offsets < n_cols
-        w_block = tl.load(w_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-        b_block = tl.load(b_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-        x_block = tl.load(x_ptr_start + col_offsets, mask=mask, other=0.0).to(
-            tl.float32
-        )
+        cols = n_cols_blks * BLOCK_SIZE + col_offsets
+        mask = cols < n_cols
+        w_block = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        b_block = tl.load(b_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        x_block = tl.load(x_ptr_start + cols, mask=mask, other=0.0).to(tl.float32)
         if ZERO_CENTERED_GAMMA:
             w_block += 1
         y_block = (x_block - mean) * rstd
@@ -166,9 +163,10 @@ def _layernorm_fwd_triton(
             amax = amax_temp if amax_temp > amax else amax
             y_block = y_block * scale
             y_block = tl.clamp(y_block, -FP8_MAX, FP8_MAX)
-        tl.store(
-            y_ptr_start + col_offsets, y_block.to(y_ptr.type.element_ty), mask=mask
-        )
+        tl.store(y_ptr_start + cols, y_block.to(y_ptr.type.element_ty), mask=mask)
+        if MAKE_TRANSPOSE:
+            output_t_ptrs = out_transpose_ptr + cols * out_transpose_stride + row_idx
+            tl.store(output_t_ptrs, y_block.to(y_ptr.type.element_ty), mask=mask)
 
     if IS_FP8:
         if APPLY_ATOMIC:
@@ -474,13 +472,20 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         )
     device = input.device
     M, N = input.shape
-    
+
+    IS_MFP8 = isinstance(quantizer, MXFP8Quantizer)
+    MAKE_TRANSPOSE = False
+
     # Create empty tensors for mu and rsigma
     mu = torch.empty((M,), dtype=torch.float32, device=device)
     rsigma = torch.empty((M,), dtype=torch.float32, device=device)
-    torch_out_dtype = te_dtype_to_torch_dtype(out_dtype)
+
+    torch_out_dtype = (
+        out_dtype if isinstance(out_dtype, torch.dtype)
+        else te_dtype_to_torch_dtype(out_dtype)
+    )
     # Create ln_out
-    if quantizer is None or isinstance(quantizer, MXFP8Quantizer):
+    if quantizer is None or IS_MFP8:
         ln_out = torch.empty(M, N, dtype=torch_out_dtype, device=device)
     else:
         if ln_out is None:
@@ -495,7 +500,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
     # MXFP8 is handled regularly, hence quantizer of Float8Quantizer is considered FP8
     IS_FP8 = isinstance(quantizer, Float8Quantizer)
 
-    amax_temp = torch.empty((M,), dtype=torch.float32, device=input.device) if IS_FP8 else None
+    amax_temp = torch.empty((M,), dtype=torch.float32, device=device) if IS_FP8 else None
 
     max_fused_size = 16384 // input.element_size()
     BLOCK_SIZE = min(max_fused_size, triton.next_power_of_2(N))
@@ -506,11 +511,24 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         amax_out = quantizer.amax
         scale_inv = ln_out._scale_inv
         cast_out = ln_out._data
+        MAKE_TRANSPOSE = quantizer.columnwise_usage
+        tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
+        if MAKE_TRANSPOSE:
+            if ln_out._transpose_invalid:
+                ln_out._transpose = torch.empty((ln_out._data.shape[1], ln_out._data.shape[0]), dtype=ln_out._data.dtype, device=device)
+                ln_out._transpose_invalid = False
+            out_transpose_ptr = triton.reinterpret(ln_out._transpose, tl_dtype)
+            out_transpose_stride = ln_out._transpose.stride(0)
+        else:
+            out_transpose_ptr = None
+            out_transpose_stride = None
     else:
         scale = None
         amax_out = None
         scale_inv = None
         cast_out = ln_out
+        out_transpose_ptr = None
+        out_transpose_stride = None
     
     _layernorm_fwd_triton[(M,)](
         input,
@@ -527,6 +545,8 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         M,
         N,
         eps,
+        out_transpose_ptr,
+        out_transpose_stride,
         ZERO_CENTERED_GAMMA=zero_centered_gamma,
         BLOCK_SIZE=BLOCK_SIZE,
         IS_FP8=IS_FP8,
@@ -536,6 +556,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         # It also lags behind TE implementation in a few cases
         PERSISTENT=False,
         FP8_MAX=get_fp8_max(quantizer.dtype) if IS_FP8 else None,
+        MAKE_TRANSPOSE=MAKE_TRANSPOSE
     )
 
     # Compute FP8 transpose if required
@@ -546,7 +567,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         )
 
     # For MXFP8, we do regular layernorm and then quantize it separately
-    if isinstance(quantizer, MXFP8Quantizer):
+    if IS_MFP8:
         ln_out = te_quantize_triton(ln_out, quantizer)
     
     # Reduce and find amax if "not APPLY_ATOMIC" is True.

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -68,6 +68,9 @@ def _layernorm_fwd_triton(
     MAKE_TRANSPOSE: tl.constexpr
 ):
 
+    # Enable the transpose cache only in FP8 mode.
+    tl.static_assert(not MAKE_TRANSPOSE or IS_FP8, msg="Transpose cache requires fp8 data type.")
+
     # program id
     pid = tl.program_id(0)
     num_tiles = tl.num_programs(0)
@@ -143,10 +146,11 @@ def _layernorm_fwd_triton(
                 amax = amax_temp if amax_temp > amax else amax
                 y_block = y_block * scale
                 y_block = tl.clamp(y_block, -FP8_MAX, FP8_MAX)
-            tl.store(y_ptr_start + cols, y_block.to(y_ptr.type.element_ty))
+            y_block = y_block.to(y_ptr.type.element_ty)
+            tl.store(y_ptr_start + cols, y_block)
             if MAKE_TRANSPOSE:
                 output_t_ptrs = out_transpose_ptr + cols * out_transpose_stride + row_idx
-                tl.store(output_t_ptrs, y_block.to(y_ptr.type.element_ty))
+                tl.store(output_t_ptrs, y_block)
 
         # For last iteration, do masked load and store
         cols = n_cols_blks * BLOCK_SIZE + col_offsets
@@ -163,10 +167,11 @@ def _layernorm_fwd_triton(
             amax = amax_temp if amax_temp > amax else amax
             y_block = y_block * scale
             y_block = tl.clamp(y_block, -FP8_MAX, FP8_MAX)
-        tl.store(y_ptr_start + cols, y_block.to(y_ptr.type.element_ty), mask=mask)
+        y_block = y_block.to(y_ptr.type.element_ty)
+        tl.store(y_ptr_start + cols, y_block, mask=mask)
         if MAKE_TRANSPOSE:
             output_t_ptrs = out_transpose_ptr + cols * out_transpose_stride + row_idx
-            tl.store(output_t_ptrs, y_block.to(y_ptr.type.element_ty), mask=mask)
+            tl.store(output_t_ptrs, y_block, mask=mask)
 
     if IS_FP8:
         if APPLY_ATOMIC:
@@ -504,7 +509,10 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
 
     max_fused_size = 16384 // input.element_size()
     BLOCK_SIZE = min(max_fused_size, triton.next_power_of_2(N))
-    
+
+    out_transpose_ptr = None
+    out_transpose_stride = None
+
     # Create necessary values for fp8 if needed
     if IS_FP8:
         scale = quantizer.scale
@@ -512,23 +520,18 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         scale_inv = ln_out._scale_inv
         cast_out = ln_out._data
         MAKE_TRANSPOSE = quantizer.columnwise_usage
-        tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
         if MAKE_TRANSPOSE:
+            tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
             if ln_out._transpose_invalid:
                 ln_out._transpose = torch.empty((ln_out._data.shape[1], ln_out._data.shape[0]), dtype=ln_out._data.dtype, device=device)
                 ln_out._transpose_invalid = False
             out_transpose_ptr = triton.reinterpret(ln_out._transpose, tl_dtype)
             out_transpose_stride = ln_out._transpose.stride(0)
-        else:
-            out_transpose_ptr = None
-            out_transpose_stride = None
     else:
         scale = None
         amax_out = None
         scale_inv = None
         cast_out = ln_out
-        out_transpose_ptr = None
-        out_transpose_stride = None
     
     _layernorm_fwd_triton[(M,)](
         input,

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -48,6 +48,10 @@ def _rmsnorm_fwd_triton(
     FP8_MAX: tl.constexpr,
     MAKE_TRANSPOSE: tl.constexpr,
 ):
+
+    # Enable the transpose cache only in FP8 mode.
+    tl.static_assert(not MAKE_TRANSPOSE or IS_FP8, msg="Transpose cache requires fp8 data type.")
+
     row_start = tl.program_id(0)
     col_offsets = tl.arange(0, BLOCK_SIZE)
     # as older version Triton doesn't support tl.assume and BUFF OPS, comment out for now

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -13,6 +13,8 @@ from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_triton_dtype,
 )
 from .common import get_fp8_max
+from ..constants import TE_DType
+from ..tensor.quantized_tensor import Quantizer
 
 def dg_tmp_rows(x, sm_margin=None):
     return x.shape[0] if use_blocked(x) else num_programs(x, sm_margin)
@@ -357,14 +359,14 @@ def te_rmsnorm_bwd_triton(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma):
 
 # triton drop-in replacement for transformer_engine::pytorch::rmsnorm_fwd
 def te_rmsnorm_fwd_triton(
-    input,
-    weight,
-    eps,
-    ln_out,
-    quantizer,
-    otype,
-    sm_margin,
-    zero_centered_gamma
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    ln_out: torch.Tensor,
+    quantizer: Quantizer,
+    out_dtype: TE_DType,
+    sm_margin: int,
+    zero_centered_gamma: bool
 ):
     if eps < 0:
         raise ValueError(f"`eps` must be non-negative, but a value of {eps} was passed")
@@ -372,6 +374,7 @@ def te_rmsnorm_fwd_triton(
         raise ValueError(
             f"The input must be a 2-dimensional matrix, but an input with {input.ndim} was passed.")
 
+    device = input.device
     N, H = input.shape
     if weight.shape[0] != H:
         raise ValueError(
@@ -385,10 +388,10 @@ def te_rmsnorm_fwd_triton(
     NUM_PRGMS = num_programs(input, sm_margin)
     MAKE_TRANSPOSE = False
 
-    rsigma = torch.empty((N,), dtype=torch.float32, device="cuda")
-    pt_otype = (
-        otype if isinstance(otype, torch.dtype)
-        else te_dtype_to_torch_dtype(otype)
+    rsigma = torch.empty((N,), dtype=torch.float32, device=device)
+    torch_out_dtype = (
+        out_dtype if isinstance(out_dtype, torch.dtype)
+        else te_dtype_to_torch_dtype(out_dtype)
     )
     if IS_FP8:
         MAKE_TRANSPOSE = quantizer.columnwise_usage
@@ -397,13 +400,13 @@ def te_rmsnorm_fwd_triton(
                 ln_out if isinstance(ln_out, Float8Tensor) else
                 quantizer.create_tensor_from_data(
                     ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)),
-                    fake_dtype=pt_otype
+                    fake_dtype=torch_out_dtype
                 )
             )
         else:
-            out = quantizer.make_empty(input.shape, dtype=pt_otype)
+            out = quantizer.make_empty(input.shape, dtype=torch_out_dtype)
 
-        amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device="cuda")
+        amax = torch.empty((NUM_PRGMS,), dtype=torch.float32, device=device)
         tl_dtype = te_dtype_to_triton_dtype(quantizer.dtype)
         scale_inv_ptr = out._scale_inv
         q_scale = quantizer.scale
@@ -412,7 +415,7 @@ def te_rmsnorm_fwd_triton(
         FP8_MAX = get_fp8_max(quantizer.dtype)
         if MAKE_TRANSPOSE:
             if out._transpose_invalid:
-                out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype)
+                out._transpose = torch.empty((out._data.shape[1], out._data.shape[0]), dtype=out._data.dtype, device=device)
                 out._transpose_invalid = False
             out_transpose_ptr = triton.reinterpret(out._transpose, tl_dtype)
             out_transpose_stride = out._transpose.stride(0)
@@ -421,7 +424,7 @@ def te_rmsnorm_fwd_triton(
             out_transpose_stride = None
 
     else:
-        out = torch.empty_like(input, dtype=pt_otype) if ln_out is None else ln_out
+        out = torch.empty_like(input, dtype=torch_out_dtype) if ln_out is None else ln_out
         amax = None
         tl_dtype = None
         scale_inv_ptr = None

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -13,8 +13,8 @@ from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_triton_dtype,
 )
 from .common import get_fp8_max
-from ..constants import TE_DType
 from ..tensor.quantized_tensor import Quantizer
+import transformer_engine_torch as tex
 
 def dg_tmp_rows(x, sm_margin=None):
     return x.shape[0] if use_blocked(x) else num_programs(x, sm_margin)
@@ -364,7 +364,7 @@ def te_rmsnorm_fwd_triton(
     eps: float,
     ln_out: torch.Tensor,
     quantizer: Quantizer,
-    out_dtype: TE_DType,
+    otype: tex.DType,
     sm_margin: int,
     zero_centered_gamma: bool
 ):
@@ -382,7 +382,7 @@ def te_rmsnorm_fwd_triton(
             f"but {weight.shape[0]=} while {input.shape[1]=}"
         )
     IS_FP8 = isinstance(quantizer, Float8Quantizer)
-    IS_MFP8 = isinstance(quantizer, MXFP8Quantizer)
+    IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)
     NUM_PRGMS = num_programs(input, sm_margin)
@@ -390,8 +390,8 @@ def te_rmsnorm_fwd_triton(
 
     rsigma = torch.empty((N,), dtype=torch.float32, device=device)
     torch_out_dtype = (
-        out_dtype if isinstance(out_dtype, torch.dtype)
-        else te_dtype_to_torch_dtype(out_dtype)
+        otype if isinstance(otype, torch.dtype)
+        else te_dtype_to_torch_dtype(otype)
     )
     if IS_FP8:
         MAKE_TRANSPOSE = quantizer.columnwise_usage
@@ -460,7 +460,7 @@ def te_rmsnorm_fwd_triton(
         FP8_MAX,
         MAKE_TRANSPOSE,
     )
-    if IS_MFP8:
+    if IS_MXFP8:
         out = quantizer.quantize(out)
 
     return out, None, rsigma


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes  https://github.com/ROCm/frameworks-internal/issues/13313

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [X] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added transpose cache for LayerNorm kernel FP8 implementation (following RMSNorm kernel implementation of transpose cache)
- Refactored variable names in both LayerNorm and RMSNorm to improve clarity and readability as well as unify variable names

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
