### PR TITLE
Don't call HIP on TE load

### DIFF
--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -50,6 +50,7 @@ run_test_config() {
     NVTE_CK_USES_FWD_V3=1 NVTE_CK_USES_BWD_V3=1 run 1 test_fused_attn.py # Using FAv3 for forward and backward pass
     run_default_fa 1 test_helper.py
     run_default_fa 1 test_layer.py #it effectevly always uses unfused attention
+    run_default_fa 1 test_sanity_import.py
     run_default_fa 1 test_sharding.py
     run_default_fa 1 test_softmax.py
 }

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -61,6 +61,7 @@ run_test_config(){
     run_default_fa 1 test_permutation.py -k "not test_permutation_mask_map_fp8 and not test_permutation_single_case"
     run_default_fa 1 test_recipe.py
     run 1 test_sanity.py
+    run_default_fa 1 test_sanity_import.py
     run_default_fa 1 fused_attn/test_fused_attn.py # Backend selection is controlled by the test
     NVTE_CK_USES_FWD_V3=1 NVTE_CK_USES_BWD_V3=1 run_default_fa 1 fused_attn/test_fused_attn.py # Using FAv3 for forward and backward pass
     run_default_fa 1 triton_kernels/test_cast.py

--- a/tests/jax/test_sanity_import.py
+++ b/tests/jax/test_sanity_import.py
@@ -11,13 +11,20 @@ if __name__ == "__main__":
 
 def test_lazy_init():
     import jax, os, pytest, subprocess, sys
-    dev_count = jax.local_device_count()
-    if dev_count < 2:
-        pytest.skip("Test requires several visible devices")
+    if not transformer_engine.jax.is_hip_extension():
+        pytest.skip("This is ROCm test")
     os.environ["NVTE_FRAMEWORK"] = "jax"
-    dev_count_test = subprocess.run([sys.executable, '-c', 
-                                     "import transformer_engine, jax, os; " +
-                                     "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
-                                     "exit(jax.local_device_count())"]
-                                     ).returncode
-    assert dev_count_test==1, "Changing visible devices after import did not affect device count"
+    ret = subprocess.run(
+        [sys.executable, "-c",
+         "import os; os.environ['HIP_VISIBLE_DEVICES']=''; import transformer_engine"]
+         ).returncode
+    assert ret == 0, "Failed to import TE witout visible devices"
+    dev_count = jax.local_device_count()
+    if dev_count >= 2:
+        dev_count_test = subprocess.run([sys.executable, '-c',
+                                        "import transformer_engine, jax, os; " +
+                                        "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+                                        "exit(jax.local_device_count())"]
+                                        ).returncode
+        assert dev_count_test==1, (
+            "Changing visible devices after import did not affect reported devices count")

--- a/tests/jax/test_sanity_import.py
+++ b/tests/jax/test_sanity_import.py
@@ -16,15 +16,17 @@ def test_lazy_init():
     os.environ["NVTE_FRAMEWORK"] = "jax"
     ret = subprocess.run(
         [sys.executable, "-c",
+         "import sys; sys.path[:] = [p for p in sys.path if p not in ['', '.']]; "+
          "import os; os.environ['HIP_VISIBLE_DEVICES']=''; import transformer_engine"]
          ).returncode
-    assert ret == 0, "Failed to import TE witout visible devices"
+    assert ret == 0, "Failed to import TE without visible devices"
     dev_count = jax.local_device_count()
     if dev_count >= 2:
-        dev_count_test = subprocess.run([sys.executable, '-c',
-                                        "import transformer_engine, jax, os; " +
-                                        "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
-                                        "exit(jax.local_device_count())"]
-                                        ).returncode
+        dev_count_test = subprocess.run(
+            [sys.executable, '-c',
+             "import sys; sys.path[:] = [p for p in sys.path if p not in ['', '.']]; "+
+             "import transformer_engine, jax, os; os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+             "exit(jax.local_device_count())"]
+             ).returncode
         assert dev_count_test==1, (
             "Changing visible devices after import did not affect reported devices count")

--- a/tests/pytorch/test_sanity_import.py
+++ b/tests/pytorch/test_sanity_import.py
@@ -11,13 +11,20 @@ if __name__ == "__main__":
 
 def test_lazy_init():
     import torch, os, pytest, subprocess, sys
-    dev_count = torch.cuda.device_count()
-    if dev_count < 2:
-        pytest.skip("Test requires several visible devices")
+    if not torch.utils.cpp_extension.IS_HIP_EXTENSION:
+        pytest.skip("This is ROCm test")
     os.environ["NVTE_FRAMEWORK"] = "pytorch"
-    dev_count_test = subprocess.run([sys.executable, '-c', 
-                                     "import transformer_engine, torch, os; " +
-                                     "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
-                                     "exit(torch.cuda.device_count())"]
-                                     ).returncode
-    assert dev_count_test==1, "Changing visible devices after import did not affect device count"
+    ret = subprocess.run(
+        [sys.executable, "-c",
+         "import os; os.environ['HIP_VISIBLE_DEVICES']=''; import transformer_engine"]
+         ).returncode
+    assert ret == 0, "Failed to import TE witout visible devices"
+    dev_count = torch.cuda.device_count()
+    if dev_count >= 2:
+        dev_count_test = subprocess.run([sys.executable, '-c',
+                                        "import transformer_engine, torch, os; " +
+                                        "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+                                        "exit(torch.cuda.device_count())"]
+                                        ).returncode
+        assert dev_count_test==1, (
+            "Changing visible devices after import did not affect reported devices count")

--- a/tests/pytorch/test_sanity_import.py
+++ b/tests/pytorch/test_sanity_import.py
@@ -16,15 +16,17 @@ def test_lazy_init():
     os.environ["NVTE_FRAMEWORK"] = "pytorch"
     ret = subprocess.run(
         [sys.executable, "-c",
+         "import sys; sys.path[:] = [p for p in sys.path if p not in ['', '.']]; "+
          "import os; os.environ['HIP_VISIBLE_DEVICES']=''; import transformer_engine"]
          ).returncode
-    assert ret == 0, "Failed to import TE witout visible devices"
+    assert ret == 0, "Failed to import TE without visible devices"
     dev_count = torch.cuda.device_count()
     if dev_count >= 2:
-        dev_count_test = subprocess.run([sys.executable, '-c',
-                                        "import transformer_engine, torch, os; " +
-                                        "os.environ['HIP_VISIBLE_DEVICES']='0'; "+
-                                        "exit(torch.cuda.device_count())"]
-                                        ).returncode
+        dev_count_test = subprocess.run(
+            [sys.executable, '-c',
+             "import sys; sys.path[:] = [p for p in sys.path if p not in ['', '.']]; "+
+             "import transformer_engine, torch, os; os.environ['HIP_VISIBLE_DEVICES']='0'; "+
+             "exit(torch.cuda.device_count())"]
+             ).returncode
         assert dev_count_test==1, (
             "Changing visible devices after import did not affect reported devices count")

--- a/transformer_engine/common/amd_detail/hip_float8.h
+++ b/transformer_engine/common/amd_detail/hip_float8.h
@@ -47,6 +47,8 @@ static constexpr inline bool te_fp8_fnuz() { return true; }
 #if HIP_VERSION >= 60300000
 #if !defined(__HIP_DEVICE_COMPILE__)
 
+#define TE_DYNAMIC_HIP_FP8_TYPE 1
+
 /* Device methods in _te_hip_fp8 are dummy and are needed for compilation
 * because HIPCC compiles __device__ and __global__ functions for host.
 * The results are discarded so those methods are declared but not defined

--- a/transformer_engine/common/utils.cuh
+++ b/transformer_engine/common/utils.cuh
@@ -991,18 +991,24 @@ struct Numeric_Traits;
 template <>
 struct Numeric_Traits<fp8e4m3> {
   static constexpr int maxUnbiasedExponent = 8;
-#if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION >= 60300000 && defined(__HIP_DEVICE_COMPILE__)
-  static constexpr double maxNorm = HIP_FP8_TYPE_FNUZ ? 240.0 : 448.0;
-#elif defined(__HIP_PLATFORM_AMD__) && HIP_VERSION >= 60300000  
-  static const double maxNorm;
-#else
+#ifndef __HIP_PLATFORM_AMD__
   static constexpr double maxNorm = 448;
-#endif //__HIP_PLATFORM_AMD__
+#elif defined(__HIP_DEVICE_COMPILE__)
+  static constexpr double maxNorm = te_fp8_fnuz() ? 240 : 448;
+#elif defined(TE_DYNAMIC_HIP_FP8_TYPE)
+ // dummy declaration for correct translation;
+ // it is not defined anywhere and it's usage should be eliminated before linking
+  static double maxNorm;
+#else
+  static constexpr double maxNorm = 240;
+#endif
 };
 
-#if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION >= 60300000 && !defined(__HIP_DEVICE_COMPILE__)
-inline const double Numeric_Traits<fp8e4m3>::maxNorm =
-    te_fp8_fnuz() ? 240.0 : 448.0;
+#ifdef TE_DYNAMIC_HIP_FP8_TYPE
+template <bool FNUZ>
+struct Numeric_Traits_fp8e4m3: public Numeric_Traits<fp8e4m3> {
+  static constexpr double maxNorm = FNUZ ? 240 : 448;
+};
 #endif
 
 template <>
@@ -1016,27 +1022,24 @@ struct Quantized_Limits {
   static constexpr int max_unbiased_exponent = Numeric_Traits<T>::maxUnbiasedExponent;
   static constexpr float emax = 1 << max_unbiased_exponent;
   static constexpr float emax_rcp = 1.0 / emax;
-#if defined(__HIP_PLATFORM_AMD__) && defined(__HIP_DEVICE_COMPILE__)
-  static constexpr float max_norm      = static_cast<float>(Numeric_Traits<T>::maxNorm);
-  static constexpr float max_norm_rcp  = 1.0f / max_norm;
-#elif defined(__HIP_PLATFORM_AMD__)
-  static const float max_norm;      
-  static const float max_norm_rcp;
-#else
+#ifdef TE_DYNAMIC_HIP_FP8_TYPE
+  static constexpr struct {
+    operator float() const {
+      if (std::is_same<T, fp8e4m3>::value) {
+        return te_fp8_fnuz() ? Numeric_Traits_fp8e4m3<true>::maxNorm
+                           : Numeric_Traits_fp8e4m3<false>::maxNorm;
+      } else {
+        return Numeric_Traits<T>::maxNorm;
+      }
+    }
+  } max_norm = {};
+  // dummy value for kernels host path compilation
+  static constexpr float max_norm_rcp = std::numeric_limits<float>::signaling_NaN();
+#else // TE_DYNAMIC_HIP_FP8_TYPE
   static constexpr float max_norm = Numeric_Traits<T>::maxNorm;
   static constexpr float max_norm_rcp = 1.0 / max_norm;
-#endif
+#endif // TE_DYNAMIC_HIP_FP8_TYPE
 };
-
-#if defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_DEVICE_COMPILE__)
-template<typename T>
-inline const float Quantized_Limits<T>::max_norm =
-    static_cast<float>(Numeric_Traits<T>::maxNorm);
-
-template<typename T>
-inline const float Quantized_Limits<T>::max_norm_rcp =
-    1.0f / Quantized_Limits<T>::max_norm;
-#endif
 
 __device__ __forceinline__ e8m0_t float_to_e8m0(float val) {
   // TODO: nan/inf needs to be set for any value


### PR DESCRIPTION
# Description

Do not call HIP on TE load to determine FP8 FNUZ/OCP limits

Fixes  [Import error when there is no GPU #13532](https://github.com/ROCm/frameworks-internal/issues/13532) / ROCm/TransformerEngine#293
CI failure

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Updated FP8 numeric traits and QuantizationLimits to postpone FNUZ/OCP limit selection on host path till actual usage

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
