### PR TITLE
Refactor keep_fp8_transpose_cache flag

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -947,7 +947,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         update_workspace: bool = True,
         skip_update_flag: Optional[torch.Tensor] = None,
         fsdp_group: Optional[dist_group_type] = None,
-        create_transpose_cache: bool = True,
     ) -> QuantizedTensor:
         """Get FP8 workspace buffer and maybe update its values
 
@@ -970,8 +969,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             over `update_workspace` if provided.
         fsdp_group: bool, default = None
             FSDP process group that the weights are distributed over.
-        create_transpose_cache: bool, default = True
-            Create transpose buffer from `tensor`.
         """
 
         # Try getting workspace from cache
@@ -989,21 +986,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             and out.data.shape != tensor.data.shape
         ):
             _fsdp_gather_tensors(fsdp_group, [tensor.data.shape], out)
-
-        if not non_tn_fp8_gemm_supported() and not create_transpose_cache:
-            current_quantizer = None
-            if out is None:
-                current_quantizer = quantizer
-            else:
-                if hasattr(out, "quantize_"):
-                    current_quantizer = out._get_quantizer()
-                else:
-                    current_quantizer = quantizer
-                    
-            assert isinstance(current_quantizer, Float8Quantizer), "`create_tranpose_buffer=False` only availabe in `Float8Quantizer`."
-
-            # NOTE: Not create transpose buffer internally.
-            current_quantizer.columnwise_usage = False
 
         # Construct workspace if needed
         if out is None:

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -924,7 +924,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                     quantizer is not None
                 )  # to use primary fp8 weight one needs to use FP8 autocast with specific recipe.
                 quantizer.internal = False
-                if not self.keep_fp8_weight_transpose_cache:
+                if IS_HIP_EXTENSION and not self.keep_fp8_weight_transpose_cache:
                     quantizer.columnwise_usage=False
                 param = quantizer(param)
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -283,7 +283,7 @@ class _LayerNormLinear(torch.autograd.Function):
 
                 # Configure quantizer
                 if weight_quantizer is not None:
-                    weight_quantizer.set_usage(rowwise=True, columnwise=True)
+                    weight_quantizer.set_usage(rowwise=True, columnwise=keep_fp8_weight_transpose_cache)
 
                 # FP8 cast to workspace buffer
                 update_workspace = is_first_microbatch is None or is_first_microbatch
@@ -294,7 +294,6 @@ class _LayerNormLinear(torch.autograd.Function):
                     update_workspace=update_workspace,
                     skip_update_flag=skip_fp8_weight_update,
                     fsdp_group=fsdp_group,
-                    create_transpose_cache=keep_fp8_weight_transpose_cache,
                 )
 
         # Cast bias to expected dtype
@@ -336,6 +335,8 @@ class _LayerNormLinear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
+            if not keep_fp8_weight_transpose_cache:
+                assert weightmat._transpose is None or weightmat._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
 
         out, *_, rs_out = general_gemm(
             weightmat,
@@ -1448,6 +1449,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
         input_quantizer.internal = False
         weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
         weight_quantizer.internal = True
+        weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
         if fp8_output:
             output_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_OUTPUT]
         if torch.is_grad_enabled():

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -127,6 +127,8 @@ class _LayerNormLinear(torch.autograd.Function):
         keep_fp8_weight_transpose_cache: bool,
     ) -> Union[Tuple[torch.Tensor, ...], torch.Tensor]:
         # pylint: disable=missing-function-docstring
+        if not IS_HIP_EXTENSION:
+            keep_fp8_weight_transpose_cache = True
 
         # NVTX label for profiling
         nvtx_label = "transformer_engine._LayerNormLinear.forward"
@@ -1449,7 +1451,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
         input_quantizer.internal = False
         weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
         weight_quantizer.internal = True
