### PR TITLE
[Fix] Remove idx tests in test_gemm_autotune

### DIFF
--- a/tests/pytorch/test_gemm_autotune.py
+++ b/tests/pytorch/test_gemm_autotune.py
@@ -97,36 +97,7 @@ def test_gemm_autotune():
             assert (str(ws_min), str(ws_max)) == (algos[0]["ws_min"], algos[0]["ws_max"]), "Invalid WS size"
         else:
             warnings.warn("Cached algo Workspace size is 0")
-
-        #Modify algo index
-        algo_index = int(algo0["aidx"])
-        algos=[copy.copy(algo0)]
-        algos[0]["aidx"] = str(algo_index + 1);
-        write_storage(fname, head, algos)
-        subprocess.run(run_args)
-        algos = read_storage(ofile)
-        assert len(algos)==1, "Expected 1 cached record"
-        assert (algo0["aidx"], algo0["algo_id"]) == (algos[0]["aidx"], algos[0]["algo_id"]), "Invalid algo IDX"
-
-        # Configure autotune range so current cached algo is out of it 
-        # and cache new value
-        os.environ["TE_HIPBLASLT_ALGO_LOAD"] = ""
-        os.environ["TE_HIPBLASLT_ALGO_SAVE"] = fname
-        os.environ["TE_HIPBLASLT_ALGO_SELECTION"] = str(algo_index + 1)
-        subprocess.run(run_args)
-        algos = read_storage(fname)
-        assert len(algos)==1, "Expected 1 cached record"
-        algo1 = copy.copy(algos[0])
-        assert algo0["algo_id"] != algo1["algo_id"], "Unexpected algo ID"
-
-        #Restore autotune range begining, the new algo should still be used
-        os.environ["TE_HIPBLASLT_ALGO_LOAD"] = fname
-        del os.environ["TE_HIPBLASLT_ALGO_SELECTION"]
-        subprocess.run(run_args)
-        algos = read_storage(fname)
-        assert len(algos)==1, "Expected 1 cached record"
-        assert algo1 == algos[0], "Invalid algo ID"
-
+            
     finally:
         shutil.rmtree(storage_dir)
         pass


### PR DESCRIPTION
# Description

Removed tests related to idx in test_gemm_autotune as the tests are not required after this commit (https://github.com/ROCm/TransformerEngine/commit/1139bc14a2b627bd725606f78a8214ec015295ff)

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Removed tests related to idx in test_gemm_autotune.py

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
