### PR TITLE
Integrate aiter HD192_HD128 backward kernels

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -360,6 +360,18 @@ class FusedAttnRunner:
                 "is either BSHD_BSHD_BSHD or THD_THD_THD"
             )
 
+        if self.head_dim_qk == 192 and self.head_dim_v == 128:
+            if self.attn_bias_type != AttnBiasType.NO_BIAS or self.bias_shape is not None:
+                pytest.skip("MLA hd192_hd128 is validated only without bias.")
+            if self.attn_mask_type not in (AttnMaskType.CAUSAL_MASK, AttnMaskType.NO_MASK):
+                pytest.skip("MLA hd192_hd128 is validated only for CAUSAL or NO_MASK.")
+            if self.dropout_prob != 0.0:
+                pytest.skip("MLA hd192_hd128 is validated only without dropout.")
+            if self.qkv_layout != QKVLayout.BSHD_BSHD_BSHD:
+                pytest.skip("MLA hd192_hd128 requires BSHD_BSHD_BSHD layout.")
+            if self.seq_desc_format != SeqDescFormat.Mask:
+                pytest.skip("MLA hd192_hd128 requires mask-based sequence descriptor.")
+
         self.backend = FusedAttnHelper(
             self.dtype,
             self.dtype,
@@ -994,6 +1006,12 @@ class FusedAttnRunner:
         ),
         pytest.param(
             2, 2048, 2048, 12, 6, 128, 64, jnp.float16, id="2-2048-2048-12-6-128-64-FP16-GQA"
+        ),
+        pytest.param(
+            10, 4096, 4096, 16, 16, 192, 128, jnp.float16, id="10-4096-4096-16-16-192-128-FP16-MLA",
+        ),
+        pytest.param(
+            10, 4096, 4096, 16, 16, 192, 128, jnp.bfloat16, id="10-4096-4096-16-16-192-128-BF16-MLA",
         ),
     ],
 )

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -362,15 +362,15 @@ class FusedAttnRunner:
 
         if self.head_dim_qk == 192 and self.head_dim_v == 128:
             if self.attn_bias_type != AttnBiasType.NO_BIAS or self.bias_shape is not None:
-                pytest.skip("MLA hd192_hd128 is validated only without bias.")
+                pytest.skip("Aiter currently supports MLA hd192_hd128 only without bias.")
             if self.attn_mask_type not in (AttnMaskType.CAUSAL_MASK, AttnMaskType.NO_MASK):
-                pytest.skip("MLA hd192_hd128 is validated only for CAUSAL or NO_MASK.")
+                pytest.skip("Aiter currently supports MLA hd192_hd128 only for CAUSAL or NO_MASK.")
             if self.dropout_prob != 0.0:
-                pytest.skip("MLA hd192_hd128 is validated only without dropout.")
+                pytest.skip("Aiter currently supports MLA hd192_hd128 only without dropout.")
             if self.qkv_layout != QKVLayout.BSHD_BSHD_BSHD:
-                pytest.skip("MLA hd192_hd128 requires BSHD_BSHD_BSHD layout.")
+                pytest.skip("Aiter currently supports MLA hd192_hd128 only with BSHD_BSHD_BSHD layout.")
             if self.seq_desc_format != SeqDescFormat.Mask:
-                pytest.skip("MLA hd192_hd128 requires mask-based sequence descriptor.")
+                pytest.skip("Aiter currently supports MLA hd192_hd128 only with mask-based SeqDescFormat.")
 
         self.backend = FusedAttnHelper(
             self.dtype,

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -375,8 +375,7 @@ def test_dot_product_attention(
     if (len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported) < 2:
         pytest.skip("Less than two backends to compare.")
 
-    # Enable backward for standard configs and MLA HD192_HD128
-    is_training = (config.head_dim_qk <= 128 and config.head_dim_v <= 128) or (config.head_dim_qk == 192 and config.head_dim_v == 128)
+    is_training = (config.head_dim_qk <= 192 and config.head_dim_v <= 128)
     # UnfusedDotProductAttention backend
     if unfused_attn_supported:
         unfused_attn_fwd, unfused_attn_bwd = _run_dot_product_attention(

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -375,7 +375,7 @@ def test_dot_product_attention(
     if (len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported) < 2:
         pytest.skip("Less than two backends to compare.")
 
-    is_training = (config.head_dim_qk <= 192 and config.head_dim_v <= 128)
+    is_training = config.head_dim_qk <= 192 and config.head_dim_v <= 128
     # UnfusedDotProductAttention backend
     if unfused_attn_supported:
         unfused_attn_fwd, unfused_attn_bwd = _run_dot_product_attention(

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -375,7 +375,8 @@ def test_dot_product_attention(
     if (len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported) < 2:
         pytest.skip("Less than two backends to compare.")
 
-    is_training = config.head_dim_qk <= 128 and config.head_dim_v <= 128
+    # Enable backward for standard configs and MLA HD192_HD128
+    is_training = (config.head_dim_qk <= 128 and config.head_dim_v <= 128) or (config.head_dim_qk == 192 and config.head_dim_v == 128)
     # UnfusedDotProductAttention backend
     if unfused_attn_supported:
         unfused_attn_fwd, unfused_attn_bwd = _run_dot_product_attention(
@@ -500,6 +501,12 @@ model_configs_mla = {
     "mla_3_1": ModelConfig(
         8, 16, 16, 256, 1, 2048, 0.0, "no_mask", "no_bias", head_dim_v=128
     ),  # inference
+    "mla_4_0": ModelConfig(
+        10, 16, 16, 192, 4096, 4096, 0.0, "causal", "no_bias", head_dim_v=128
+    ),
+    "mla_4_1": ModelConfig(
+        10, 16, 16, 192, 4096, 4096, 0.0, "no_mask", "no_bias", head_dim_v=128
+    ),
 }
 
 


### PR DESCRIPTION
Update 3rdparty/aiter commit which adds FMHAv3 backward support for MLA head_dim_qk=192, head_dim_v=128 configuration.

- Add MLA test configs mla_4_0 and mla_4_1 for HD192_HD128
- Fix is_training logic to enable backward pass testing for HD192_HD128

Aiter commit: https://github.com/ROCm/aiter/tree/7a41cca67187bd5f77c337765a1a289337901cef

# Description

This PR integrates the aiter HD192_HD128 backward kernels (aiter PR #1308) which adds FMHAv3 backward pass support for Multi-Latent Attention (MLA) configurations with head_dim_qk=192 and head_dim_v=128.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- **Update 3rdparty/aiter** to commit 7a41cca67187bd5f77c337765a1a289337901cef 
  - Adds FMHAv3 backward kernels: `fmha_bwd_hd192_hd128_{fp16,bf16}_{causal,}_a32_pssk`
  - Fixes dq_acc buffer to use head_dim_qk (192) instead of head_dim_v (128)

- **Add MLA test configurations** for HD192_HD128 in `test_fused_attn.py`:
  - `mla_4_0`: batch=10, heads=16, qk=192, v=128, seqlen=4096, causal mask
  - `mla_4_1`: batch=10, heads=16, qk=192, v=128, seqlen=4096, no mask

- **Fix is_training logic** to enable backward pass testing for HD192_HD128


# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
