### PR TITLE
Cleanup env variables on test failure

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -83,6 +83,28 @@ def reset_global_fp8_state():
     fp8.FP8GlobalStateManager.reset()
 
 
+class EnvVarCleaner:
+    def __init__(self, envs_):
+        self.envs = envs_
+        self.flags = {}
+        for env in self.envs:
+          if env in os.environ:
+            self.flags[env] = os.environ[env]
+    def __del__(self):
+      for env in self.envs:
+        if env in self.flags:
+            os.environ[env] = self.flags[env]
+        else:
+            os.environ.pop(env, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_attn_backend():
+    env = EnvVarCleaner(["NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN",
+                         "NVTE_FUSED_ATTN_CK", "NVTE_FUSED_ATTN_AOTRITON"])
+    yield
+
+
 class ModelConfig:
     def __init__(
         self,

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -197,19 +197,31 @@ def reset_global_fp8_state():
     FP8GlobalStateManager.reset()
 
 
-@pytest.fixture()
-def reset_attn_backend():
-    envs = ["NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN"]
-    flags = {}
-    for env in envs:
-        if env in os.environ:
-            flags[env] = os.environ[env]
-    yield
-    for env in envs:
-        if env in flags:
-            os.environ[env] = flags[env]
+class EnvVarCleaner:
+    def __init__(self, envs_):
+        self.envs = envs_
+        self.flags = {}
+        for env in self.envs:
+          if env in os.environ:
+            self.flags[env] = os.environ[env]
+    def __del__(self):
+      for env in self.envs:
+        if env in self.flags:
+            os.environ[env] = self.flags[env]
         else:
             os.environ.pop(env, None)
+
+
+@pytest.fixture()
+def reset_env_var(request):
+    envs = getattr(request, 'param', [])
+    env = EnvVarCleaner(envs)
+    yield
+
+@pytest.fixture
+def reset_attn_backend():
+    env = EnvVarCleaner(["NVTE_FLASH_ATTN", "NVTE_FUSED_ATTN", "NVTE_UNFUSED_ATTN"])
+    yield
 
 
 class TorchScaledMaskedSoftmax(nn.Module):
@@ -715,6 +727,8 @@ def _test_e2e_full_recompute(
 @pytest.mark.parametrize("recipe", fp8_recipes)
 @pytest.mark.parametrize("fp8_model_params", all_boolean)
 @pytest.mark.parametrize("use_reentrant", all_boolean)
+@pytest.mark.parametrize("reset_env_var", [["NVTE_BIAS_GELU_NVFUSION"]], indirect=True)
+@pytest.mark.usefixtures("reset_env_var")
 def test_gpt_full_activation_recompute(
     dtype, bs, model, fp8, recipe, fp8_model_params, use_reentrant
 ):


### PR DESCRIPTION
# Description

Cleanup env variables on test failure to avoid poisoning following tests

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Clean NVTE_BIAS_GELU_NVFUSION in test_numeric:test_gpt_full_activation_recompute
- Clean Attention backend vars in test_fused_attn

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