-        weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
+        if IS_HIP_EXTENSION:
+            weight_quantizer.set_usage(columnwise = self.keep_fp8_weight_transpose_cache)
         if fp8_output:
             output_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_OUTPUT]
         if torch.is_grad_enabled():

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -337,7 +337,7 @@ class _LayerNormLinear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
-            if not keep_fp8_weight_transpose_cache:
+            if IS_HIP_EXTENSION and not keep_fp8_weight_transpose_cache:
                 assert weightmat._transpose is None or weightmat._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
 
         out, *_, rs_out = general_gemm(

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -392,7 +392,7 @@ class _LayerNormMLP(torch.autograd.Function):
             if gemm_gelu_fusion and bias_gelu_fusion:
                 gemm_gelu_fusion = False
         
-        if fp8 and not keep_fp8_weight_transpose_cache:
+        if IS_HIP_EXTENSION and fp8 and not keep_fp8_weight_transpose_cache:
             assert fc1_weight_final._transpose is None or fc1_weight_final._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         fc1_outputs = general_gemm(
             fc1_weight_final,
@@ -450,7 +450,7 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_out = torch.empty(dim_size, dtype=activation_dtype, device=device)
 
         # FC2 GEMM
-        if fp8 and not keep_fp8_weight_transpose_cache:
+        if IS_HIP_EXTENSION and fp8 and not keep_fp8_weight_transpose_cache:
             assert fc2_weight_final._transpose is None or fc2_weight_final._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         _ = general_gemm(
             fc2_weight_final,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -345,10 +345,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     update_workspace=update_workspace,
                     skip_update_flag=skip_fp8_weight_update,
                     fsdp_group=fsdp_group,
-                    create_transpose_cache=keep_fp8_weight_transpose_cache,
                 )
             if not isinstance(fc2_weight, QuantizedTensor):
-                fc2_weight_quantizer.set_usage(rowwise=True, columnwise=True)
+                fc2_weight_quantizer.set_usage(rowwise=True, columnwise=keep_fp8_weight_transpose_cache)
                 fc2_weight_final = module.get_weight_workspace(
                     tensor=fc2_weight,
                     quantizer=fc2_weight_quantizer,
@@ -356,7 +355,6 @@ class _LayerNormMLP(torch.autograd.Function):
                     update_workspace=update_workspace,
                     skip_update_flag=skip_fp8_weight_update,
                     fsdp_group=fsdp_group,
-                    create_transpose_cache=keep_fp8_weight_transpose_cache,
                 )
 
         # Cast biases to expected dtype
@@ -390,7 +388,9 @@ class _LayerNormMLP(torch.autograd.Function):
                 gemm_gelu_fusion = True
             if gemm_gelu_fusion and bias_gelu_fusion:
                 gemm_gelu_fusion = False
-
+        
+        if fp8 and not keep_fp8_weight_transpose_cache:
+            assert fc1_weight_final._transpose is None or fc1_weight_final._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         fc1_outputs = general_gemm(
             fc1_weight_final,
             ln_out_total,
@@ -447,6 +447,8 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_out = torch.empty(dim_size, dtype=activation_dtype, device=device)
 
         # FC2 GEMM
+        if fp8 and not keep_fp8_weight_transpose_cache:
+            assert fc2_weight_final._transpose is None or fc2_weight_final._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         _ = general_gemm(
             fc2_weight_final,
             act_out,
@@ -1591,12 +1593,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
             fc1_input_quantizer.internal = False  # temporary
             fc1_weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
             fc1_weight_quantizer.internal = True
+            fc1_weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
             fc2_input_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM2_INPUT]
             fc2_input_quantizer.set_usage(
                 rowwise=True, columnwise=isinstance(fc2_input_quantizer, MXFP8Quantizer)
             )
             fc2_weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM2_WEIGHT]
             fc2_weight_quantizer.internal = True
+            fc2_weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
             if torch.is_grad_enabled():
                 grad_fc2_output_quantizer = self.quantizers["scaling_bwd"][
                     tex.FP8BwdTensors.GRAD_OUTPUT1

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -191,6 +191,9 @@ class _LayerNormMLP(torch.autograd.Function):
         keep_fp8_weight_transpose_cache: bool,
     ) -> Union[Tuple[torch.Tensor, ...], torch.Tensor]:
         # pylint: disable=missing-function-docstring
+        
+        if not IS_HIP_EXTENSION:
+            keep_fp8_weight_transpose_cache = True
 
         in_features, inp_shape = ln_weight.numel(), inp.shape
         # Make sure input dimensions are compatible
@@ -1593,14 +1596,16 @@ class LayerNormMLP(TransformerEngineBaseModule):
             fc1_input_quantizer.internal = False  # temporary
             fc1_weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
             fc1_weight_quantizer.internal = True
-            fc1_weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
+            if IS_HIP_EXTENSION:
+                fc1_weight_quantizer.set_usage(columnwise = self.keep_fp8_weight_transpose_cache)
             fc2_input_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM2_INPUT]
             fc2_input_quantizer.set_usage(
                 rowwise=True, columnwise=isinstance(fc2_input_quantizer, MXFP8Quantizer)
             )
             fc2_weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM2_WEIGHT]
             fc2_weight_quantizer.internal = True
