### PR TITLE
Hotfix removal of env variable in test

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -288,6 +288,7 @@ def test_dot_product_mem_calc(workspace_opt):
     if FusedAttnBackend["CK"] not in fused_attn_backends:
         pytest.skip("This test requires the CK fused attention backend.")
 
+    nvte_ck_uses_fwd_v3 = os.environ["NVTE_CK_USES_FWD_V3"]
     os.environ["NVTE_CK_USES_FWD_V3"] = "1"
     os.environ["NVTE_FUSED_ATTN_CK"] = "1"
     os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
@@ -301,7 +302,7 @@ def test_dot_product_mem_calc(workspace_opt):
         pad_between_seqs,
         is_training,
     )
-    del os.environ["NVTE_CK_USES_FWD_V3"]
+    os.environ["NVTE_CK_USES_FWD_V3"] = nvte_ck_uses_fwd_v3
     del os.environ["NVTE_FUSED_ATTN_CK"]
     del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
 

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -288,8 +288,6 @@ def test_dot_product_mem_calc(workspace_opt):
     if FusedAttnBackend["CK"] not in fused_attn_backends:
         pytest.skip("This test requires the CK fused attention backend.")
 
-    nvte_ck_uses_fwd_v3 = os.environ["NVTE_CK_USES_FWD_V3"]
-    os.environ["NVTE_CK_USES_FWD_V3"] = "1"
     os.environ["NVTE_FUSED_ATTN_CK"] = "1"
     os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
     _, _ = _run_dot_product_attention(
@@ -302,7 +300,6 @@ def test_dot_product_mem_calc(workspace_opt):
         pad_between_seqs,
         is_training,
     )
-    os.environ["NVTE_CK_USES_FWD_V3"] = nvte_ck_uses_fwd_v3
     del os.environ["NVTE_FUSED_ATTN_CK"]
     del os.environ["NVTE_FUSED_ATTN_AOTRITON"]
 

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -557,6 +557,12 @@ void fused_attn_ck_fwd_impl(
       nvte_log_ck_config = true;
   }
   bool nvte_ck_uses_fwd_v3 = getenv<int>("NVTE_CK_USES_FWD_V3", 0);
+  if(layout==NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD){
+    if(nvte_ck_uses_fwd_v3 && nvte_log_ck_config){
+      std::cout<<"Disable CK FWD v3 since only BSHD_BSHD_BSHD layout supported"<<std::endl;
+    }
+    nvte_ck_uses_fwd_v3 = false;
+  }
   bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD; 
 
   // extract the qkv and o storage bytes to allocate buffer for padding removing

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -557,13 +557,18 @@ void fused_attn_ck_fwd_impl(
       nvte_log_ck_config = true;
   }
   bool nvte_ck_uses_fwd_v3 = getenv<int>("NVTE_CK_USES_FWD_V3", 0);
-  if(layout==NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD){
+  NVTE_QKV_Format format = nvte_get_qkv_format(layout);
+  if(
+    format==NVTE_QKV_Format::NVTE_SBHD ||
+    layout==NVTE_QKV_Layout::NVTE_BSH3D ||
+    layout==NVTE_QKV_Layout::NVTE_BS3HD
+  ){
     if(nvte_ck_uses_fwd_v3 && nvte_log_ck_config){
       std::cout<<"Disable CK FWD v3 since only BSHD_BSHD_BSHD layout supported"<<std::endl;
     }
     nvte_ck_uses_fwd_v3 = false;
   }
-  bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD; 
+  bool is_ragged = format==NVTE_QKV_Format::NVTE_THD;
 
   // extract the qkv and o storage bytes to allocate buffer for padding removing
   // b from cu_seqlen is not the actual storage batch for pad_between_seqs case

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -557,18 +557,7 @@ void fused_attn_ck_fwd_impl(
       nvte_log_ck_config = true;
   }
   bool nvte_ck_uses_fwd_v3 = getenv<int>("NVTE_CK_USES_FWD_V3", 0);
-  NVTE_QKV_Format format = nvte_get_qkv_format(layout);
-  if(
-    format==NVTE_QKV_Format::NVTE_SBHD ||
-    layout==NVTE_QKV_Layout::NVTE_BSH3D ||
-    layout==NVTE_QKV_Layout::NVTE_BS3HD
-  ){
-    if(nvte_ck_uses_fwd_v3 && nvte_log_ck_config){
-      std::cout<<"Disable CK FWD v3 since only BSHD_BSHD_BSHD layout supported"<<std::endl;
-    }
-    nvte_ck_uses_fwd_v3 = false;
-  }
-  bool is_ragged = format==NVTE_QKV_Format::NVTE_THD;
+  bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD;
 
   // extract the qkv and o storage bytes to allocate buffer for padding removing
   // b from cu_seqlen is not the actual storage batch for pad_between_seqs case


### PR DESCRIPTION
# Description

Originally even if test was run with `NVTE_CK_USES_FWD_V3=1` it would be deleted in the first test run and consequently prevents the use of FWD_V3 kernels. Setting the env variable in the test is not necessary since CI runs it with `NVTE_CK_USES_FWD_V3=1` anyways.

This PR will also update the AITER submodule commit to include fixes necessary for the tests to pass. This will fix https://github.com/ROCm/frameworks-internal/issues/13708

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
