### PR TITLE
MNT Optimize Triton tests

### DIFF
--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -65,6 +65,8 @@ run_test_config(){
     run_default_fa 1 triton_kernels/test_cast.py
     run_default_fa 1 triton_kernels/test_cast_mxfp8.py
     run_default_fa 1 triton_kernels/test_norm_common.py
+    run_default_fa 1 triton_kernels/test_norms.py
+    NVTE_TEST_TRITON_AUTOTUNE=1 run_default_fa 3 triton_kernels/test_norms.py
     run_default_fa 1 test_parallel_cross_entropy.py
     NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 NVTE_USE_LAYERNORM_TRITON=1 run_default_fa 3 test_numerics.py
     NVTE_USE_RMSNORM_TRITON=1 run_default_fa 1 test_fusible_ops.py

--- a/tests/pytorch/triton_kernels/test_common.py
+++ b/tests/pytorch/triton_kernels/test_common.py
@@ -19,15 +19,6 @@ from transformer_engine.pytorch.triton_kernels.common import (
 rng_seed = 12345
 rng = np.random.default_rng(np.random.MT19937(rng_seed))
 
-# Add `i` prefix to identify input type.
-def input_dtypes_str(dtypes_str):
-    return ["i" + dtype_str for dtype_str in dtypes_str]
-
-
-# Add `o` prefix to identify output type.
-def output_dtypes_str(dtypes_str):
-    return ["o" + dtype_str for dtype_str in dtypes_str]
-
 
 def fill_uniform(shape, dtype):
     x = rng.uniform(-2.0, 1.0, shape)
@@ -178,6 +169,16 @@ def compare_results(provider, actual, expected, atol, rtol, msg):
 # Get size in bytes of a given PyTorch type.
 def sizeof(dtype):
     return torch.finfo(dtype).bits // 8
+
+
+# Add `i` prefix to identify input type.
+def input_dtypes_str(dtypes_str):
+    return ["i" + dtype_str for dtype_str in dtypes_str]
+
+
+# Add `o` prefix to identify output type.
+def output_dtypes_str(dtypes_str):
+    return ["o" + dtype_str for dtype_str in dtypes_str]
 
 
 # Convert descriptive type string to PyTorch type.

--- a/tests/pytorch/triton_kernels/test_common.py
+++ b/tests/pytorch/triton_kernels/test_common.py
@@ -89,12 +89,13 @@ def te_compare_results(t, r, atol, rtol, msg, use_torch_semantics=False):
     t = t.cpu().to(torch.float32).to(torch.float64)
     r = r.cpu().to(torch.float32).to(torch.float64)
     diff = t - r
+    adiff = torch.abs(diff)
+    nonzero_r = r != 0
+    rel_diff = torch.where(nonzero_r, torch.abs(diff / r), torch.zeros_like(diff))
     if use_torch_semantics:
-        mismatch = torch.abs(diff) > atol + rtol * torch.abs(r)
+        mismatch = adiff > atol + rtol * torch.abs(r)
     else:
-        atol_mismatch = torch.abs(diff) > atol
-        nonzero_r = r != 0
-        rel_diff = torch.where(nonzero_r, torch.abs(diff / r), torch.zeros_like(diff))
+        atol_mismatch = adiff > atol
         rtol_mismatch = torch.where(nonzero_r, rel_diff > rtol, torch.full_like(atol_mismatch, False))
         mismatch = atol_mismatch & (~nonzero_r | rtol_mismatch)
     has_mismatch = torch.any(mismatch).item()
@@ -128,7 +129,7 @@ def te_compare_results(t, r, atol, rtol, msg, use_torch_semantics=False):
         has_mismatch = torch.any(mismatch).item()
 
     if has_mismatch:
-        abs_diff = torch.where(mismatch, torch.abs(diff), 0)
+        abs_diff = torch.where(mismatch, adiff, 0)
         rel_diff = torch.where(mismatch, rel_diff, 0)
         max_abs_diff = torch.max(abs_diff).item()
         max_rel_diff = torch.max(rel_diff).item()

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -24,7 +24,7 @@ from transformer_engine.pytorch.triton_kernels.layernorm import (
     te_layernorm_bwd_triton,
     te_layernorm_fwd_triton,
 )
-from .test_common import dtype_tols, compare_results, str_to_torch_dtype, fill_uniform
+from test_common import dtype_tols, compare_results, str_to_torch_dtype, fill_uniform
 
 # Check if FP8 is supported
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -95,7 +95,7 @@ test_quantizations += tuple(
 _triton_funcs = {
     "fwd": {
         "rms":partial(te_rmsnorm_fwd_triton, autotune=False),
-        "layer":te_layernorm_fwd_triton,
+        "layer":partial(te_layernorm_fwd_triton, autotune=False),
     },
     "bwd": {
         "rms":te_rmsnorm_bwd_triton,

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -94,7 +94,7 @@ test_quantizations += tuple(
 
 _triton_funcs = {
     "fwd": {
-        "rms":te_rmsnorm_fwd_triton,
+        "rms":partial(te_rmsnorm_fwd_triton, autotune=False),
         "layer":te_layernorm_fwd_triton,
     },
     "bwd": {

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -174,7 +174,7 @@ def rmsnorm_fwd_ref(
 
 @pytest.fixture
 def autotune():
-    return bool(int(os.environ.get("TE_TEST_TRITON_AUTOTUNE", "0")))
+    return bool(int(os.environ.get("NVTE_TEST_TRITON_AUTOTUNE", "0")))
 
 class TestNorms:
 

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -585,8 +585,7 @@ class TestNorms:
         dbeta_triton, dbeta_hip,
         norm
     ):
-        tols = dtype_tols(dx_triton.dtype)
-        _compare_func = partial(compare_results, provider="te", **tols, use_torch_semantics=True)
+        _compare_func = partial(compare_results, provider="te", atol=1.5e-4, rtol=1e-4, use_torch_semantics=True)
 
         _compare_func(
             actual=dx_triton,

--- a/tests/pytorch/triton_kernels/test_norms.py
+++ b/tests/pytorch/triton_kernels/test_norms.py
@@ -2,6 +2,7 @@
 # License for AMD contributions = MIT. See LICENSE for more information
 
 
+import os
 import torch
 import pytest
 from functools import partial
@@ -94,8 +95,8 @@ test_quantizations += tuple(
 
 _triton_funcs = {
     "fwd": {
-        "rms":partial(te_rmsnorm_fwd_triton, autotune=False),
-        "layer":partial(te_layernorm_fwd_triton, autotune=False),
+        "rms":te_rmsnorm_fwd_triton,
+        "layer":te_layernorm_fwd_triton,
     },
     "bwd": {
         "rms":te_rmsnorm_bwd_triton,
@@ -170,6 +171,11 @@ def rmsnorm_fwd_ref(
     out = quantizer.quantize(x_normed, out=out)
     return out, None, rsigma.squeeze(1)
 
+
+@pytest.fixture
+def autotune():
+    return bool(int(os.environ.get("TE_TEST_TRITON_AUTOTUNE", "0")))
+
 class TestNorms:
 
     @pytest.mark.parametrize(
@@ -198,6 +204,7 @@ class TestNorms:
         columnwise,
         ln_out_mode,
         norm,
+        autotune,
     ):
         # We only support 8E4M3 for forward kernels
         fp8_dtype = tex.DType.kFloat8E4M3
@@ -245,7 +252,7 @@ class TestNorms:
                 hip_fwd_func = rmsnorm_fwd_ref
 
         # run the triton path
-        ln_out_triton, mu_triton, rsigma_triton = triton_fwd_func(**fwd_args["triton"])
+        ln_out_triton, mu_triton, rsigma_triton = triton_fwd_func(autotune=autotune, **fwd_args["triton"])
 
         # run the reference hipified kernel path
         ln_out_hip, mu_hip, rsigma_hip = hip_fwd_func(**fwd_args["hip"])
@@ -319,7 +326,7 @@ class TestNorms:
 
     @pytest.mark.parametrize("norm", norms)
     @pytest.mark.parametrize("columnwise", [False, True])
-    def test_norm_fwd_triton_clamp(self, columnwise, norm):
+    def test_norm_fwd_triton_clamp(self, columnwise, norm, autotune):
         """
         Non-regression test for MLPerf divergence issue. We test to ensure that in
         the case of output values beyond the range of the used FP8 dtype, we clamp
@@ -366,7 +373,7 @@ class TestNorms:
         triton_fwd_func = _triton_funcs["fwd"][norm]
         hip_fwd_func = _hip_funcs["fwd"][norm]
 
-        ln_out_triton, mu_triton, rsigma_triton = triton_fwd_func(**fwd_args["triton"])
+        ln_out_triton, mu_triton, rsigma_triton = triton_fwd_func(autotune=autotune, **fwd_args["triton"])
         ln_out_hip, mu_hip, rsigma_hip = hip_fwd_func(**fwd_args["hip"])
 
         if ln_out_triton.dtype != out_dtype:

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -34,11 +34,8 @@ def get_autotune_config(full_tuning_space=False):
     ]
 
 
-@triton.autotune(
-    configs=get_autotune_config(), key=["n_rows", "n_cols"], use_cuda_graph=True
-)
 @triton.jit
-def _layernorm_fwd_triton(
+def _layernorm_fwd_triton_impl(
     x_ptr,
     y_ptr,
     w_ptr,
@@ -175,6 +172,8 @@ def _layernorm_fwd_triton(
         else:
             tl.store(amax_ptr + pid, amax)
 
+autotune_dec = triton.autotune(configs=get_autotune_config(), key=["n_rows", "n_cols"], use_cuda_graph=True)
+_layernorm_fwd_triton = autotune_dec(_layernorm_fwd_triton_impl)
 
 @triton.jit
 def _layernorm_fwd_reduce_triton(
@@ -462,7 +461,8 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
                             quantizer: Quantizer, 
                             otype: tex.DType,
                             sm_margin: int,
-                            zero_centered_gamma: bool):
+                            zero_centered_gamma: bool,
+                            autotune: bool,):
     if sm_margin is not None and sm_margin > 0:
         warnings.warn(
             '"sm_margin" is not supported in the Triton based forward layer-norm kernel. '
@@ -500,7 +500,8 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         scale_inv = None
         cast_out = ln_out
     
-    _layernorm_fwd_triton[(M,)](
+    kernel = _layernorm_fwd_triton if autotune else _layernorm_fwd_triton_impl
+    kernel[(M,)](
         input,
         triton.reinterpret(cast_out, te_dtype_to_triton_dtype(ln_out._fp8_dtype)) if IS_FP8 else cast_out,
         weight,

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -462,7 +462,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
                             otype: tex.DType,
                             sm_margin: int,
                             zero_centered_gamma: bool,
-                            autotune: bool,):
+                            autotune: bool = True,):
     if sm_margin is not None and sm_margin > 0:
         warnings.warn(
             '"sm_margin" is not supported in the Triton based forward layer-norm kernel. '

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -22,9 +22,8 @@ def get_autotune_config():
     return [triton.Config({'waves_per_eu': we}, num_warps=nw) for (we, nw) in product([0, 1, 2, 4], [4, 8, 16])]
 
 
-@triton.autotune(configs=get_autotune_config(), key=['n_rows', 'n_cols'], use_cuda_graph=True)
 @triton.jit
-def _rmsnorm_fwd_triton(
+def _rmsnorm_fwd_triton_impl(
     output_ptr,
     input_ptr,
     g_ptr, rsigma_ptr,
@@ -172,6 +171,9 @@ def _rmsnorm_fwd_triton(
             scale = tl.load(q_scale_ptr)
             scale_inv = tl.fdiv(1.0, scale)
             tl.store(scale_inv_ptr, scale_inv)
+
+autotune_dec = triton.autotune(configs=get_autotune_config(), key=['n_rows', 'n_cols'], use_cuda_graph=True)
+_rmsnorm_fwd_triton = autotune_dec(_rmsnorm_fwd_triton_impl)
 
 @triton.jit
 def _rmsnorm_bwd_triton(grad_output_ptr, input_ptr, g_ptr, rsigma_ptr, dx_ptr, dg_ptr, input_row_stride, output_row_stride,
@@ -364,7 +366,8 @@ def te_rmsnorm_fwd_triton(
     quantizer,
     otype,
     sm_margin,
-    zero_centered_gamma
+    zero_centered_gamma,
+    autotune = True,
 ):
     if eps < 0:
         raise ValueError(f"`eps` must be non-negative, but a value of {eps} was passed")
@@ -427,7 +430,8 @@ def te_rmsnorm_fwd_triton(
 
     grid_fwd = lambda meta: (NUM_PRGMS, )
     # TODO(micky774) Implement fused MXFP8 quantization within the kernel
-    _rmsnorm_fwd_triton[grid_fwd](
+    kernel = _rmsnorm_fwd_triton if autotune else _rmsnorm_fwd_triton_impl
+    kernel[grid_fwd](
         out_ptr,
         input,
         weight,


### PR DESCRIPTION
# Description

This PR disentangles the underlying JIT implementation of the kernels and an autotune-wrapped implementation, allowing users to toggle auto-tuning. Furthermore, it disables autotuning in the tests, cutting run time from **~24min** to **~2.5min**.

Note that this PR targets `zain/triton-tests` for ease of review. If that PR is merged before this one, then I will retarget `dev`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Creates auto-tune wrapped, and auto-tune free implementations of underlying normalization kernels.
- Adds backwards-compatible `autotune=True` variable to `te_{rms, layer}norm_fwd_triton` functions
- Dispatches to auto-tune free implementations for testing.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
