### PR TITLE
Add envvar to cleanup hipified files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,11 +92,7 @@ After a successful Transformer Engine installation via `pip install`, execute th
 .. code-block:: bash
 
   cd tests/cpp
-  mkdir build
-  cd build
-  cmake ../
-  make
-  make test
+  cmake -GNinja -Bbuild . && cmake --build build
 
 Note that some of operator unit tests fail in hipBLASLt config due to limited input data configurations support
 
@@ -307,6 +303,15 @@ To enable MXFP8 support, use NVTE_ROCM_ENABLE_MXFP8 environment variable which c
 * 0 - disable MXFP8 support (default);
 * 1 - enable MXFP8 support in fp8;
 * 2 - make MXFP8 a default fp8 recipe.
+
+Switching Between TE versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When switching between TE versions, it is recommended to clean up the hipified files before rebuilding.
+This helps avoid linking errors, and is done with the cleanup environment variable:
+
+.. code-block:: bash
+  export NVTE_CLEAN_HIP=1
 
 
 Transformer Engine

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -232,7 +232,20 @@ def rocm_path() -> Tuple[str, str]:
         hipcc_bin = rocm_home / "bin" / "hipcc"
     return rocm_home, hipcc_bin
 
+def clean_hipified_files() -> None:
+    """Removes hipified files and regenerates them -- useful when switching between TE versions"""
+    hipified_patterns = ["*.hip", "*_hip.*", "hip_*"]
+    te_subdirectories = ['transformer_engine', 'tests']
+    ignore_subdirs = ["ck_fused_attn", "aotriton", "amd_detail"]
 
+    for sub in te_subdirectories:
+        path = Path(sub)
+        for p in hipified_patterns:
+            for f in path.rglob(p):
+                if any(ignore_dir in str(f) for ignore_dir in ignore_subdirs):
+                    continue
+                else:
+                    f.unlink()
 
 def cuda_toolkit_include_path() -> Tuple[str, str]:
     """Returns root path for cuda toolkit includes.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ from build_tools.build_ext import CMakeExtension, get_build_ext
 from build_tools.te_version import te_version
 from build_tools.utils import (
     rocm_build,
+    clean_hipified_files,
     cuda_archs,
     found_cmake,
     found_ninja,
@@ -189,6 +190,8 @@ if __name__ == "__main__":
         }
     else:
         setup_requires, install_requires, test_requires = setup_requirements()
+        if rocm_build() and bool(int(os.getenv("NVTE_CLEAN_HIP", "0"))):
+            clean_hipified_files()
         ext_modules = [setup_common_extension()]
         cmdclass = {"build_ext": CMakeBuildExtension, "bdist_wheel": TimedBdist}
         package_data = {"": ["VERSION.txt"]}


### PR DESCRIPTION
Added NVTE_CLEAN_HIP logic that removes hipified files before building. Useful for devs when switching between TE versions before incrementally building.