### PR TITLE
Bump AITER version

### DIFF
--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn.hpp
@@ -71,7 +71,7 @@ hipError_t ck_attn_varlen_fwd(
   uint64_t stride_h_k, uint64_t stride_s_k,
   const void* v_ptr, 
   uint64_t stride_h_v, uint64_t stride_s_v,
-  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  void* cu_seqlen_q_ptr, void* cu_seqlen_kv_ptr,
   bool is_training,
   float scaling_factor,
   float dropout_probability,

--- a/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn_utils.hpp
+++ b/transformer_engine/common/ck_fused_attn/include/ck_fused_attn/ck_fused_attn_utils.hpp
@@ -52,6 +52,7 @@ enum class BiasType;
 std::string get_data_type_str(DType dtype);
 BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
 std::pair<bias_enum, BiasShape> get_ck_bias_type_shape(BiasType attn_bias_type, uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+std::string get_gfx();
 void set_aiter_asm_dir();
 
 }//namespace ck_fused_attn

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -11,7 +11,7 @@
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "ck_tile/host.hpp"
 #include "mha_bwd.h"
-#include "ck_fused_attn_utils.hpp"
+#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
 
 namespace ck_fused_attn{
 

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_bwd.cpp
@@ -11,7 +11,7 @@
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "ck_tile/host.hpp"
 #include "mha_bwd.h"
-#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
+#include "ck_fused_attn_utils.hpp"
 
 namespace ck_fused_attn{
 
@@ -920,8 +920,8 @@ hipError_t ck_attn_varlen_bwd(
                          cu_seqlen_q_ptr,//cu_seqlen_q
                          cu_seqlen_kv_ptr,//cu_seqlen_kv
                          nullptr, /* seqlen_k_ptr */
-                         0, //seqlen_q, unused in group mode
-                         0, //seqlen_kv, unused in group mode
+                         max_seqlen_q, //seqlen_q, unused in group mode
+                         max_seqlen_k, //seqlen_kv, unused in group mode
                          batch,
                          max_seqlen_q,
                          max_seqlen_k,

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
@@ -206,12 +206,16 @@ hipError_t ck_attn_fwd(
                          k_ptr,
                          v_ptr,
                          bias_type==bias_enum::alibi? alibi_slope_ptr :bias_ptr,
-                         nullptr,//rand_val_ptr
+                         nullptr, //rand_val_ptr
                          lse_ptr,
                          o_ptr,
-                         nullptr,//cu_seqlen_q
-                         nullptr,//cu_seqlen_kv
-                         nullptr, /* seqlen_k_ptr */
+                         nullptr, //cu_seqlen_q
+                         nullptr, //cu_seqlen_kv
+                         nullptr, // seqstart_q_ptr
+                         nullptr, // seqstart_k_ptr
+                         nullptr, // seqlen_k_ptr
+                         nullptr, // seqstart_padded_q_ptr
+                         nullptr, // seqstart_padded_k_ptr
                          max_seqlen_q,
                          max_seqlen_k,
                          batch,
@@ -285,7 +289,7 @@ hipError_t ck_attn_varlen_fwd(
   uint64_t stride_h_k, uint64_t stride_s_k,
   const void* v_ptr, 
   uint64_t stride_h_v, uint64_t stride_s_v,
-  const void* cu_seqlen_q_ptr, const void* cu_seqlen_kv_ptr,
+  void* cu_seqlen_q_ptr, void* cu_seqlen_kv_ptr,
   bool is_training,
   float scaling_factor,
   float dropout_probability,
@@ -308,6 +312,8 @@ hipError_t ck_attn_varlen_fwd(
   ck_tile::index_t nhead_k = hg;
   ck_tile::index_t hdim_v = d_v;
   ck_tile::index_t max_seqlen_q = s_q;
+  ck_tile::index_t total_seqlen_q = static_cast<ck_tile::index_t*>(cu_seqlen_q_ptr)[b];
+  ck_tile::index_t total_seqlen_kv =  static_cast<ck_tile::index_t*>(cu_seqlen_kv_ptr)[b];
 
   float scale_s = scaling_factor;
   float scale_p = 1.f;
@@ -379,11 +385,15 @@ hipError_t ck_attn_varlen_fwd(
                          nullptr,//rand_val_ptr
                          lse_thd_ptr,
                          o_ptr,
-                         cu_seqlen_q_ptr,//cu_seqlen_q
-                         cu_seqlen_kv_ptr,//cu_seqlen_kv
-                         nullptr, /* seqlen_k_ptr */
-                         0, //seqlen_q, unused in group mode
-                         0, //seqlen_kv, unused in group mode
+                         nullptr,//cu_seqlen_q
+                         nullptr,//cu_seqlen_kv
+                         cu_seqlen_q_ptr, // seqstart_q_ptr
+                         cu_seqlen_kv_ptr, // seqstart_k_ptr
+                         nullptr, // seqlen_k_ptr
+                         nullptr, // seqstart_padded_q_ptr
+                         nullptr, // seqstart_padded_k_ptr
+                         total_seqlen_q, //seqlen_q, unused in group mode
+                         total_seqlen_kv, //seqlen_kv, unused in group mode
                          batch,
                          max_seqlen_q,
                          hdim_q,

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
@@ -11,7 +11,7 @@
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "ck_tile/host.hpp"
 #include "mha_fwd.h"
-#include "ck_fused_attn_utils.hpp"
+#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
 
 namespace ck_fused_attn{
 

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_fwd.cpp
@@ -11,7 +11,7 @@
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "ck_tile/host.hpp"
 #include "mha_fwd.h"
-#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
+#include "ck_fused_attn_utils.hpp"
 
 namespace ck_fused_attn{
 

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -8,7 +8,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <mutex> //once_flag
-#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
+#include "ck_fused_attn_utils.hpp"
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "mask.hpp"
 #include "bias.hpp"
@@ -16,29 +16,27 @@
 
 namespace ck_fused_attn{
 
-
-std::string get_gfx(){
-  hipDeviceProp_t prop;
-  hipError_t res= hipGetDeviceProperties(&prop, 0);
-  if (res != hipSuccess) {
-    throw std::runtime_error(std::string(
-      "hipGetDeviceProperties failed with error: ") + hipGetErrorString(res));
-  }
-  switch (prop.major*10 + prop.minor) {
-    case 94: // Gfx942
-      return "gfx942"; 
-    case 95: // Gfx950
-      return "gfx950";
-    default:
-      return "";
-  }
-
-}
 void set_aiter_asm_dir() {
   static std::once_flag aiter_asm_dir_once;
   std::call_once(aiter_asm_dir_once, []() {
-    // trailing slash is mandatory
-    std::string arh_str = get_gfx() + "/";
+    hipDeviceProp_t prop;
+    hipError_t res= hipGetDeviceProperties(&prop, 0);
+    if (res != hipSuccess) {
+      throw std::runtime_error(std::string(
+        "hipGetDeviceProperties failed with error: ") + hipGetErrorString(res));
+    }
+    const char *arh_str = nullptr;
+    switch (prop.major*10 + prop.minor) {
+      case 94: // Gfx942
+        arh_str = "gfx942/"; // trailing slash is mandatory
+        break;
+      case 95: // Gfx950
+        arh_str = "gfx950/"; // trailing slash is mandatory
+        break;
+      default:
+        // Unsupported V3 architecture
+        return;
+    }
     Dl_info info;
     dladdr((void*)set_aiter_asm_dir, &info);
     setenv("AITER_ASM_DIR",

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -8,7 +8,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <mutex> //once_flag
-#include "ck_fused_attn_utils.hpp"
+#include "../include/ck_fused_attn/ck_fused_attn_utils.hpp"
 #include "ck_fused_attn/ck_fused_attn.hpp"
 #include "mask.hpp"
 #include "bias.hpp"
@@ -16,27 +16,28 @@
 
 namespace ck_fused_attn{
 
+
+std::string get_gfx(){
+  hipDeviceProp_t prop;
+  hipError_t res= hipGetDeviceProperties(&prop, 0);
+  if (res != hipSuccess) {
+    throw std::runtime_error(std::string(
+      "hipGetDeviceProperties failed with error: ") + hipGetErrorString(res));
+  }
+  switch (prop.major*10 + prop.minor) {
+    case 94: // Gfx942
+      return "gfx942/"; // trailing slash is mandatory
+    case 95: // Gfx950
+      return "gfx950/"; // trailing slash is mandatory
+    default:
+      return "";
+  }
+
+}
 void set_aiter_asm_dir() {
   static std::once_flag aiter_asm_dir_once;
   std::call_once(aiter_asm_dir_once, []() {
-    hipDeviceProp_t prop;
-    hipError_t res= hipGetDeviceProperties(&prop, 0);
-    if (res != hipSuccess) {
-      throw std::runtime_error(std::string(
-        "hipGetDeviceProperties failed with error: ") + hipGetErrorString(res));
-    }
-    const char *arh_str = nullptr;
-    switch (prop.major*10 + prop.minor) {
-      case 94: // Gfx942
-        arh_str = "gfx942/"; // trailing slash is mandatory
-        break;
-      case 95: // Gfx950
-        arh_str = "gfx950/"; // trailing slash is mandatory
-        break;
-      default:
-        // Unsupported V3 architecture
-        return;
-    }
+    std::string arh_str = get_gfx();
     Dl_info info;
     dladdr((void*)set_aiter_asm_dir, &info);
     setenv("AITER_ASM_DIR",

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.cpp
@@ -26,9 +26,9 @@ std::string get_gfx(){
   }
   switch (prop.major*10 + prop.minor) {
     case 94: // Gfx942
-      return "gfx942/"; // trailing slash is mandatory
+      return "gfx942"; 
     case 95: // Gfx950
-      return "gfx950/"; // trailing slash is mandatory
+      return "gfx950";
     default:
       return "";
   }
@@ -37,7 +37,8 @@ std::string get_gfx(){
 void set_aiter_asm_dir() {
   static std::once_flag aiter_asm_dir_once;
   std::call_once(aiter_asm_dir_once, []() {
-    std::string arh_str = get_gfx();
+    // trailing slash is mandatory
+    std::string arh_str = get_gfx() + "/";
     Dl_info info;
     dladdr((void*)set_aiter_asm_dir, &info);
     setenv("AITER_ASM_DIR",

--- a/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
+++ b/transformer_engine/common/ck_fused_attn/src/ck_fused_attn_utils.hpp
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * License for AMD contributions = MIT. See LICENSE for more information
+ ************************************************************************/
+
+#ifndef CK_FUSED_ATTN_UTILS_H
+#define CK_FUSED_ATTN_UTILS_H
+
+#include<iostream>
+#include<cstdint>
+
+//forward declaration for ck_tile enum
+enum class mask_enum;
+//forward declaration for ck_tile enum
+enum class bias_enum;
+
+namespace ck_fused_attn{
+
+#define CK_FUSED_ATTN_TYPE_SWITCH_16BIT(dtype, type, ...)   \
+switch (dtype) {                                            \
+  case DType::kFloat16: {                                   \
+    using type = ck_tile::half_t;                           \
+    __VA_ARGS__;                                            \
+    break;                                                  \
+  }                                                         \
+  case DType::kBFloat16: {                                  \
+    using type = ck_tile::bf16_t;                           \
+    __VA_ARGS__;                                            \
+    break;                                                  \
+  }                                                         \
+  default:                                                  \
+    throw std::runtime_error("Invalid type for 16 bit..");  \
+}
+
+// element-wise bias shape
+enum class BiasShape{
+  k11SS = 0,
+  k1HSS = 1,
+  kB1SS = 2,
+  kBHSS = 3,
+  kNumBiasShapes  /*!< Number of supported bias shapes */
+};
+
+//forward declaration of ck_fused_attn::DType
+enum class DType ;
+//forward declaration of ck_fused_attn::MaskType
+enum class MaskType;
+//forward declaration of ck_fused_attn::BiasType
+enum class BiasType;
+
+std::string get_data_type_str(DType dtype);
+BiasShape get_bias_shape(uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+std::pair<bias_enum, BiasShape> get_ck_bias_type_shape(BiasType attn_bias_type, uint64_t b, uint64_t h, uint64_t bias_b, uint64_t bias_h);
+void set_aiter_asm_dir();
+
+}//namespace ck_fused_attn
+#endif // CK_FUSED_ATTN_UTILS_H

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -9,6 +9,7 @@
 #include <numeric> // Required for std::accumulate
 #ifdef USE_FUSED_ATTN_CK
 #include <ck_fused_attn/ck_fused_attn.hpp>
+#include "../ck_fused_attn/include/ck_fused_attn/ck_fused_attn_utils.hpp"
 #endif // USE_FUSED_ATTN_CK
 #include "../util/cuda_runtime.h"
 #include "../util/system.h"
@@ -1046,6 +1047,23 @@ void fused_attn_ck_bwd_impl(
   // bwd v3 is optional by enabling the following envs
   // default values follows the ck example setting
   bool nvte_ck_uses_bwd_v3 = getenv<int>("NVTE_CK_USES_BWD_V3", 0);
+
+  // TODO(micky774): Remove when AITER gfx950 BWD V3 kernels are fixed
+  // See AITER gh-1026 for details
+  ck_fused_attn::MaskType ck_mask_type = set_ck_mask(mask_type, window_size_left, window_size_right);
+  nvte_ck_uses_bwd_v3 &= (
+    ck_fused_attn::get_gfx() == "gfx950" &&
+    (devPtrAlibiSlope == nullptr) &&
+    (bias_type==NVTE_Bias_Type::NVTE_NO_BIAS) &&
+    (devPtrdBias==nullptr) &&
+    (dropout_probability == 0.0) &&
+    (!deterministic) &&
+    (d_qk == d_v) &&
+    (h % hg == 0) &&
+    (d_qk > 64 and d_qk <= 128 and d_qk % 8 == 0) &&
+    ((ck_mask_type==ck_fused_attn::MaskType::no_mask) || (s_q == s_kv))
+  );
+
   bool nvte_ck_is_v3_atomic_fp32 = getenv<int>("NVTE_CK_IS_V3_ATOMIC_FP32", 1);
   int nvte_ck_how_v3_bf16_cvt = getenv<int>("NVTE_CK_HOW_V3_BF16_CVT", 1);
   if (nvte_log_ck_config) {

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -559,6 +559,15 @@ void fused_attn_ck_fwd_impl(
   bool nvte_ck_uses_fwd_v3 = getenv<int>("NVTE_CK_USES_FWD_V3", 0);
   bool is_ragged = nvte_get_qkv_format(layout)==NVTE_QKV_Format::NVTE_THD;
 
+
+  // TODO(micky774): Remove when AITER FWD V3 varlen kernels are fixed
+  if(
+    (is_ragged || pad_between_seqs) &&
+    (window_size_left>0 || window_size_right>0)
+  ){
+    nvte_ck_uses_fwd_v3 = false;
+  }
+
   // extract the qkv and o storage bytes to allocate buffer for padding removing
   // b from cu_seqlen is not the actual storage batch for pad_between_seqs case
   size_t q_storage_bytes = max_tokens_q*h*d_qk*nvte_dtype_size(dtype); 

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -9,7 +9,6 @@
 #include <numeric> // Required for std::accumulate
 #ifdef USE_FUSED_ATTN_CK
 #include <ck_fused_attn/ck_fused_attn.hpp>
-#include "../ck_fused_attn/include/ck_fused_attn/ck_fused_attn_utils.hpp"
 #endif // USE_FUSED_ATTN_CK
 #include "../util/cuda_runtime.h"
 #include "../util/system.h"
@@ -1051,8 +1050,8 @@ void fused_attn_ck_bwd_impl(
   // TODO(micky774): Remove when AITER gfx950 BWD V3 kernels are fixed
   // See AITER gh-1026 for details
   ck_fused_attn::MaskType ck_mask_type = set_ck_mask(mask_type, window_size_left, window_size_right);
-  nvte_ck_uses_bwd_v3 &= !(
-    ck_fused_attn::get_gfx() == "gfx950" &&
+  bool needs_gfx950_workaround = (
+    cuda::sm_arch(0)==95 &&
     (devPtrAlibiSlope == nullptr) &&
     (bias_type==NVTE_Bias_Type::NVTE_NO_BIAS) &&
     (devPtrdBias==nullptr) &&
@@ -1063,6 +1062,13 @@ void fused_attn_ck_bwd_impl(
     (d_qk > 64 and d_qk <= 128 and d_qk % 8 == 0) &&
     ((ck_mask_type==ck_fused_attn::MaskType::no_mask) || (s_q == s_kv))
   );
+  needs_gfx950_workaround = false;
+  if(needs_gfx950_workaround){
+    if(nvte_log_ck_config){
+      std::cout << "Disabling BWD V3 kernels due to known AITER issues." << std::endl;
+    }
+    nvte_ck_uses_bwd_v3 = false;
+  }
 
   bool nvte_ck_is_v3_atomic_fp32 = getenv<int>("NVTE_CK_IS_V3_ATOMIC_FP32", 1);
   int nvte_ck_how_v3_bf16_cvt = getenv<int>("NVTE_CK_HOW_V3_BF16_CVT", 1);
@@ -1098,6 +1104,7 @@ void fused_attn_ck_bwd_impl(
     std::cout<<"deterministic: "<<deterministic<<", ";
     std::cout<<"nvte_ck_uses_bwd_v3: "<<nvte_ck_uses_bwd_v3<<", ";
     std::cout<<"nvte_ck_is_v3_atomic_fp32: "<<nvte_ck_is_v3_atomic_fp32<<", ";
+    std::cout<<"needs_gfx950_workaround: "<<needs_gfx950_workaround<<", ";
     std::cout<<"nvte_ck_how_v3_bf16_cvt: "<<nvte_ck_how_v3_bf16_cvt<<std::endl;
   }
   if(pad_between_seqs){

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -1051,7 +1051,7 @@ void fused_attn_ck_bwd_impl(
   // TODO(micky774): Remove when AITER gfx950 BWD V3 kernels are fixed
   // See AITER gh-1026 for details
   ck_fused_attn::MaskType ck_mask_type = set_ck_mask(mask_type, window_size_left, window_size_right);
-  nvte_ck_uses_bwd_v3 &= (
+  nvte_ck_uses_bwd_v3 &= !(
     ck_fused_attn::get_gfx() == "gfx950" &&
     (devPtrAlibiSlope == nullptr) &&
     (bias_type==NVTE_Bias_Type::NVTE_NO_BIAS) &&


### PR DESCRIPTION
# Description

As part of work on https://github.com/ROCm/frameworks-internal/issues/13982 this PR bumps AITER to its at-the-time `main` (`23a0e9`) so that future work can be done off of this PR, synchronizing the various integration work. In particular, this PR also _disables_ some new FWD V3 varlen configs (they were not previously enabled, so this is not a regression) pending AITER fixes.

This will also unblock https://github.com/ROCm/TransformerEngine/pull/327

Towards https://github.com/ROCm/frameworks-internal/issues/13982

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