-            fc2_weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
+            if IS_HIP_EXTENSION:
+                fc2_weight_quantizer.set_usage(columnwise = self.keep_fp8_weight_transpose_cache)
             if torch.is_grad_enabled():
                 grad_fc2_output_quantizer = self.quantizers["scaling_bwd"][
                     tex.FP8BwdTensors.GRAD_OUTPUT1

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -251,7 +251,7 @@ class _Linear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
-            if not keep_fp8_weight_transpose_cache:
+            if IS_HIP_EXTENSION and not keep_fp8_weight_transpose_cache:
                 assert weightmat._transpose is None or weightmat._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         out, *_, rs_out = general_gemm(
             weightmat,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -188,8 +188,8 @@ class _Linear(torch.autograd.Function):
             if not isinstance(weight, QuantizedTensor):
                 # Configure quantizer
                 if weight_quantizer is not None:
-                    columnwise_usage = is_grad_enabled and inp.requires_grad
-                    if not columnwise_usage:
+                    columnwise_usage = is_grad_enabled and inp.requires_grad and keep_fp8_weight_transpose_cache
+                    if not columnwise_usage and keep_fp8_weight_transpose_cache:
                         columnwise_usage = (
                             is_fp8_activation_recompute_enabled()
                             and not in_fp8_activation_recompute_phase()
@@ -205,7 +205,6 @@ class _Linear(torch.autograd.Function):
                     update_workspace=update_workspace,
                     skip_update_flag=skip_fp8_weight_update,
                     fsdp_group=fsdp_group,
-                    create_transpose_cache=keep_fp8_weight_transpose_cache,
                 )
 
         # Cast bias to expected dtype
@@ -249,7 +248,8 @@ class _Linear(torch.autograd.Function):
             recipe = FP8GlobalStateManager.get_fp8_recipe()
             if hasattr(recipe, "fp8_gemm_fprop"):
                 fprop_gemm_use_split_accumulator = recipe.fp8_gemm_fprop.use_split_accumulator
-
+            if not keep_fp8_weight_transpose_cache:
+                assert weightmat._transpose is None or weightmat._transpose.numel() == 0, "Expected _transpose to be None or an empty tensor when transpose cache is disabled."
         out, *_, rs_out = general_gemm(
             weightmat,
             inputmat_total,
@@ -1206,6 +1206,7 @@ class Linear(TransformerEngineBaseModule):
         input_quantizer.internal = False
         weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
         weight_quantizer.internal = True
+        weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
         if fp8_output:
             output_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_OUTPUT]
         if torch.is_grad_enabled():

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -11,6 +11,7 @@ from operator import mul as multiply_op
 
 import torch
 
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
@@ -109,6 +110,8 @@ class _Linear(torch.autograd.Function):
         keep_fp8_weight_transpose_cache: bool,
     ) -> torch.Tensor:
         # pylint: disable=missing-function-docstring
+        if not IS_HIP_EXTENSION:
+            keep_fp8_weight_transpose_cache = True
 
         # NVTX label for profiling
         nvtx_label = "transformer_engine._Linear.forward"
@@ -1206,7 +1209,8 @@ class Linear(TransformerEngineBaseModule):
         input_quantizer.internal = False
         weight_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_WEIGHT]
         weight_quantizer.internal = True
-        weight_quantizer.columnwise_usage = self.keep_fp8_weight_transpose_cache
+        if IS_HIP_EXTENSION:
+            weight_quantizer.set_usage(columnwise = self.keep_fp8_weight_transpose_cache)
         if fp8_output:
             output_quantizer = self.quantizers["scaling_fwd"][tex.FP8FwdTensors.GEMM1_OUTPUT]
         if torch.is_grad_enabled():


### PR DESCRIPTION
# Description

Figure out when fp8 weight transpose is needed in TE modules for each weight transposes and refactor it accordingly. Added assertions to make sure that the flag is working as intended.

Fixes # ([13679](https://github.com/ROCm/frameworks-internal/issues/13679))

There are 2 ways to initialize parameters in modules, 
`with fp8_model_init(enabled=(True/False):`

When set to True, modules created inside this context will only store FP8 copies of their parameters, not the higher precision versions.
When set to False, modules created inside this context stores both higher precision and FP8 copies of parameters.

When enabled is set to True, https://github.com/ROCm/TransformerEngine/blob/18f925ffb00ababdb3268e99af5d651f55c3fd52/transformer_engine/pytorch/module/base.py#L921-L929
the code goes inside the above block and quantizer's columnwise usage is updated based on the keep_fp8_weight_transpose_cache. So, while initializing, we don't create any transpose cache.

While enabled is set to False,
FP8 parameters are created lazily during the first forward pass through the get_weight_workspace() method. Since out is None here, whatever quantizer is passed to this function will be used to create the transpose. So, we just have to make sure that the quantizer passed to this function has columnwise usage set based on keep_fp8_transpose_cache. 
Quantizers are retrieved using _get_quantizers method as shown in this block -> https://github.com/ROCm/TransformerEngine/blob/18f925ffb00ababdb3268e99af5d651f55c3fd52/transformer_engine/pytorch/module/linear.py#L1140-L1146

https://github.com/ROCm/TransformerEngine/blob/18f925ffb00ababdb3268e99af5d651f55c3fd52/transformer_engine/pytorch/module/linear.py#L1212-L1213
Hence, adding the lines to update the columnwise usage in the _get_quantizers method does the job since this would be the quantizer that'll be used when get_weight_workspace is called.

Why we reverted get_weight_workspace method in base.py? (https://github.com/ROCm/TransformerEngine/blob/18f925ffb00ababdb3268e99af5d651f55c3fd52/transformer_engine/pytorch/module/base.py#L941-L1019)

Since when create workspace is called with the updated quantizer, the workspace is cached using: `self._fp8_workspaces[cache_name] = out`

This means out tensor would now have quantizer object as the one that's initially passed which depended on keep_fp8_transpose cache. So, no need to change anything here.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Refactoring the keep_fp8_transpose_cache flag
Added assertion statements to make sure the flag is working as intended.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
