### PR TITLE
Fix GPU fault due to invalid argument with current quantization

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -476,8 +476,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
     M, N = input.shape
 
     #TODO: Check if need distinct Current and Delayed quantization
-    IS_FP8 = (isinstance(quantizer, Float8Quantizer) or 
-              isinstance(quantizer, Float8CurrentScalingQuantizer))
+    IS_FP8 = isinstance(quantizer, (Float8Quantizer, Float8CurrentScalingQuantizer))
     IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     assert (quantizer is None or IS_FP8 or IS_MXFP8), "Unsupported quantizer type"
 

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -7,7 +7,7 @@ import os
 
 import torch
 
-from ..tensor.float8_tensor import Float8Quantizer
+from ..tensor.float8_tensor import Float8Quantizer, Float8CurrentScalingQuantizer
 from ..constants import TE_DType
 from ..tensor.mxfp8_tensor import MXFP8Quantizer
 from ..tensor.quantized_tensor import Quantizer
@@ -474,13 +474,21 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         )
     device = input.device
     M, N = input.shape
-    
+
+    # MXFP8 is handled regularly, hence other quantizers are considered FP8
+    IS_FP8_DELAYED = isinstance(quantizer, Float8Quantizer)
+    IS_FP8 = IS_FP8_DELAYED or isinstance(quantizer, Float8CurrentScalingQuantizer)
+    IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
+    assert (quantizer is None or IS_FP8 or IS_MXFP8), "Unsupported quantizer type"
+
+    MAKE_TRANSPOSE = False
+
     # Create empty tensors for mu and rsigma
     mu = torch.empty((M,), dtype=torch.float32, device=device)
     rsigma = torch.empty((M,), dtype=torch.float32, device=device)
     torch_out_dtype = te_dtype_to_torch_dtype(out_dtype)
     # Create ln_out
-    if quantizer is None or isinstance(quantizer, MXFP8Quantizer):
+    if quantizer is None or IS_MXFP8:
         ln_out = torch.empty(M, N, dtype=torch_out_dtype, device=device)
     else:
         if ln_out is None:
@@ -491,9 +499,6 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
             ln_out = quantizer.create_tensor_from_data(ln_out._data)
     # To update the amax ptr directly with atomic max
     APPLY_ATOMIC = M < 512
-
-    # MXFP8 is handled regularly, hence quantizer of Float8Quantizer is considered FP8
-    IS_FP8 = isinstance(quantizer, Float8Quantizer)
 
     amax_temp = torch.empty((M,), dtype=torch.float32, device=input.device) if IS_FP8 else None
 
@@ -546,7 +551,7 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
         )
 
     # For MXFP8, we do regular layernorm and then quantize it separately
-    if isinstance(quantizer, MXFP8Quantizer):
+    if IS_MXFP8:
         ln_out = te_quantize_triton(ln_out, quantizer)
     
     # Reduce and find amax if "not APPLY_ATOMIC" is True.

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -475,13 +475,11 @@ def te_layernorm_fwd_triton(input: torch.Tensor,
     device = input.device
     M, N = input.shape
 
-    # MXFP8 is handled regularly, hence other quantizers are considered FP8
-    IS_FP8_DELAYED = isinstance(quantizer, Float8Quantizer)
-    IS_FP8 = IS_FP8_DELAYED or isinstance(quantizer, Float8CurrentScalingQuantizer)
+    #TODO: Check if need distinct Current and Delayed quantization
+    IS_FP8 = (isinstance(quantizer, Float8Quantizer) or 
+              isinstance(quantizer, Float8CurrentScalingQuantizer))
     IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     assert (quantizer is None or IS_FP8 or IS_MXFP8), "Unsupported quantizer type"
-
-    MAKE_TRANSPOSE = False
 
     # Create empty tensors for mu and rsigma
     mu = torch.empty((M,), dtype=torch.float32, device=device)

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -384,8 +384,7 @@ def te_rmsnorm_fwd_triton(
         )
 
     #TODO: Check if need distinct Current and Delayed quantization
-    IS_FP8 = (isinstance(quantizer, Float8Quantizer) or 
-              isinstance(quantizer, Float8CurrentScalingQuantizer))
+    IS_FP8 = isinstance(quantizer, (Float8Quantizer, Float8CurrentScalingQuantizer))
     IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -383,8 +383,9 @@ def te_rmsnorm_fwd_triton(
             f"but {weight.shape[0]=} while {input.shape[1]=}"
         )
 
-    IS_FP8_DELAYED = isinstance(quantizer, Float8Quantizer)
-    IS_FP8 = IS_FP8_DELAYED or isinstance(quantizer, Float8CurrentScalingQuantizer)
+    #TODO: Check if need distinct Current and Delayed quantization
+    IS_FP8 = (isinstance(quantizer, Float8Quantizer) or 
+              isinstance(quantizer, Float8CurrentScalingQuantizer))
     IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -6,7 +6,11 @@ import triton
 import triton.language as tl
 from itertools import product
 from .norm_common import num_programs, block_size, use_blocked
-from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer, Float8Tensor
+from transformer_engine.pytorch.tensor.float8_tensor import (
+    Float8Quantizer,
+    Float8CurrentScalingQuantizer,
+    Float8Tensor
+)
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_torch_dtype,
@@ -378,8 +382,10 @@ def te_rmsnorm_fwd_triton(
             f"The shape of `weight` must be feature-aligned, "
             f"but {weight.shape[0]=} while {input.shape[1]=}"
         )
-    IS_FP8 = isinstance(quantizer, Float8Quantizer)
-    IS_MFP8 = isinstance(quantizer, MXFP8Quantizer)
+
+    IS_FP8_DELAYED = isinstance(quantizer, Float8Quantizer)
+    IS_FP8 = IS_FP8_DELAYED or isinstance(quantizer, Float8CurrentScalingQuantizer)
+    IS_MXFP8 = isinstance(quantizer, MXFP8Quantizer)
     BLOCK_SIZE = block_size(input)
     USE_BLOCKED = use_blocked(input)
     NUM_PRGMS = num_programs(input, sm_margin)
@@ -457,7 +463,7 @@ def te_rmsnorm_fwd_triton(
         FP8_MAX,
         MAKE_TRANSPOSE,
     )
-    if IS_MFP8:
+    if IS_MXFP8:
         out = quantizer.quantize(out)
 
     return out, None, rsigma


### PR DESCRIPTION
# Description

Fixes [13564](https://github.com/ROCm/frameworks-internal/issues/13564)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Properly pass tensors to triton kernel when Float8CurrentScalingQuantizer is used

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
