### PR TITLE
std::max type mismatch hotfix

### DIFF
--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -696,7 +696,7 @@ void compare_e8m0_scaling_factors(const std::string &name, Tensor &output, const
   const uint8_t *const test = rowwise ? output.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
                                        : output.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
 
-  const float scale_tol = std::max(1.f, row_blocks * col_blocks * tol);
+  const double scale_tol = std::max(1., row_blocks * col_blocks * tol);
 
   for (int i = 0; i < row_blocks; i++) {
     for (int j = 0; j < col_blocks; j++) {


### PR DESCRIPTION
hotfix for cpp unit test build failure. This issue occurred when merging the hipify_transpilation ticket at the same time as the mxfp8 cast off by one ticket.

Rebase resolved correctly, however, in the cast off by 1 ticket std::max is mapped to ::max,  where the integer function of max is used for this, causing scale_tol calculation to be cast to an int then back to float:

const float scale_tol = ::max(1.f, row_blocks * col_blocks * tol);.


In rocm 7.0, there is no function template for std::max(float, double), so build fails. Making all variables/values doubles fixes the issue.