### PR TITLE
Removed duplicated tests run with params that do not have effect

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -265,8 +265,7 @@ if is_bf16_compatible():  # bf16 requires sm_80 or higher
 param_types_lean = [torch.bfloat16]
 
 @pytest.mark.skipif(not IS_HIP_EXTENSION, reason="ROCm TE specific pytests.")
-@pytest.mark.parametrize("workspace_opt", [True, False])
-def test_dot_product_mem_calc(workspace_opt):
+def test_dot_product_mem_calc():
     """
     Non-regression test for memory workspace calculation integer overflow issue.
     """
@@ -297,7 +296,7 @@ def test_dot_product_mem_calc(workspace_opt):
         "FusedAttention",
         ckpt_attn,
         qkv_layout,
-        workspace_opt,
+        False, #workspace_opt
         pad_between_seqs,
         is_training,
     )
@@ -311,7 +310,7 @@ def test_dot_product_mem_calc(workspace_opt):
 @pytest.mark.parametrize("model_configs", [model_configs_base])
 @pytest.mark.parametrize("model", model_configs_base.keys())
 @pytest.mark.parametrize("ckpt_attn", [False])
-@pytest.mark.parametrize("workspace_opt", [True, False])
+@pytest.mark.parametrize("workspace_opt", [False] if IS_HIP_EXTENSION else [True, False])
 @pytest.mark.parametrize("qkv_layout", [None])
 @pytest.mark.parametrize("swa", [False])
 @pytest.mark.parametrize("pad_between_seqs", [False])
@@ -800,6 +799,8 @@ model_configs_layout_thd = {
     ),
 }
 
+padding_configs = ([(True, False), (False, False), (False, True)] if IS_HIP_EXTENSION
+                   else [(True, False), (False, False)])
 
 # ROCm fused attn does not use cudnn, return high numbers to avoid tests filtering out
 @pytest.mark.skipif(get_cudnn_version() < (9, 0, 0), reason="cuDNN 9.0.0+ is required.")
@@ -811,10 +812,7 @@ model_configs_layout_thd = {
 @pytest.mark.parametrize("model_configs", [model_configs_layout_thd])
 @pytest.mark.parametrize("model", model_configs_layout_thd.keys())
 @pytest.mark.parametrize("qkv_layout", qkv_layouts_thd)
-@pytest.mark.parametrize(
-    ("pad_between_seqs", "share_cu_seqlens_ref"),
-    [(True, False), (False, False), (False, True)]
-)
+@pytest.mark.parametrize(("pad_between_seqs", "share_cu_seqlens_ref"), padding_configs)
 def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout, pad_between_seqs, share_cu_seqlens_ref):
     """Test DotProductAttention module with different QKV layouts"""
     config = model_configs[model]
@@ -830,11 +828,8 @@ def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout, pad_between
         window_size=config.window_size,
         pad_between_seqs=pad_between_seqs,
     )
-    if share_cu_seqlens_ref:
-        if not IS_HIP_EXTENSION:
-            pytest.skip("share_cu_seqlens_ref is a ROCm TE specific implementation detail.")
-        if FusedAttnBackend["CK"] not in fused_attn_backends:
-            pytest.skip("This test is only required for the CK fused attention backend.")
+    if share_cu_seqlens_ref and FusedAttnBackend["CK"] not in fused_attn_backends:
+        pytest.skip("This test is only required for the CK fused attention backend.")
     test_dot_product_attention(
         dtype, model_configs, model, False, True, qkv_layout, False, pad_between_seqs, share_cu_seqlens_ref
     )
@@ -844,10 +839,7 @@ def test_dpa_qkv_layout_thd(dtype, model_configs, model, qkv_layout, pad_between
 @pytest.mark.parametrize("model_configs", [model_configs_layout_thd])
 @pytest.mark.parametrize("model", model_configs_layout_thd.keys())
 @pytest.mark.parametrize("qkv_layout", qkv_layouts_thd)
-@pytest.mark.parametrize(
-    ("pad_between_seqs", "share_cu_seqlens_ref"),
-    [(True, False), (False, False), (False, True)]
-)
+@pytest.mark.parametrize(("pad_between_seqs", "share_cu_seqlens_ref"), padding_configs)
 def test_dpa_qkv_layout_thd_mqa_gqa(dtype, model_configs, model, qkv_layout, pad_between_seqs, share_cu_seqlens_ref):
     config = model_configs[model]
 


### PR DESCRIPTION
# Description

Do not run Pytorch test_fused_attn subtests with multiople values of parameters that do not have effect

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Do not run on ROCm with workspace_opt
- Do not run on CUDA with share_cu_seqlens_ref

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
