### PR TITLE
Fix failures with fused_attn tests

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2316,9 +2316,11 @@ def test_kv_cache_accuracy(dtype, bs, model_key, use_RoPE, input_format, module,
     if backend == "FlashAttention" and not fa_utils.is_installed:
         pytest.skip("FlashAttention is not installed")
 
-    if IS_HIP_EXTENSION:
-        if is_paged and backend == "FusedAttention":
+    if IS_HIP_EXTENSION and backend == "FusedAttention":
+        if is_paged:
             pytest.skip("FusedAttention does not support KV cache with paging on ROCm")
+        if os.getenv("NVTE_FUSED_ATTN_CK", "1") == "0":
+            pytest.skip("CK FusedAttention backend is disabled")
 
     reset_rng_states()
 

--- a/transformer_engine/common/fused_attn_rocm/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn.cpp
@@ -183,6 +183,7 @@ const std::unordered_map<NVTEDType, std::string> mNVTEDTypeStr = {
   {NVTEDType::kNVTEBFloat16, "BFloat16"},
   {NVTEDType::kNVTEFloat8E4M3, "Float8E4M3"},
   {NVTEDType::kNVTEFloat8E5M2, "Float8E5M2"},
+  {NVTEDType::kNVTEFloat8E8M0, "Float8E8M0"},
 };
 
 // for printing qkv_layout in log_fused_attn_config
@@ -202,6 +203,10 @@ const std::unordered_map<NVTE_QKV_Layout, std::string> mNVTEQKVLayoutStr = {
   {NVTE_QKV_Layout::NVTE_THD_T2HD, "THD_T2HD"},
   {NVTE_QKV_Layout::NVTE_THD_TH2D, "THD_TH2D"},
   {NVTE_QKV_Layout::NVTE_THD_THD_THD, "THD_THD_THD"},
+  {NVTE_QKV_Layout::NVTE_SBHD_BSHD_BSHD, "SBHD_BSHD_BSHD"},
+  {NVTE_QKV_Layout::NVTE_BSHD_SBHD_SBHD, "BSHD_SBHD_SBHD"},
+  {NVTE_QKV_Layout::NVTE_THD_BSHD_BSHD, "THD_BSHD_BSHD"},
+  {NVTE_QKV_Layout::NVTE_THD_SBHD_SBHD, "THD_SBHD_SBHD"},
 };
 
 // for printing bias_type in log_fused_attn_config

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_aotriton.cpp
@@ -77,13 +77,6 @@ bool is_aotriton_backend_supported(
     return false;
   }
 
-  const int device_id = cuda::current_device();
-  const std::string sm_arch_name_ = cuda::sm_arch_name(device_id);
-  //only MI250 or MI300X supported
-  if(!((sm_arch_name_.find("gfx942")!=std::string::npos) || (sm_arch_name_.find("gfx90a")!=std::string::npos))){
-    return false;
-  }
-  
   // Q and KV must have the same data type, in fp16 or bf16
   if((q_dtype!=kv_dtype) || !((q_dtype==NVTEDType::kNVTEFloat16) || (q_dtype == NVTEDType::kNVTEBFloat16))){
     return false;

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -71,18 +71,6 @@ bool is_ck_backend_supported(
     return false;
   }
 
-  const int device_id = cuda::current_device();
-  const int gpu_arch = cuda::sm_arch(device_id);
-  //only gfx94x and gfx95x supported
-  if(gpu_arch != 94 && gpu_arch != 95){
-    if(nvte_log_ck_config){
-      std::cout<<"Only gfx94x and gfx95x are supported"<<std::endl;
-    }
-    return false;
-  }
-
-  // joint filters
-
   // joint filter based on sliding window and attn_mask
   bool is_causal = (attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
                     attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK||


### PR DESCRIPTION
# Description

Fix failures when run fused_attn tests with modified env variables.
Remove redundant filtering in fused_attn code

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Skip test_kv_cache when CK is disabled
- Fix exception when run with NVTE_LOG_FUSED_ATTN_CONFIG
- Remove GPU family filtering from fused_attn code

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
