### PR TITLE
Added keep_fp8_weight_transpose_cache checks while updating transpose in fwd pass

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1115,7 +1115,9 @@ def _test_granular_accuracy(block, bs, dtype, config):
             outputs.append(p.grad)
     return outputs
 
-
+# During initialization/first forward, the weight has transpose even when keep_fp8_weight_transpose_cache = False
+# The backward call clears transpose if keep_fp8_weight_transpose_cache = False
+# in the next iteration of the forward pass will now have no transpose, hence the need for multiple iter check
 def _test_granular_accuracy_with_fp8(block, bs, dtype, config, num_iterations=1):
     all_outputs = []
     reset_rng_states()

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1115,9 +1115,9 @@ def _test_granular_accuracy(block, bs, dtype, config):
             outputs.append(p.grad)
     return outputs
 
-# During initialization/first forward, the weight has transpose even when keep_fp8_weight_transpose_cache = False
-# The backward call clears transpose if keep_fp8_weight_transpose_cache = False
-# in the next iteration of the forward pass will now have no transpose, hence the need for multiple iter check
+# During initialization/first forward, the weight has transpose even when keep_fp8_weight_transpose_cache = False.
+# The backward call clears transpose if keep_fp8_weight_transpose_cache = False.
+# The next iteration of the forward pass will now have no transpose, hence the need for multiple iter check
 def _test_granular_accuracy_with_fp8(block, bs, dtype, config, num_iterations=1):
     all_outputs = []
     reset_rng_states()

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1115,6 +1115,7 @@ def _test_granular_accuracy(block, bs, dtype, config):
             outputs.append(p.grad)
     return outputs
 
+
 def _test_granular_accuracy_with_fp8(block, bs, dtype, config):
     reset_rng_states()
 
@@ -1137,6 +1138,7 @@ def _test_granular_accuracy_with_fp8(block, bs, dtype, config):
         if p.requires_grad:
             outputs.append(p.grad)
     return outputs
+
 
 def _test_dpa_accuracy(block, bs, dtype, config):
     reset_rng_states()

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1116,29 +1116,33 @@ def _test_granular_accuracy(block, bs, dtype, config):
     return outputs
 
 
-def _test_granular_accuracy_with_fp8(block, bs, dtype, config):
+def _test_granular_accuracy_with_fp8(block, bs, dtype, config, num_iterations=1):
+    all_outputs = []
     reset_rng_states()
+    for _ in range(num_iterations):
 
-    inp_hidden_states = torch.randn(
-        (config.seq_len, bs, config.hidden_size),
-        dtype=dtype,
-        device="cuda",
-        requires_grad=True,
-    )
-    inp_hidden_states.retain_grad()
+        inp_hidden_states = torch.randn(
+            (config.seq_len, bs, config.hidden_size),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=True,
+        )
+        inp_hidden_states.retain_grad()
 
-    with fp8_autocast(enabled=True):
-        out = block(inp_hidden_states)
-        loss = out.sum()
-        loss.backward()
+        with fp8_autocast(enabled=True):
+            out = block(inp_hidden_states)
+            loss = out.sum()
+            loss.backward()
 
-    torch.cuda.synchronize()
-    outputs = [out, inp_hidden_states.grad]
-    for p in block.parameters():
-        if p.requires_grad:
-            outputs.append(p.grad)
-    return outputs
+        torch.cuda.synchronize()
+        outputs = [out, inp_hidden_states.grad]
+        for p in block.parameters():
+            if p.requires_grad:
+                outputs.append(p.grad)
+        
+        all_outputs.extend(outputs)
 
+    return all_outputs
 
 def _test_dpa_accuracy(block, bs, dtype, config):
     reset_rng_states()
@@ -1274,13 +1278,21 @@ def test_linear_accuracy(dtype, bs, model, return_bias, bias):
 @pytest.mark.parametrize("bs", batch_sizes)
 @pytest.mark.parametrize("model", ["small"])
 @pytest.mark.parametrize("fp8_model_params", all_boolean)
