### PR TITLE
Added fallback path for `make_ln_out`

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/norm_common.py
+++ b/transformer_engine/pytorch/triton_kernels/norm_common.py
@@ -77,7 +77,10 @@ def make_ln_out(ln_out, quantizer=None, input_shape=None, out_dtype=torch.float3
             return ln_out
         return quantizer.make_empty(input_shape, dtype=out_dtype)
 
-    return quantizer.create_tensor_from_data(
-            ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)),
-            fake_dtype=out_dtype
-        )
+    if quantizer is not None:
+        return quantizer.create_tensor_from_data(
+                ln_out.view(te_dtype_to_torch_dtype(quantizer.dtype)),
+                fake_dtype=out_dtype
+            )
+
+    return ln_out


### PR DESCRIPTION
# Description

Adds a fallback path for `make_ln_out` when no quantizer is passed.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
