### PR TITLE
FIX Occasional import error when only building for a single framework

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -30,12 +30,12 @@ if os.getenv("NVTE_FRAMEWORK"):
 
 try:
     if _use_pytorch: from . import pytorch
-except (ImportError, FileNotFoundError, RuntimeError):
+except (ImportError, FileNotFoundError):
     pass
 
 try:
     if _use_jax: from . import jax
-except (ImportError, FileNotFoundError, RuntimeError):
+except (ImportError, FileNotFoundError):
     pass
 
 try:

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -30,12 +30,12 @@ if os.getenv("NVTE_FRAMEWORK"):
 
 try:
     if _use_pytorch: from . import pytorch
-except (ImportError, FileNotFoundError):
+except (ImportError, FileNotFoundError, RuntimeError):
     pass
 
 try:
     if _use_jax: from . import jax
-except (ImportError, FileNotFoundError):
+except (ImportError, FileNotFoundError, RuntimeError):
     pass
 
 try:

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -139,7 +139,7 @@ def _get_shared_object_file(library: str) -> Path:
     if so_path_in_default_dir is not None:
         return so_path_in_default_dir
 
-    raise RuntimeError(f"Could not find shared object file for Transformer Engine {library} lib.")
+    raise FileNotFoundError(f"Could not find shared object file for Transformer Engine {library} lib.")
 
 
 @functools.lru_cache(maxsize=None)

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -113,10 +113,9 @@ def _get_shared_object_file(library: str) -> Path:
 
     # Case 1: Typical user workflow: Both locations are the same, return any result.
     if te_install_dir == site_packages_dir:
-        assert (
-            so_path_in_install_dir is not None
-        ), f"Could not find shared object file for Transformer Engine {library} lib."
-        return so_path_in_install_dir
+        if so_path_in_install_dir is not None:
+            return so_path_in_install_dir
+        raise FileNotFoundError(f"Could not find shared object file for Transformer Engine {library} lib.")
 
     # Case 2: ERR! Both locations are different but returned a valid result.
     # NOTE: Unlike for source installations, pip does not wipe out artifacts from


### PR DESCRIPTION
# Description

Sometimes, during import, both frameworks will _try_ to get imported but in the event that their relevant `.so` is not found, will throw a `RuntimeError` that currently **is not caught** by the try/catch clauses, breaking an otherwise viable build. This PR fixes that.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