-def test_fp8_linear_without_transpose_cache_accuracy(dtype, bs, model, fp8_model_params):
+@pytest.mark.parametrize("module_str", ["linear", "layernorm_mlp", "layernorm_linear"])
+def test_fp8_linear_without_transpose_cache_accuracy(dtype, bs, model, fp8_model_params, module_str):
     reset_rng_states()
     FP8GlobalStateManager.reset()
 
+    if module_str == "linear":
+        module = Linear
+    elif module_str == "layernorm_mlp":
+        module = LayerNormMLP
+    elif module_str == "layernorm_linear":
+        module = LayerNormLinear
+
     config = model_configs[model]
     with fp8_model_init(enabled=fp8_model_params):    
-        linear = Linear(
+        layer = module(
             config.hidden_size,
             4 * config.hidden_size,
             bias=True,
@@ -1290,7 +1302,7 @@ def test_fp8_linear_without_transpose_cache_accuracy(dtype, bs, model, fp8_model
         ).eval()
 
         reset_rng_states()
-        ref_linear = Linear(
+        ref_layer = module(
             config.hidden_size,
             4 * config.hidden_size,
             bias=True,
@@ -1299,9 +1311,18 @@ def test_fp8_linear_without_transpose_cache_accuracy(dtype, bs, model, fp8_model
             keep_fp8_weight_transpose_cache=True # defaults to True
         ).eval()
 
-
-    outputs = _test_granular_accuracy_with_fp8(linear, bs, dtype, config)
-    ref_outputs = _test_granular_accuracy_with_fp8(ref_linear, bs, dtype, config)
+    # Share params
+    with torch.no_grad():
+        if module_str != "layernorm_mlp":
+            ref_layer.weight = Parameter(layer.weight.clone())
+            ref_layer.bias = Parameter(layer.bias.clone())
+        else:
+            ref_layer.fc1_weight = Parameter(layer.fc1_weight.clone())
+            ref_layer.fc1_bias = Parameter(layer.fc1_bias.clone())
+            ref_layer.fc2_weight = Parameter(layer.fc2_weight.clone())
+            ref_layer.fc2_bias = Parameter(layer.fc2_bias.clone())
+    outputs = _test_granular_accuracy_with_fp8(layer, bs, dtype, config, num_iterations=2)
+    ref_outputs = _test_granular_accuracy_with_fp8(ref_layer, bs, dtype, config, num_iterations=2)
 
     # Check output.
     for te_output_no_cache, te_output_cache in zip(outputs, ref_outputs):

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1115,36 +1115,28 @@ def _test_granular_accuracy(block, bs, dtype, config):
             outputs.append(p.grad)
     return outputs
 
-# During initialization/first forward, the weight has transpose even when keep_fp8_weight_transpose_cache = False.
-# The backward call clears transpose if keep_fp8_weight_transpose_cache = False.
-# The next iteration of the forward pass will now have no transpose, hence the need for multiple iter check
-def _test_granular_accuracy_with_fp8(block, bs, dtype, config, num_iterations=1):
-    all_outputs = []
+def _test_granular_accuracy_with_fp8(block, bs, dtype, config):
     reset_rng_states()
-    for _ in range(num_iterations):
 
-        inp_hidden_states = torch.randn(
-            (config.seq_len, bs, config.hidden_size),
-            dtype=dtype,
-            device="cuda",
-            requires_grad=True,
-        )
-        inp_hidden_states.retain_grad()
+    inp_hidden_states = torch.randn(
+        (config.seq_len, bs, config.hidden_size),
+        dtype=dtype,
+        device="cuda",
+        requires_grad=True,
+    )
+    inp_hidden_states.retain_grad()
 
-        with fp8_autocast(enabled=True):
-            out = block(inp_hidden_states)
-            loss = out.sum()
-            loss.backward()
+    with fp8_autocast(enabled=True):
+        out = block(inp_hidden_states)
+        loss = out.sum()
+        loss.backward()
 
-        torch.cuda.synchronize()
-        outputs = [out, inp_hidden_states.grad]
-        for p in block.parameters():
-            if p.requires_grad:
-                outputs.append(p.grad)
-        
-        all_outputs.extend(outputs)
-
-    return all_outputs
+    torch.cuda.synchronize()
+    outputs = [out, inp_hidden_states.grad]
+    for p in block.parameters():
+        if p.requires_grad:
+            outputs.append(p.grad)
+    return outputs
 
 def _test_dpa_accuracy(block, bs, dtype, config):
     reset_rng_states()
@@ -1313,18 +1305,8 @@ def test_fp8_linear_without_transpose_cache_accuracy(dtype, bs, model, fp8_model
             keep_fp8_weight_transpose_cache=True # defaults to True
         ).eval()
 
-    # Share params
-    with torch.no_grad():
-        if module_str != "layernorm_mlp":
-            ref_layer.weight = Parameter(layer.weight.clone())
-            ref_layer.bias = Parameter(layer.bias.clone())
-        else:
-            ref_layer.fc1_weight = Parameter(layer.fc1_weight.clone())
-            ref_layer.fc1_bias = Parameter(layer.fc1_bias.clone())
-            ref_layer.fc2_weight = Parameter(layer.fc2_weight.clone())
-            ref_layer.fc2_bias = Parameter(layer.fc2_bias.clone())
-    outputs = _test_granular_accuracy_with_fp8(layer, bs, dtype, config, num_iterations=2)
-    ref_outputs = _test_granular_accuracy_with_fp8(ref_layer, bs, dtype, config, num_iterations=2)
+    outputs = _test_granular_accuracy_with_fp8(layer, bs, dtype, config)
+    ref_outputs = _test_granular_accuracy_with_fp8(ref_layer, bs, dtype, config)
 
     # Check output.
     for te_output_no_cache, te_output_cache in zip(outputs, ref_outputs):

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -338,9 +338,9 @@ class _LayerNormLinear(torch.autograd.Function):
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
-        # Verify that the transpose cache state matches the configuration.
-        if IS_HIP_EXTENSION:
-            assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
+            # Verify that the transpose cache state matches the configuration.
+            if IS_HIP_EXTENSION:
+                assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
         
         out, *_, rs_out = general_gemm(
             weightmat,
@@ -1000,7 +1000,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
                 This reduces memory consumption, especially during checkpoint loading and runtime.
 
-                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
                 Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
                 `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
                 reduced efficiency of PyTorch's caching allocator.

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -70,7 +70,6 @@ from ..cpp_extensions import (
 if IS_HIP_EXTENSION:
     from ..triton_kernels.layernorm import te_layernorm_bwd_triton
     from ..triton_kernels.rmsnorm import te_rmsnorm_bwd_triton
-    from ..utils import assert_check_transpose_cache
 
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
@@ -338,10 +337,6 @@ class _LayerNormLinear(torch.autograd.Function):
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
-            # Verify that the transpose cache state matches the configuration.
-            if IS_HIP_EXTENSION:
-                assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
-        
         out, *_, rs_out = general_gemm(
             weightmat,
             ln_out_total,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -29,7 +29,6 @@ from .base import (
 )
 from ..fp8 import FP8GlobalStateManager
 from ..utils import (
-    assert_check_transpose_cache,
     assert_dim_for_fp8_exec,
     cast_if_needed,
     clear_tensor_data,
@@ -71,6 +70,7 @@ from ..cpp_extensions import (
 if IS_HIP_EXTENSION:
     from ..triton_kernels.layernorm import te_layernorm_bwd_triton
     from ..triton_kernels.rmsnorm import te_rmsnorm_bwd_triton
+    from ..utils import assert_check_transpose_cache
 
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
@@ -339,7 +339,8 @@ class _LayerNormLinear(torch.autograd.Function):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
         # Verify that the transpose cache state matches the configuration.
-        assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
+        if IS_HIP_EXTENSION:
+            assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
         
         out, *_, rs_out = general_gemm(
             weightmat,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -370,8 +370,8 @@ class _LayerNormLinear(torch.autograd.Function):
                     if isinstance(ln_out, MXFP8TensorBase) or not ctx.ln_out_needs_gather:
                         ln_out.update_usage(rowwise_usage=False)
 
-            # Weight with column-wise usage is needed for dgrad GEMM.
-            if inp.requires_grad:
+            # Weight with column-wise usage is needed for dgrad GEMM while keeping fp8 weight transpose cache.
+            if inp.requires_grad and keep_fp8_weight_transpose_cache:
                 if isinstance(weightmat, QuantizedTensor):
                     weightmat.update_usage(columnwise_usage=True)
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -29,6 +29,7 @@ from .base import (
 )
 from ..fp8 import FP8GlobalStateManager
 from ..utils import (
+    assert_check_transpose_cache,
     assert_dim_for_fp8_exec,
     cast_if_needed,
     clear_tensor_data,
@@ -337,6 +338,9 @@ class _LayerNormLinear(torch.autograd.Function):
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
+        # Verify that the transpose cache state matches the configuration.
+        assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
+        
         out, *_, rs_out = general_gemm(
             weightmat,
             ln_out_total,
@@ -987,10 +991,20 @@ class LayerNormLinear(TransformerEngineBaseModule):
                   it controls the type used to allocate the initial parameters. Useful when
                   the model is trained with lower precision and the original FP32 parameters
                   would not fit in GPU memory.
-    keep_fp8_weight_transpose_cache: bool, default = 'True'
-                                     if set to `False`, it will not cache fp8 weight buffer instead of 
-                                     recomputing fp8 weight transpose. Recommend set to `False` when
-                                     enable FSDP parallel.
+    keep_fp8_weight_transpose_cache: bool, default = True
+                Controls whether to cache the FP8 weight transpose buffer during training.
+
+                - If set to `True` (default), the FP8 weight transpose buffer is cached to avoid recomputation, 
+                which can improve performance but significantly increases memory usage.
+                - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
+                This reduces memory consumption, especially during checkpoint loading and runtime.
+
+                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
+                `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
+                reduced efficiency of PyTorch's caching allocator.
+
+                Use this setting to balance memory usage and performance based on your training configuration.
                                      
     """
 

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -36,7 +36,6 @@ from ..jit import (
     warmup_jit_bias_gelu_all_dtypes,
 )
 from ..utils import (
-    assert_check_transpose_cache,
     divide,
     get_default_init_method,
     init_method_constant,
@@ -78,6 +77,7 @@ from ..cpp_extensions import (
 if IS_HIP_EXTENSION:
     from ..triton_kernels.layernorm import te_layernorm_bwd_triton
     from ..triton_kernels.rmsnorm import te_rmsnorm_bwd_triton
+    from ..utils import assert_check_transpose_cache
 
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
@@ -393,7 +393,8 @@ class _LayerNormMLP(torch.autograd.Function):
                 gemm_gelu_fusion = False
 
         # Verify that the transpose cache state matches the configuration.
-        assert_check_transpose_cache(fc1_weight_final, keep_fp8_weight_transpose_cache)
+        if IS_HIP_EXTENSION:
+            assert_check_transpose_cache(fc1_weight_final, keep_fp8_weight_transpose_cache)
         fc1_outputs = general_gemm(
             fc1_weight_final,
             ln_out_total,
@@ -452,7 +453,8 @@ class _LayerNormMLP(torch.autograd.Function):
         # FC2 GEMM
 
         # Verify that the transpose cache state matches the configuration.
-        assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
+        if IS_HIP_EXTENSION:
+            assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
 
         _ = general_gemm(
             fc2_weight_final,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -461,8 +461,8 @@ class _LayerNormMLP(torch.autograd.Function):
             extra_output=rs_out,
         )
 
-        # Weight with column-wise usage is needed for dgrad GEMM.
-        if is_grad_enabled and inp.requires_grad:
+        # Weight with column-wise usage is needed for dgrad GEMM while keeping fp8 weight transpose cache.
+        if is_grad_enabled and inp.requires_grad and keep_fp8_weight_transpose_cache:
             if isinstance(fc1_weight_final, QuantizedTensor):
                 fc1_weight_final.update_usage(columnwise_usage=True)
             if isinstance(fc2_weight_final, QuantizedTensor):

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -393,8 +393,10 @@ class _LayerNormMLP(torch.autograd.Function):
                 gemm_gelu_fusion = False
 
         # Verify that the transpose cache state matches the configuration.
-        if IS_HIP_EXTENSION:
+        if IS_HIP_EXTENSION and fp8:
             assert_check_transpose_cache(fc1_weight_final, keep_fp8_weight_transpose_cache)
+            assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
+
         fc1_outputs = general_gemm(
             fc1_weight_final,
             ln_out_total,
@@ -451,10 +453,6 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_out = torch.empty(dim_size, dtype=activation_dtype, device=device)
 
         # FC2 GEMM
-
-        # Verify that the transpose cache state matches the configuration.
-        if IS_HIP_EXTENSION:
-            assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
 
         _ = general_gemm(
             fc2_weight_final,
@@ -1229,7 +1227,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
                 This reduces memory consumption, especially during checkpoint loading and runtime.
 
-                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
                 Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
                 `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
                 reduced efficiency of PyTorch's caching allocator.

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -77,7 +77,6 @@ from ..cpp_extensions import (
 if IS_HIP_EXTENSION:
     from ..triton_kernels.layernorm import te_layernorm_bwd_triton
     from ..triton_kernels.rmsnorm import te_rmsnorm_bwd_triton
-    from ..utils import assert_check_transpose_cache
 
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
@@ -391,11 +390,6 @@ class _LayerNormMLP(torch.autograd.Function):
                 gemm_gelu_fusion = True
             if gemm_gelu_fusion and bias_gelu_fusion:
                 gemm_gelu_fusion = False
-
-        # Verify that the transpose cache state matches the configuration.
-        if IS_HIP_EXTENSION and fp8:
-            assert_check_transpose_cache(fc1_weight_final, keep_fp8_weight_transpose_cache)
-            assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
 
         fc1_outputs = general_gemm(
             fc1_weight_final,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -447,7 +447,6 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_out = torch.empty(dim_size, dtype=activation_dtype, device=device)
 
         # FC2 GEMM
-
         _ = general_gemm(
             fc2_weight_final,
             act_out,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -36,6 +36,7 @@ from ..jit import (
     warmup_jit_bias_gelu_all_dtypes,
 )
 from ..utils import (
+    assert_check_transpose_cache,
     divide,
     get_default_init_method,
     init_method_constant,
@@ -391,6 +392,8 @@ class _LayerNormMLP(torch.autograd.Function):
             if gemm_gelu_fusion and bias_gelu_fusion:
                 gemm_gelu_fusion = False
 
+        # Verify that the transpose cache state matches the configuration.
+        assert_check_transpose_cache(fc1_weight_final, keep_fp8_weight_transpose_cache)
         fc1_outputs = general_gemm(
             fc1_weight_final,
             ln_out_total,
@@ -447,6 +450,10 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_out = torch.empty(dim_size, dtype=activation_dtype, device=device)
 
         # FC2 GEMM
+
+        # Verify that the transpose cache state matches the configuration.
+        assert_check_transpose_cache(fc2_weight_final, keep_fp8_weight_transpose_cache)
+
         _ = general_gemm(
             fc2_weight_final,
             act_out,
@@ -1212,10 +1219,20 @@ class LayerNormMLP(TransformerEngineBaseModule):
                      batch size per training step. Needed for JIT Warmup, a technique where jit
                      fused functions are warmed up before training to ensure same kernels are
                      used for forward propogation and activation recompute phase.
-    keep_fp8_weight_transpose_cache: bool, default = 'True'
-                                     if set to `False`, it will not cache fp8 weight buffer instead of 
-                                     recomputing fp8 weight transpose. Recommend set to `False` when
-                                     enable FSDP parallel.
+    keep_fp8_weight_transpose_cache: bool, default = True
+                Controls whether to cache the FP8 weight transpose buffer during training.
+
+                - If set to `True` (default), the FP8 weight transpose buffer is cached to avoid recomputation, 
+                which can improve performance but significantly increases memory usage.
+                - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
+                This reduces memory consumption, especially during checkpoint loading and runtime.
+
+                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
+                `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
+                reduced efficiency of PyTorch's caching allocator.
+
+                Use this setting to balance memory usage and performance based on your training configuration.
                                      
     """
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -278,8 +278,8 @@ class _Linear(torch.autograd.Function):
                         inputmat.update_usage(rowwise_usage=False)
                 saved_inputmat = inputmat
 
-            # Weight with column-wise usage is needed for dgrad GEMM.
-            if inp.requires_grad:
+            # Weight with column-wise usage is needed for dgrad GEMM while keeping fp8 weight transpose cache.
+            if inp.requires_grad and keep_fp8_weight_transpose_cache:
                 if isinstance(weightmat, QuantizedTensor):
                     weightmat.update_usage(columnwise_usage=True)
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1,5 +1,6 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
 # See LICENSE for license information.
 
 """Linear API"""
@@ -251,9 +252,9 @@ class _Linear(torch.autograd.Function):
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
-        # Verify that the transpose cache state matches the configuration.
-        if IS_HIP_EXTENSION:
-            assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
+            # Verify that the transpose cache state matches the configuration.
+            if IS_HIP_EXTENSION:
+                assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
 
         out, *_, rs_out = general_gemm(
             weightmat,
@@ -821,7 +822,7 @@ class Linear(TransformerEngineBaseModule):
                 - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
                 This reduces memory consumption, especially during checkpoint loading and runtime.
 
-                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
                 Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
                 `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
                 reduced efficiency of PyTorch's caching allocator.

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -23,6 +23,7 @@ from .base import (
 from ._common import noop_cat, _fix_gathered_fp8_transpose
 from ..fp8 import FP8GlobalStateManager
 from ..utils import (
+    assert_check_transpose_cache,
     cast_if_needed,
     clear_tensor_data,
     divide,
@@ -247,6 +248,9 @@ class _Linear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
+
+        # Verify that the transpose cache state matches the configuration.
+        assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
 
         out, *_, rs_out = general_gemm(
             weightmat,
@@ -806,10 +810,20 @@ class Linear(TransformerEngineBaseModule):
                   it controls the type used to allocate the initial parameters. Useful when
                   the model is trained with lower precision and the original FP32 parameters
                   would not fit in GPU memory.
-    keep_fp8_weight_transpose_cache: bool, default = 'True'
-                                     if set to `False`, it will not cache fp8 weight buffer instead of 
-                                     recomputing fp8 weight transpose. Recommend set to `False` when
-                                     enable FSDP parallel.
+    keep_fp8_weight_transpose_cache: bool, default = True
+                Controls whether to cache the FP8 weight transpose buffer during training.
+
+                - If set to `True` (default), the FP8 weight transpose buffer is cached to avoid recomputation, 
+                which can improve performance but significantly increases memory usage.
+                - If set to `False`, the buffer is not cached and the FP8 weight transpose is recomputed as needed. 
+                This reduces memory consumption, especially during checkpoint loading and runtime.
+
+                ⚠️ **Recommendation**: Set this to `False` when using Fully Sharded Data Parallel (FSDP) training. 
+                Caching FP8 weight transposes can double memory usage for modules such as `Linear`, 
+                `LayerNormLinear`, and `LayerNormMLP`, which may lead to excessive memory pressure and 
+                reduced efficiency of PyTorch's caching allocator.
+
+                Use this setting to balance memory usage and performance based on your training configuration.
 
     """
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1,6 +1,7 @@
 # This file was modified for portability to AMDGPU
 # Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
 # See LICENSE for license information.
 
 """Linear API"""
@@ -9,7 +10,6 @@ from functools import reduce
 from operator import mul as multiply_op
 
 import torch
-from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import transformer_engine_torch as tex
 
@@ -63,8 +63,6 @@ from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
 from ..cpu_offload import is_cpu_offload_enabled, set_offloading_param
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
-if IS_HIP_EXTENSION:
-    from ..utils import assert_check_transpose_cache
 
 __all__ = ["Linear"]
 
@@ -251,10 +249,6 @@ class _Linear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
-
-            # Verify that the transpose cache state matches the configuration.
-            if IS_HIP_EXTENSION:
-                assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
 
         out, *_, rs_out = general_gemm(
             weightmat,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -8,6 +8,7 @@ from functools import reduce
 from operator import mul as multiply_op
 
 import torch
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 import transformer_engine_torch as tex
 
@@ -23,7 +24,6 @@ from .base import (
 from ._common import noop_cat, _fix_gathered_fp8_transpose
 from ..fp8 import FP8GlobalStateManager
 from ..utils import (
-    assert_check_transpose_cache,
     cast_if_needed,
     clear_tensor_data,
     divide,
@@ -62,6 +62,8 @@ from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
 from ..cpu_offload import is_cpu_offload_enabled, set_offloading_param
 from ..rocm_utils import create_fp8_weight_transpose_cache, clear_fp8_weight_transpose_cache
 
+if IS_HIP_EXTENSION:
+    from ..utils import assert_check_transpose_cache
 
 __all__ = ["Linear"]
 
@@ -250,7 +252,8 @@ class _Linear(torch.autograd.Function):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
 
         # Verify that the transpose cache state matches the configuration.
-        assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
+        if IS_HIP_EXTENSION:
+            assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache)
 
         out, *_, rs_out = general_gemm(
             weightmat,

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -246,22 +246,6 @@ def assert_dim_for_fp8_exec(*tensors: List[torch.Tensor]) -> None:
         )
 
 if IS_HIP_EXTENSION:
-    def assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache):
-        """
-        Asserts that the state of the weight matrix's transpose cache
-        is consistent with the `keep_fp8_weight_transpose_cache` flag.
-
-        Args:
-            weightmat (torch.Tensor): The weight matrix object to check.
-            keep_fp8_weight_transpose_cache (bool): A flag indicating whether
-                                                    the cache should be retained.
-        """
-        transpose_is_empty_or_none = weightmat._transpose is None or weightmat._transpose.numel() == 0
-        if keep_fp8_weight_transpose_cache:
-            assert not transpose_is_empty_or_none, "Expected _transpose to be a valid, non-empty tensor when transpose cache is enabled."
-        else:
-            assert transpose_is_empty_or_none, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
-
     @functools.lru_cache(maxsize=None)
     def is_mi200():
       """check whether this machine is mi200/210/250"""

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -244,6 +244,7 @@ def assert_dim_for_fp8_exec(*tensors: List[torch.Tensor]) -> None:
             "height divisible by 8 and width divisible by 16, "
             f"but got tensor with dims={list(tensor.size())}"
         )
+
 if IS_HIP_EXTENSION:
     def assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache):
         """
@@ -261,7 +262,6 @@ if IS_HIP_EXTENSION:
         else:
             assert transpose_is_empty_or_none, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
 
-if IS_HIP_EXTENSION:
     @functools.lru_cache(maxsize=None)
     def is_mi200():
       """check whether this machine is mi200/210/250"""

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -245,6 +245,22 @@ def assert_dim_for_fp8_exec(*tensors: List[torch.Tensor]) -> None:
             f"but got tensor with dims={list(tensor.size())}"
         )
 
+def assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache):
+    """
+    Asserts that the state of the weight matrix's transpose cache
+    is consistent with the `keep_fp8_weight_transpose_cache` flag.
+
+    Args:
+        weightmat (torch.Tensor): The weight matrix object to check.
+        keep_fp8_weight_transpose_cache (bool): A flag indicating whether
+                                                the cache should be retained.
+    """
+    transpose_is_empty_or_none = weightmat._transpose is None or weightmat._transpose.numel() == 0
+    if keep_fp8_weight_transpose_cache:
+        assert not transpose_is_empty_or_none, "Expected _transpose to be a valid, non-empty tensor when transpose cache is enabled."
+    else:
+        assert transpose_is_empty_or_none, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
+
 if IS_HIP_EXTENSION:
     @functools.lru_cache(maxsize=None)
     def is_mi200():

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -244,22 +244,22 @@ def assert_dim_for_fp8_exec(*tensors: List[torch.Tensor]) -> None:
             "height divisible by 8 and width divisible by 16, "
             f"but got tensor with dims={list(tensor.size())}"
         )
+if IS_HIP_EXTENSION:
+    def assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache):
+        """
+        Asserts that the state of the weight matrix's transpose cache
+        is consistent with the `keep_fp8_weight_transpose_cache` flag.
 
-def assert_check_transpose_cache(weightmat, keep_fp8_weight_transpose_cache):
-    """
-    Asserts that the state of the weight matrix's transpose cache
-    is consistent with the `keep_fp8_weight_transpose_cache` flag.
-
-    Args:
-        weightmat (torch.Tensor): The weight matrix object to check.
-        keep_fp8_weight_transpose_cache (bool): A flag indicating whether
-                                                the cache should be retained.
-    """
-    transpose_is_empty_or_none = weightmat._transpose is None or weightmat._transpose.numel() == 0
-    if keep_fp8_weight_transpose_cache:
-        assert not transpose_is_empty_or_none, "Expected _transpose to be a valid, non-empty tensor when transpose cache is enabled."
-    else:
-        assert transpose_is_empty_or_none, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
+        Args:
+            weightmat (torch.Tensor): The weight matrix object to check.
+            keep_fp8_weight_transpose_cache (bool): A flag indicating whether
+                                                    the cache should be retained.
+        """
+        transpose_is_empty_or_none = weightmat._transpose is None or weightmat._transpose.numel() == 0
+        if keep_fp8_weight_transpose_cache:
+            assert not transpose_is_empty_or_none, "Expected _transpose to be a valid, non-empty tensor when transpose cache is enabled."
+        else:
+            assert transpose_is_empty_or_none, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
 
 if IS_HIP_EXTENSION:
     @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
# Description

While keep_fp8_weight_transpose_cache is False, the expectation is to not create any transpose in the forward pass and compute transpose in the backward pass. https://github.com/ROCm/TransformerEngine/commit/ad76b62166c189fa9f922c8f567af8fbac825b86#diff-ba97b0d1ae75d17a678bc38b4fa69ffec1e0ea007657a28d65565ee2cff35b95
The above commit introduced check to ensure transpose is created when input requires grad is True. But we don't want to create transpose when keep_fp8_weight_transpose_cache is False.
Without this check, it leads to creating transpose while transpose data ptr isn't initialized.

 RuntimeError: /workspace/TransformerEngine/transformer_engine/common/transpose/transpose.hip:206 in function transpose: Assertion failed: output.data.dptr != nullptr. Output is not allocated.
 
Fixes # ([13552](https://github.com/ROCm/frameworks-internal/issues/13552))
https://ontrack-internal.amd.com/browse/SWDEV-553639

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
Added keep_fp8_weight_transpose_cache checks while updating transpose

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
