### PR TITLE
MXFP8 test scale off by 1 fix

### DIFF
--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ if(USE_CUDA)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   project(transformer_engine_tests LANGUAGES CUDA CXX)
 else()
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   project(transformer_engine_tests LANGUAGES HIP CXX)
   # Ask hcc to generate device code during compilation so we can use
   # host linker to link.

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ if(USE_CUDA)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   project(transformer_engine_tests LANGUAGES CUDA CXX)
 else()
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 17)
   project(transformer_engine_tests LANGUAGES HIP CXX)
   # Ask hcc to generate device code during compilation so we can use
   # host linker to link.

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -320,7 +320,7 @@ void performTest_x1(const ProcessingMethod processing_method,
                                 unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, rowwise, mismatch_idx);
 
         if (mismatch_idx.size()) {
-            adjust_ref<OutputType>(mismatch_idx, ref_output_c.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+            adjust_ref(mismatch_idx, ref_output_c.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols, otype);
         }
 
         auto [atol, rtol] = getTolerances(otype);
@@ -339,7 +339,7 @@ void performTest_x1(const ProcessingMethod processing_method,
     compare_e8m0_scaling_factors("scales", gpu_scales_ptr, ref_output_scales.get(),
                                  unpadded_blocks_Y, unpadded_blocks_X, scales_stride);
     }
-    
+
     if (processing_method == ProcessingMethod::CAST_DBIAS || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
         if (itype == DType::kFloat32) {
@@ -479,14 +479,14 @@ void performTest_x2(const ProcessingMethod processing_method,
                                 unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
 
         if (mismatch_idx_r.size()) {
-            adjust_ref<OutputType>(mismatch_idx_r, ref_output_c_rowwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
+            adjust_ref(mismatch_idx_r, ref_output_c_rowwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols, otype);
         }
         std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
         compare_e8m0_scaling_factors("scales_colwise", output, ref_scales_colwise.get(),
                                 unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
 
         if (mismatch_idx_c.size()) {
-            adjust_ref<OutputType>(mismatch_idx_c, ref_output_c_colwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
+            adjust_ref(mismatch_idx_c, ref_output_c_colwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols, otype);
         }
 
         auto [atol, rtol] = getTolerances(otype);

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -76,12 +76,12 @@ void scale_block(const ProcessingMethod processing_method,
                 continue;
             }
             amax = std::max(amax, std::abs(elt));
-#else
+#else // #ifdef __HIP_PLATFORM_AMD__
             if (std::isinf(elt) || std::isnan(elt)) {
                 continue;
             }
             amax = fmaxf(amax, fabsf(elt));
-#endif
+#endif // #ifdef __HIP_PLATFORM_AMD__
         }
     }
 
@@ -312,6 +312,12 @@ void performTest_x1(const ProcessingMethod processing_method,
                                               block_size_cols,
                                               scales_stride);
 
+    
+#ifdef __HIP_PLATFORM_AMD__
+compare_mxfp8_results("scales", ref_output_scales.get(), unpadded_blocks_Y, 
+                           unpadded_blocks_X, scales_stride, "output_c", 
+                           output_c, ref_output_c.get(), rowwise, rows, cols);
+#else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
 
@@ -321,6 +327,7 @@ void performTest_x1(const ProcessingMethod processing_method,
 
     compare_e8m0_scaling_factors("scales", gpu_scales_ptr, ref_output_scales.get(),
                                  unpadded_blocks_Y, unpadded_blocks_X, scales_stride);
+#endif // #ifdef __HIP_PLATFORM_AMD__
 
     if (processing_method == ProcessingMethod::CAST_DBIAS || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
@@ -454,7 +461,14 @@ void performTest_x2(const ProcessingMethod processing_method,
                                               block_size_cols,
                                               scales_stride_rowwise,
                                               scales_stride_colwise);
-
+#ifdef __HIP_PLATFORM_AMD__
+    compare_mxfp8_results("scales_rowwise", ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise, 
+                           unpadded_blocks_X_rowwise, scales_stride_rowwise, "output_c_rowwise", 
+                           output, ref_output_c_rowwise.get(), true, rows, cols);
+    compare_mxfp8_results("scales_colwise", ref_scales_colwise.get(), unpadded_blocks_Y_colwise, 
+                           unpadded_blocks_X_colwise, scales_stride_colwise, "output_c_colwise", 
+                           output, ref_output_c_colwise.get(), false, rows, cols);
+#else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);
     compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol);
@@ -464,6 +478,7 @@ void performTest_x2(const ProcessingMethod processing_method,
     compare_e8m0_scaling_factors("scales_colwise", output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
                                  ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
                                  unpadded_blocks_X_colwise, scales_stride_colwise);
+#endif // #ifdef __HIP_PLATFORM_AMD__
 
     if (processing_method == ProcessingMethod::CAST_DBIAS || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
@@ -563,7 +578,7 @@ TEST_P(FusedCastMXFP8TestSuite, TestFusedCastMXFP8) {
     if (getDeviceComputeCapability() < blackwellComputeCapability) {
         GTEST_SKIP();
     }
-#endif
+#endif // #ifdef __HIP_PLATFORM_AMD__
 
     using namespace transformer_engine;
     using namespace test;

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -314,9 +314,17 @@ void performTest_x1(const ProcessingMethod processing_method,
 
     
 #ifdef __HIP_PLATFORM_AMD__
-compare_mxfp8_results("scales", ref_output_scales.get(), unpadded_blocks_Y, 
-                           unpadded_blocks_X, scales_stride, "output_c", 
-                           output_c, ref_output_c.get(), rowwise, rows, cols);
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx;
+    compare_e8m0_scaling_factors("scales", output_c, ref_output_scales.get(),
+                             unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, rowwise, mismatch_idx);
+
+    if (mismatch_idx.size()) {
+        adjust_ref<OutputType>(mismatch_idx, ref_output_c.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+    }
+
+    auto [atol, rtol] = getTolerances(otype);
+    compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
+    
 #else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
@@ -462,12 +470,24 @@ void performTest_x2(const ProcessingMethod processing_method,
                                               scales_stride_rowwise,
                                               scales_stride_colwise);
 #ifdef __HIP_PLATFORM_AMD__
-    compare_mxfp8_results("scales_rowwise", ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise, 
-                           unpadded_blocks_X_rowwise, scales_stride_rowwise, "output_c_rowwise", 
-                           output, ref_output_c_rowwise.get(), true, rows, cols);
-    compare_mxfp8_results("scales_colwise", ref_scales_colwise.get(), unpadded_blocks_Y_colwise, 
-                           unpadded_blocks_X_colwise, scales_stride_colwise, "output_c_colwise", 
-                           output, ref_output_c_colwise.get(), false, rows, cols);
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_r;
+    compare_e8m0_scaling_factors("scales_rowwise", output, ref_scales_rowwise.get(),
+                             unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
+
+    if (mismatch_idx_r.size()) {
+        adjust_ref<OutputType>(mismatch_idx_r, ref_output_c_rowwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
+    }
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
+    compare_e8m0_scaling_factors("scales_colwise", output, ref_scales_colwise.get(),
+                             unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
+
+    if (mismatch_idx_c.size()) {
+        adjust_ref<OutputType>(mismatch_idx_c, ref_output_c_colwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
+    }
+
+    auto [atol, rtol] = getTolerances(otype);
+    compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);
+    compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol);
 #else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -314,18 +314,21 @@ void performTest_x1(const ProcessingMethod processing_method,
 
     
 #ifdef __HIP_PLATFORM_AMD__
-    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx;
-    compare_e8m0_scaling_factors("scales", output_c, ref_output_scales.get(),
-                             unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, rowwise, mismatch_idx);
+    if (processing_method != ProcessingMethod::CAST_ONLY) {
+        std::vector<std::tuple<size_t, size_t, int>> mismatch_idx;
+        compare_e8m0_scaling_factors("scales", output_c, ref_output_scales.get(),
+                                unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, rowwise, mismatch_idx);
 
-    if (mismatch_idx.size()) {
-        adjust_ref<OutputType>(mismatch_idx, ref_output_c.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+        if (mismatch_idx.size()) {
+            adjust_ref<OutputType>(mismatch_idx, ref_output_c.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+        }
+
+        auto [atol, rtol] = getTolerances(otype);
+        compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
     }
-
-    auto [atol, rtol] = getTolerances(otype);
-    compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
-    
-#else // #ifdef __HIP_PLATFORM_AMD__
+    else
+#endif // #ifdef __HIP_PLATFORM_AMD__
+    {
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol);
 
@@ -335,8 +338,8 @@ void performTest_x1(const ProcessingMethod processing_method,
 
     compare_e8m0_scaling_factors("scales", gpu_scales_ptr, ref_output_scales.get(),
                                  unpadded_blocks_Y, unpadded_blocks_X, scales_stride);
-#endif // #ifdef __HIP_PLATFORM_AMD__
-
+    }
+    
     if (processing_method == ProcessingMethod::CAST_DBIAS || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
         if (itype == DType::kFloat32) {
@@ -470,25 +473,28 @@ void performTest_x2(const ProcessingMethod processing_method,
                                               scales_stride_rowwise,
                                               scales_stride_colwise);
 #ifdef __HIP_PLATFORM_AMD__
-    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_r;
-    compare_e8m0_scaling_factors("scales_rowwise", output, ref_scales_rowwise.get(),
-                             unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
+    if (processing_method != ProcessingMethod::CAST_ONLY) {
+        std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_r;
+        compare_e8m0_scaling_factors("scales_rowwise", output, ref_scales_rowwise.get(),
+                                unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
 
-    if (mismatch_idx_r.size()) {
-        adjust_ref<OutputType>(mismatch_idx_r, ref_output_c_rowwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
-    }
-    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
-    compare_e8m0_scaling_factors("scales_colwise", output, ref_scales_colwise.get(),
-                             unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
+        if (mismatch_idx_r.size()) {
+            adjust_ref<OutputType>(mismatch_idx_r, ref_output_c_rowwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
+        }
+        std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
+        compare_e8m0_scaling_factors("scales_colwise", output, ref_scales_colwise.get(),
+                                unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
 
-    if (mismatch_idx_c.size()) {
-        adjust_ref<OutputType>(mismatch_idx_c, ref_output_c_colwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
-    }
+        if (mismatch_idx_c.size()) {
+            adjust_ref<OutputType>(mismatch_idx_c, ref_output_c_colwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
+        }
 
-    auto [atol, rtol] = getTolerances(otype);
-    compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);
-    compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol);
-#else // #ifdef __HIP_PLATFORM_AMD__
+        auto [atol, rtol] = getTolerances(otype);
+        compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);
+        compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol);
+    } else
+#endif // #ifdef __HIP_PLATFORM_AMD__
+    {
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol);
     compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol);
@@ -498,7 +504,7 @@ void performTest_x2(const ProcessingMethod processing_method,
     compare_e8m0_scaling_factors("scales_colwise", output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
                                  ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
                                  unpadded_blocks_X_colwise, scales_stride_colwise);
-#endif // #ifdef __HIP_PLATFORM_AMD__
+    }
 
     if (processing_method == ProcessingMethod::CAST_DBIAS || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);

--- a/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
@@ -272,7 +272,7 @@ void performTest_x1(const size_t rows,
                                    unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, false, mismatch_idx);
     }
     if (mismatch_idx.size()) {
-        adjust_ref<OType>(mismatch_idx, ref_output.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+        adjust_ref(mismatch_idx, ref_output.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols, otype);
     }
 
     auto [atol, rtol] = getTolerances(otype);
@@ -384,7 +384,7 @@ void performTest_x2(const size_t rows,
                                  unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
 
     if (mismatch_idx_r.size()) {
-        adjust_ref<OType>(mismatch_idx_r, ref_output_colwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
+        adjust_ref(mismatch_idx_r, ref_output_colwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols, otype);
     }
 
     std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
@@ -393,7 +393,7 @@ void performTest_x2(const size_t rows,
                                  unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
 
     if (mismatch_idx_c.size()) {
-        adjust_ref<OType>(mismatch_idx_c, ref_output_rowwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
+        adjust_ref(mismatch_idx_c, ref_output_rowwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols, otype);
     }
 
     auto [atol, rtol] = getTolerances(otype);

--- a/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
@@ -263,15 +263,20 @@ void performTest_x1(const size_t rows,
                                             block_size_cols,
                                             scales_stride);
 #ifdef __HIP_PLATFORM_AMD__
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx;
     if (rowwise) {
-        compare_mxfp8_results("rowwise scales", ref_output_scales.get(), unpadded_blocks_Y, 
-                           unpadded_blocks_X, scales_stride, "output", 
-                           output, ref_output.get(), rowwise, rows, cols);
+      compare_e8m0_scaling_factors("rowwise scales", output, ref_output_scales.get(),
+                                   unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, true, mismatch_idx);
     } else {
-        compare_mxfp8_results("colwise scales", ref_output_scales.get(), unpadded_blocks_Y, 
-                           unpadded_blocks_X, scales_stride, "output", 
-                           output, ref_output.get(), rowwise, rows, cols);
+      compare_e8m0_scaling_factors("colwise scales", output, ref_output_scales.get(),
+                                   unpadded_blocks_Y, unpadded_blocks_X, scales_stride, 0.01, false, mismatch_idx);
     }
+    if (mismatch_idx.size()) {
+        adjust_ref<OType>(mismatch_idx, ref_output.get(), unpadded_blocks_Y, unpadded_blocks_X, rows, cols);
+    }
+
+    auto [atol, rtol] = getTolerances(otype);
+    compareResults("output", output, ref_output.get(), rowwise, atol, rtol);
 #else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output", output, ref_output.get(), rowwise, atol, rtol);
@@ -373,12 +378,28 @@ void performTest_x2(const size_t rows,
                                             scales_stride_rowwise,
                                             scales_stride_colwise);
 #ifdef __HIP_PLATFORM_AMD__
-    compare_mxfp8_results("scales_rowwise", ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise, 
-                           unpadded_blocks_X_rowwise, scales_stride_rowwise, "output_c_rowwise", 
-                           output, ref_output_rowwise.get(), true, rows, cols);
-    compare_mxfp8_results("scales_colwise", ref_scales_colwise.get(), unpadded_blocks_Y_colwise, 
-                           unpadded_blocks_X_colwise, scales_stride_colwise, "output_c_colwise", 
-                           output, ref_output_colwise.get(), false, rows, cols);
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_r;
+    compare_e8m0_scaling_factors("scales_rowwise", output,
+                                 ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise,
+                                 unpadded_blocks_X_rowwise, scales_stride_rowwise, 0.01, true, mismatch_idx_r);
+
+    if (mismatch_idx_r.size()) {
+        adjust_ref<OType>(mismatch_idx_r, ref_output_colwise.get(), unpadded_blocks_Y_rowwise, unpadded_blocks_X_rowwise, rows, cols);
+    }
+
+    std::vector<std::tuple<size_t, size_t, int>> mismatch_idx_c;
+    compare_e8m0_scaling_factors("scales_colwise", output,
+                                 ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
+                                 unpadded_blocks_X_colwise, scales_stride_colwise, 0.01, false, mismatch_idx_c);
+
+    if (mismatch_idx_c.size()) {
+        adjust_ref<OType>(mismatch_idx_c, ref_output_rowwise.get(), unpadded_blocks_Y_colwise, unpadded_blocks_X_colwise, rows, cols);
+    }
+
+    auto [atol, rtol] = getTolerances(otype);
+    auto [atol_amax, rtol_amax] = getTolerances(DType::kFloat32);
+    compareResults("output_c_rowwise", output, ref_output_rowwise.get(), true, atol, rtol);
+    compareResults("output_c_colwise", output, ref_output_colwise.get(), false, atol, rtol);
 #else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     auto [atol_amax, rtol_amax] = getTolerances(DType::kFloat32);

--- a/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
@@ -262,7 +262,17 @@ void performTest_x1(const size_t rows,
                                             block_size_rows,
                                             block_size_cols,
                                             scales_stride);
-
+#ifdef __HIP_PLATFORM_AMD__
+    if (rowwise) {
+        compare_mxfp8_results("rowwise scales", ref_output_scales.get(), unpadded_blocks_Y, 
+                           unpadded_blocks_X, scales_stride, "output", 
+                           output, ref_output.get(), rowwise, rows, cols);
+    } else {
+        compare_mxfp8_results("colwise scales", ref_output_scales.get(), unpadded_blocks_Y, 
+                           unpadded_blocks_X, scales_stride, "output", 
+                           output, ref_output.get(), rowwise, rows, cols);
+    }
+#else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     compareResults("output", output, ref_output.get(), rowwise, atol, rtol);
 
@@ -276,6 +286,7 @@ void performTest_x1(const size_t rows,
       compare_e8m0_scaling_factors("colwise scales", gpu_scales_ptr, ref_output_scales.get(),
                                    unpadded_blocks_Y, unpadded_blocks_X, scales_stride);
     }
+#endif // #ifdef __HIP_PLATFORM_AMD__
 }
 
 /**
@@ -361,7 +372,14 @@ void performTest_x2(const size_t rows,
                                             block_size_cols,
                                             scales_stride_rowwise,
                                             scales_stride_colwise);
-
+#ifdef __HIP_PLATFORM_AMD__
+    compare_mxfp8_results("scales_rowwise", ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise, 
+                           unpadded_blocks_X_rowwise, scales_stride_rowwise, "output_c_rowwise", 
+                           output, ref_output_rowwise.get(), true, rows, cols);
+    compare_mxfp8_results("scales_colwise", ref_scales_colwise.get(), unpadded_blocks_Y_colwise, 
+                           unpadded_blocks_X_colwise, scales_stride_colwise, "output_c_colwise", 
+                           output, ref_output_colwise.get(), false, rows, cols);
+#else // #ifdef __HIP_PLATFORM_AMD__
     auto [atol, rtol] = getTolerances(otype);
     auto [atol_amax, rtol_amax] = getTolerances(DType::kFloat32);
     compareResults("output_c_rowwise", output, ref_output_rowwise.get(), true, atol, rtol);
@@ -372,6 +390,7 @@ void performTest_x2(const size_t rows,
     compare_e8m0_scaling_factors("scales_colwise", output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
                                  ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
                                  unpadded_blocks_X_colwise, scales_stride_colwise);
+#endif // #ifdef __HIP_PLATFORM_AMD__
 }
 
 std::vector<std::pair<size_t, size_t>> matrix_sizes = {
@@ -418,12 +437,12 @@ class CastMXFP8_GatedActTestSuite : public ::testing::TestWithParam
 TEST_P(CastMXFP8_GatedActTestSuite, TestCastMXFP8Swiglu) {
  #ifdef __HIP_PLATFORM_AMD__
     omp_set_num_threads(std::min(128, omp_get_max_threads())); // Using threads = # of vcpus causes occasional errors.
-#else
+#else // #ifdef __HIP_PLATFORM_AMD__
    // Skip tests for pre-Blackwell architectures
     if (getDeviceComputeCapability() < blackwellComputeCapability) {
         GTEST_SKIP();
     }
-#endif
+#endif // #ifdef __HIP_PLATFORM_AMD__
 
 
     using namespace transformer_engine;

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -715,9 +715,6 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
 void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const uint8_t *ref,
                              const size_t row_blocks, const size_t col_blocks, const size_t stride, 
                              double tol, bool rowwise, std::vector<std::tuple<size_t, size_t, int>> &mismatch_idx) {
-  constexpr bool on_gpus = true;
-  if (on_gpus) output.to_cpu();
-
   const uint8_t *const test = rowwise ? output.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
                                        : output.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
 
@@ -732,7 +729,7 @@ void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const
         if (std::abs(t_scale - r_scale) == 1) {
           mismatch_idx.emplace_back(i, j, r_scale-t_scale);
         } else {
-          ASSERT_FALSE(1) << "Error in " << name << std::endl
+          GTEST_FAIL() << "Error in " << name << std::endl
           << "Mismatch: " << t_scale << " vs "
           << r_scale << " at index " << idx;
         }

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -754,6 +754,8 @@ void adjust_ref(std::vector<std::tuple<size_t, size_t, int>> mismatch_idx, void 
   TRANSFORMER_ENGINE_TYPE_SWITCH_FP8_ONLY( otype, T,
     T *ref_data = reinterpret_cast<T*>(ref);
     double scale_val;
+    const size_t col_blocks_size = cols / col_blocks;
+    const size_t row_blocks_size = rows / row_blocks;
     for (const auto &[i, j, scale_diff] : mismatch_idx) {
       if (scale_diff == 1) {
         scale_val = 2.;
@@ -762,14 +764,14 @@ void adjust_ref(std::vector<std::tuple<size_t, size_t, int>> mismatch_idx, void 
       } else { // Shouldn't ever reach this
         GTEST_FAIL() << "Error in adjust_ref, |scale_diff| > 1";
       }
-      size_t ii_min = i * col_blocks;
-      const size_t ii_max = std::min(ii_min + col_blocks, rows);
+      size_t ii_min = i * row_blocks_size;
+      const size_t ii_max = std::min(ii_min + row_blocks_size, rows);
       for (; ii_min < ii_max; ii_min++) {
-        size_t jj_min = j * row_blocks;
-        const size_t jj_max = std::min(jj_min + row_blocks, cols);
+        size_t jj_min = j * col_blocks_size;
+        const size_t jj_max = std::min(jj_min + col_blocks_size, cols);
         for (; jj_min < jj_max; jj_min++) {
           const size_t data_idx = ii_min * cols + jj_min;
-          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx]) * scale_val);
+          ref_data[data_idx] = static_cast<T>(static_cast<double>(ref_data[data_idx]) * scale_val);
         }
       }
     }

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -712,110 +712,44 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
 }
 
 #ifdef __HIP_PLATFORM_AMD__
-template <typename T>
-// For amax values near the boundary of a scale, sometimes there is an off by 1 error between ref 
-// and output block scales -- most of the time the values are off by a scale of 2 as well, so there is
-// no accuracy loss, however, tols alone can't cover this when scale and vals are checked separately.
-bool compare_values(const double t, const double r, const double atol, const double rtol) {
-  bool mismatch = fabs(t - r) > atol && (r == 0 || fabs((t - r) / r) > rtol);
-  if (mismatch) {
-    const double mean = (t + r) / 2;
-    const double mean_p = mean >= 0 ? mean * (1 + 1e-6) : mean * (1 - 1e-6);
-    const double mean_m = mean >= 0 ? mean * (1 - 1e-6) : mean * (1 + 1e-6);
-    const double cast_mean_p =
-        static_cast<double>(static_cast<float>(static_cast<T>(static_cast<float>(mean_p))));
-    const double cast_mean_m =
-        static_cast<double>(static_cast<float>(static_cast<T>(static_cast<float>(mean_m))));
-    mismatch = !(cast_mean_m == std::min<double>(t, r) && cast_mean_p == std::max<double>(t, r));
-  }
-  return mismatch;
-}
+void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const uint8_t *ref,
+                             const size_t row_blocks, const size_t col_blocks, const size_t stride, 
+                             double tol, bool rowwise, std::vector<std::tuple<size_t, size_t, int>> &mismatch_idx) {
+  constexpr bool on_gpus = true;
+  if (on_gpus) output.to_cpu();
 
-template <typename T>
-std::pair<size_t, size_t> compare_mxfp8_block(const T *test_data, const T *ref_data, const uint8_t *scale_test, 
-                         const uint8_t *scale_ref, size_t row_blocks, size_t col_blocks, size_t stride,
-                         size_t rows, size_t cols, double atol, double rtol) {
-  size_t first_failure    = (size_t)-1;
-  size_t scale_mismatches = 0;
+  const uint8_t *const test = rowwise ? output.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
+                                       : output.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
 
-  std::function<void(double&)> OP;
+  const float scale_tol = std::max(1.f, row_blocks * col_blocks * tol);
 
-#pragma omp parallel for collapse(2) schedule(dynamic, 8) nonmonotonic reduction(+:scale_mismatches) reduction(first_failure)
   for (int i = 0; i < row_blocks; i++) {
     for (int j = 0; j < col_blocks; j++) {
-      const size_t scale_idx = i * stride + j;
-
-      if (auto comp = scale_test[scale_idx] <=> scale_ref[scale_idx]; 
-        comp == std::strong_ordering::equal) {
-        OP = [](double &x) {};
-      } else if (comp == std::strong_ordering::less) {
-        OP = [](double &x) { x /= 2.0; };
-        scale_mismatches++;
-      } else {
-        OP = [](double &x) { x *= 2.0; };
-        scale_mismatches++;
-      } 
-
-      // Make this more general if upstream blocksize = 32 restriction is lifted
-      size_t ii_min = i * col_blocks;
-      const size_t ii_max = std::min(ii_min + col_blocks, rows);
-      for (; ii_min < ii_max; ii_min++) {
-        size_t jj_min = j * row_blocks;
-        const size_t jj_max = std::min(jj_min + row_blocks, cols);
-        for (; jj_min < jj_max; jj_min++) {
-          const size_t data_idx = ii_min * cols + jj_min;
-          double t = static_cast<double>(static_cast<float>(test_data[data_idx]));
-          double r = static_cast<double>(static_cast<float>(ref_data[data_idx]));
-          OP(t);
-          if (compare_values<T>(t, r, atol, rtol)) first_failure = std::min(first_failure, data_idx);
+      const int idx = i * stride + j;
+      if (test[idx] != ref[idx]) {
+        int t_scale = static_cast<int>(test[idx]);
+        int r_scale = static_cast<int>(ref[idx]);
+        if (std::abs(t_scale - r_scale) == 1) {
+          mismatch_idx.emplace_back(i, j, r_scale-t_scale);
+        } else {
+          ASSERT_FALSE(1) << "Error in " << name << std::endl
+          << "Mismatch: " << t_scale << " vs "
+          << r_scale << " at index " << idx;
         }
       }
     }
   }
-  
-  return {scale_mismatches, first_failure};
-}
+  const size_t scale_mismatches = mismatch_idx.size();
 
-void compare_mxfp8_results(const std::string &scale_name, const uint8_t *scale_ref, const size_t row_blocks, 
-                           const size_t col_blocks, const size_t stride, const std::string &output_name, 
-                           Tensor &output_test, const void *output_ref, const bool rowwise, const size_t rows, 
-                           const size_t cols, const float mismatch_tol, double atol, double rtol, bool if_on_gpus) {
-  if (if_on_gpus) output_test.to_cpu();
-  const auto& shape = rowwise ? output_test.rowwise_shape() : output_test.columnwise_shape();
-  std::string direction = rowwise ? "rowwise" : "columnwise";
-  const size_t N = product(shape);
-  const uint8_t *const scale_test = rowwise
-                                    ? output_test.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
-                                    : output_test.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
-  const float scale_tol = std::max<float>(1.f, (float)N * mismatch_tol);
+  ASSERT_FALSE(scale_mismatches > scale_tol) 
+  << "Error in " << name << std::endl << std::setprecision(4)
+  << "Total scale mismatches: " << scale_mismatches << " (" << 100.*(double)scale_mismatches/(double)(row_blocks*col_blocks)
+  << "%) Exceeds tolerance of " << scale_tol << " (" << 100.*tol <<  "%) mismatches";
 
-  TRANSFORMER_ENGINE_TYPE_SWITCH_ALL(output_test.dtype(), T,
-  const T *test_data = rowwise ? output_test.rowwise_cpu_dptr<T>() : output_test.columnwise_cpu_dptr<T>();
-  const T *ref_data  = reinterpret_cast<const T*>(output_ref);
-
-  auto [scale_mismatches, first_failure] = compare_mxfp8_block<T>(test_data, ref_data, scale_test, scale_ref, 
-                                                       row_blocks, col_blocks, stride, rows, cols, atol, rtol);
-
-  if (first_failure != (size_t)-1) {
-      const double t = static_cast<double>(test_data[first_failure]);
-      const double r = static_cast<double>(ref_data[first_failure]);
-      std::string direction = rowwise ? "rowwise" : "columnwise";
-      ASSERT_FALSE(true) << "Error in tensor " << output_name << " in "
-                         << direction << " direction." << std::endl
-                         << "Mismatch at place " << to_string(unravel(first_failure, shape))
-                         << " (" << std::to_string(first_failure) << "): " << t << " vs " << r;
+  if (scale_mismatches) {
+    std::cout << "\x1b[33mWARNING:\x1b[0m " << scale_mismatches 
+    << " scale mismatches were found. This does not imply an accuracy issue." << std::endl;
     }
-
-    ASSERT_FALSE(scale_mismatches > scale_tol) 
-    << "Error in " << scale_name << std::endl << std::setprecision(4)
-    << "Total scale mismatches: " << scale_mismatches << " (" << 100.*(double)scale_mismatches/(double)(row_blocks*col_blocks)
-    << "%) Exceeds tolerance of " << scale_tol << " (" << 100.*mismatch_tol <<  "%) mismatches";
-
-    if (scale_mismatches) {
-      std::cout << "WARNING: " << scale_mismatches 
-      << " scale mismatches were found. This does not imply an accuracy issue." << std::endl;
-    }
-  ) // NOLINT(*)
 }
 #endif // #ifdef __HIP_PLATFORM_AMD__
 

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -711,6 +711,114 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
   }
 }
 
+#ifdef __HIP_PLATFORM_AMD__
+template <typename T>
+// For amax values near the boundary of a scale, sometimes there is an off by 1 error between ref 
+// and output block scales -- most of the time the values are off by a scale of 2 as well, so there is
+// no accuracy loss, however, tols alone can't cover this when scale and vals are checked separately.
+bool compare_values(const double t, const double r, const double atol, const double rtol) {
+  bool mismatch = fabs(t - r) > atol && (r == 0 || fabs((t - r) / r) > rtol);
+  if (mismatch) {
+    const double mean = (t + r) / 2;
+    const double mean_p = mean >= 0 ? mean * (1 + 1e-6) : mean * (1 - 1e-6);
+    const double mean_m = mean >= 0 ? mean * (1 - 1e-6) : mean * (1 + 1e-6);
+    const double cast_mean_p =
+        static_cast<double>(static_cast<float>(static_cast<T>(static_cast<float>(mean_p))));
+    const double cast_mean_m =
+        static_cast<double>(static_cast<float>(static_cast<T>(static_cast<float>(mean_m))));
+    mismatch = !(cast_mean_m == std::min<double>(t, r) && cast_mean_p == std::max<double>(t, r));
+  }
+  return mismatch;
+}
+
+template <typename T>
+std::pair<size_t, size_t> compare_mxfp8_block(const T *test_data, const T *ref_data, const uint8_t *scale_test, 
+                         const uint8_t *scale_ref, size_t row_blocks, size_t col_blocks, size_t stride,
+                         size_t rows, size_t cols, double atol, double rtol) {
+  size_t first_failure    = (size_t)-1;
+  size_t scale_mismatches = 0;
+
+  std::function<void(double&)> OP;
+
+#pragma omp parallel for collapse(2) schedule(dynamic, 8) nonmonotonic reduction(+:scale_mismatches) reduction(first_failure)
+  for (int i = 0; i < row_blocks; i++) {
+    for (int j = 0; j < col_blocks; j++) {
+      const size_t scale_idx = i * stride + j;
+
+      if (auto comp = scale_test[scale_idx] <=> scale_ref[scale_idx]; 
+        comp == std::strong_ordering::equal) {
+        OP = [](double &x) {};
+      } else if (comp == std::strong_ordering::less) {
+        OP = [](double &x) { x /= 2.0; };
+        scale_mismatches++;
+      } else {
+        OP = [](double &x) { x *= 2.0; };
+        scale_mismatches++;
+      } 
+
+      // Make this more general if upstream blocksize = 32 restriction is lifted
+      size_t ii_min = i * col_blocks;
+      const size_t ii_max = std::min(ii_min + col_blocks, rows);
+      for (; ii_min < ii_max; ii_min++) {
+        size_t jj_min = j * row_blocks;
+        const size_t jj_max = std::min(jj_min + row_blocks, cols);
+        for (; jj_min < jj_max; jj_min++) {
+          const size_t data_idx = ii_min * cols + jj_min;
+          double t = static_cast<double>(static_cast<float>(test_data[data_idx]));
+          double r = static_cast<double>(static_cast<float>(ref_data[data_idx]));
+          OP(t);
+          if (compare_values<T>(t, r, atol, rtol)) first_failure = std::min(first_failure, data_idx);
+        }
+      }
+    }
+  }
+  
+  return {scale_mismatches, first_failure};
+}
+
+void compare_mxfp8_results(const std::string &scale_name, const uint8_t *scale_ref, const size_t row_blocks, 
+                           const size_t col_blocks, const size_t stride, const std::string &output_name, 
+                           Tensor &output_test, const void *output_ref, const bool rowwise, const size_t rows, 
+                           const size_t cols, const float mismatch_tol, double atol, double rtol, bool if_on_gpus) {
+  if (if_on_gpus) output_test.to_cpu();
+  const auto& shape = rowwise ? output_test.rowwise_shape() : output_test.columnwise_shape();
+  std::string direction = rowwise ? "rowwise" : "columnwise";
+  const size_t N = product(shape);
+  const uint8_t *const scale_test = rowwise
+                                    ? output_test.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
+                                    : output_test.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
+  const float scale_tol = std::max<float>(1.f, (float)N * mismatch_tol);
+
+  TRANSFORMER_ENGINE_TYPE_SWITCH_ALL(output_test.dtype(), T,
+  const T *test_data = rowwise ? output_test.rowwise_cpu_dptr<T>() : output_test.columnwise_cpu_dptr<T>();
+  const T *ref_data  = reinterpret_cast<const T*>(output_ref);
+
+  auto [scale_mismatches, first_failure] = compare_mxfp8_block<T>(test_data, ref_data, scale_test, scale_ref, 
+                                                       row_blocks, col_blocks, stride, rows, cols, atol, rtol);
+
+  if (first_failure != (size_t)-1) {
+      const double t = static_cast<double>(test_data[first_failure]);
+      const double r = static_cast<double>(ref_data[first_failure]);
+      std::string direction = rowwise ? "rowwise" : "columnwise";
+      ASSERT_FALSE(true) << "Error in tensor " << output_name << " in "
+                         << direction << " direction." << std::endl
+                         << "Mismatch at place " << to_string(unravel(first_failure, shape))
+                         << " (" << std::to_string(first_failure) << "): " << t << " vs " << r;
+    }
+
+    ASSERT_FALSE(scale_mismatches > scale_tol) 
+    << "Error in " << scale_name << std::endl << std::setprecision(4)
+    << "Total scale mismatches: " << scale_mismatches << " (" << 100.*(double)scale_mismatches/(double)(row_blocks*col_blocks)
+    << "%) Exceeds tolerance of " << scale_tol << " (" << 100.*mismatch_tol <<  "%) mismatches";
+
+    if (scale_mismatches) {
+      std::cout << "WARNING: " << scale_mismatches 
+      << " scale mismatches were found. This does not imply an accuracy issue." << std::endl;
+    }
+  ) // NOLINT(*)
+}
+#endif // #ifdef __HIP_PLATFORM_AMD__
+
 std::pair<double, double> getTolerances(const DType type) {
   switch(type) {
     case DType::kFloat32:

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -748,6 +748,33 @@ void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const
     << " scale mismatches were found. This does not imply an accuracy issue." << std::endl;
     }
 }
+
+void adjust_ref(std::vector<std::tuple<size_t, size_t, int>> mismatch_idx, void *ref, const size_t row_blocks,
+                const size_t col_blocks, const size_t rows, const size_t cols, DType otype) {
+  TRANSFORMER_ENGINE_TYPE_SWITCH_FP8_ONLY( otype, T,
+    T *ref_data = reinterpret_cast<T*>(ref);
+    double scale_val;
+    for (const auto &[i, j, scale_diff] : mismatch_idx) {
+      if (scale_diff == 1) {
+        scale_val = 2.;
+      } else if (scale_diff == -1) {
+        scale_val = .5;
+      } else { // Shouldn't ever reach this
+        GTEST_FAIL() << "Error in adjust_ref, |scale_diff| > 1";
+      }
+      size_t ii_min = i * col_blocks;
+      const size_t ii_max = std::min(ii_min + col_blocks, rows);
+      for (; ii_min < ii_max; ii_min++) {
+        size_t jj_min = j * row_blocks;
+        const size_t jj_max = std::min(jj_min + row_blocks, cols);
+        for (; jj_min < jj_max; jj_min++) {
+          const size_t data_idx = ii_min * cols + jj_min;
+          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx]) * scale_val);
+        }
+      }
+    }
+  ); // NOLINT(*)
+}
 #endif // #ifdef __HIP_PLATFORM_AMD__
 
 std::pair<double, double> getTolerances(const DType type) {

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -19,6 +19,7 @@
 #else
 #include <hip/hip_bfloat16.h>
 #include "amd_detail/hip_float8.h"
+#include <gtest/gtest.h>
 #endif
 #include <cuda_runtime_api.h>
 
@@ -462,11 +463,32 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
 void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, const uint8_t *ref,
                                   const size_t N);
 #ifdef USE_ROCM
-void compare_mxfp8_results(const std::string &scale_name, const uint8_t *scale_ref, const size_t row_blocks, 
-                           const size_t col_blocks, const size_t stride, const std::string &output_name, 
-                           Tensor &output_test, const void *output_ref, const bool rowwise, 
-                           const size_t rows, const size_t cols, const float mismatch_tol = .01f, 
-                           double atol = 1e-2, double rtol = 1e-2, bool if_on_gpus = true);
+void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const uint8_t *ref,
+                             const size_t row_blocks, const size_t col_blocks, const size_t stride, 
+                             double tol, bool rowwise, std::vector<std::tuple<size_t, size_t, int>> &mismatch_idx);
+template <typename T>
+void adjust_ref(std::vector<std::tuple<size_t, size_t, int>> mismatch_idx, void *ref, const size_t row_blocks,
+                const size_t col_blocks, const size_t rows, const size_t cols) {
+  T *ref_data = reinterpret_cast<T*>(ref);
+  for (const auto &[i, j, scale_diff] : mismatch_idx) {
+    size_t ii_min = i * col_blocks;
+    const size_t ii_max = std::min(ii_min + col_blocks, rows);
+    for (; ii_min < ii_max; ii_min++) {
+      size_t jj_min = j * row_blocks;
+      const size_t jj_max = std::min(jj_min + row_blocks, cols);
+      for (; jj_min < jj_max; jj_min++) {
+        const size_t data_idx = ii_min * cols + jj_min;
+        if (scale_diff == 1) {
+          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx])*2);
+        } else if (scale_diff == -1) {
+          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx])/2);
+        } else { // Shouldn't ever reach this
+          ASSERT_FALSE(1) << "Error in adjust_ref, |scale_diff| > 1";
+        }
+      }
+    }
+  }
+}
 #endif
 
 std::array<size_t, 4> get_scale_tensor_dims(const size_t rows, const size_t cols,

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -466,29 +466,9 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
 void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const uint8_t *ref,
                              const size_t row_blocks, const size_t col_blocks, const size_t stride, 
                              double tol, bool rowwise, std::vector<std::tuple<size_t, size_t, int>> &mismatch_idx);
-template <typename T>
+
 void adjust_ref(std::vector<std::tuple<size_t, size_t, int>> mismatch_idx, void *ref, const size_t row_blocks,
-                const size_t col_blocks, const size_t rows, const size_t cols) {
-  T *ref_data = reinterpret_cast<T*>(ref);
-  for (const auto &[i, j, scale_diff] : mismatch_idx) {
-    size_t ii_min = i * col_blocks;
-    const size_t ii_max = std::min(ii_min + col_blocks, rows);
-    for (; ii_min < ii_max; ii_min++) {
-      size_t jj_min = j * row_blocks;
-      const size_t jj_max = std::min(jj_min + row_blocks, cols);
-      for (; jj_min < jj_max; jj_min++) {
-        const size_t data_idx = ii_min * cols + jj_min;
-        if (scale_diff == 1) {
-          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx])*2);
-        } else if (scale_diff == -1) {
-          ref_data[data_idx] = static_cast<T>(static_cast<float>(ref_data[data_idx])/2);
-        } else { // Shouldn't ever reach this
-          ASSERT_FALSE(1) << "Error in adjust_ref, |scale_diff| > 1";
-        }
-      }
-    }
-  }
-}
+                const size_t col_blocks, const size_t rows, const size_t cols, DType otype);
 #endif
 
 std::array<size_t, 4> get_scale_tensor_dims(const size_t rows, const size_t cols,

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -461,6 +461,13 @@ void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, 
                                   const size_t row_blocks, const size_t col_blocks, const size_t stride);
 void compare_e8m0_scaling_factors(const std::string &name, const uint8_t *test, const uint8_t *ref,
                                   const size_t N);
+#ifdef USE_ROCM
+void compare_mxfp8_results(const std::string &scale_name, const uint8_t *scale_ref, const size_t row_blocks, 
+                           const size_t col_blocks, const size_t stride, const std::string &output_name, 
+                           Tensor &output_test, const void *output_ref, const bool rowwise, 
+                           const size_t rows, const size_t cols, const float mismatch_tol = .01f, 
+                           double atol = 1e-2, double rtol = 1e-2, bool if_on_gpus = true);
+#endif
 
 std::array<size_t, 4> get_scale_tensor_dims(const size_t rows, const size_t cols,
                                             const size_t block_size_rows, const size_t block_size_cols);


### PR DESCRIPTION
# Description

Added a combined check for scale and values
If an scale difference is detected, values are checked for an off by one boundary condition
mismatch tolerance allows for a few scale differences (1% by default), before throwing an error.


Additionally, issues with dgelu CPU-side jitter have been resolved with data generation fixes. 
