### PR TITLE
Current scaling: two-stage HIP amax kernel

### DIFF
--- a/tests/cpp/operator/test_cast_current_scaling.cu
+++ b/tests/cpp/operator/test_cast_current_scaling.cu
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/tests/cpp/operator/test_cast_current_scaling.cu
+++ b/tests/cpp/operator/test_cast_current_scaling.cu
@@ -196,6 +196,41 @@ TEST_P(CastCSTestSuite, TestCastCS) {
 }
 
 
+TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
+  using namespace transformer_engine;
+  using namespace test;
+
+  std::vector<size_t> shape{256, 1024};
+  const size_t N = product(shape);
+
+  // Input: FP32, Output: FP8 (E4M3) with per-tensor scaling
+  Tensor input("input", shape, DType::kFloat32);
+  Tensor out_atomic("out_atomic", shape, DType::kFloat8E4M3, true, false);
+  Tensor out_ws("out_ws", shape, DType::kFloat8E4M3, true, false);
+
+  fillUniform(&input);
+
+  // Path 1: atomic-based amax (no workspace)
+  nvte_compute_amax(input.data(), out_atomic.data(), 0);
+
+  // Path 2: two-stage amax using workspace
+  // Use a workspace capacity >= number of blocks
+  std::vector<size_t> ws_shape{N};
+  Tensor workspace("workspace", ws_shape, DType::kFloat32);
+  nvte_compute_amax_with_workspace(input.data(), out_ws.data(), workspace.data(), 0);
+
+  cudaDeviceSynchronize();
+  auto err = cudaGetLastError();
+  ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
+
+  // Compare the resulting amax values
+  float amax_atomic = out_atomic.amax();
+  float amax_ws     = out_ws.amax();
+
+  compareResults("amax_consistency", amax_atomic, amax_ws, /*atol=*/0.0f, /*rtol=*/0.0f);
+}
+
+
 
 INSTANTIATE_TEST_SUITE_P(
   OperatorTest,

--- a/tests/cpp/operator/test_cast_current_scaling.cu
+++ b/tests/cpp/operator/test_cast_current_scaling.cu
@@ -209,7 +209,6 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   Tensor input("input", shape, DType::kFloat32);
   Tensor out_atomic("out_atomic", shape, DType::kFloat8E4M3, true, false);
   Tensor out_ws("out_ws", shape, DType::kFloat8E4M3, true, false);
-  Tensor out_ws2("out_ws2", shape, DType::kFloat8E4M3, true, false);
 
   fillUniform(&input);
 
@@ -217,12 +216,10 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   nvte_compute_amax(input.data(), out_atomic.data(), 0);
 
   // Path 2: two-stage amax using workspace
+  // Use a workspace capacity >= number of blocks
   std::vector<size_t> ws_shape{N};
   Tensor workspace("workspace", ws_shape, DType::kFloat32);
   nvte_compute_amax_with_workspace(input.data(), out_ws.data(), workspace.data(), 0);
-
-  // Path 3: Use workspace allocator
-  nvte_compute_amax_with_workspace(input.data(), out_ws2.data(), allocate_amax_workspace(input).data(), 0);
 
   cudaDeviceSynchronize();
   auto err = cudaGetLastError();
@@ -231,10 +228,8 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   // Compare the resulting amax values
   float amax_atomic = out_atomic.amax();
   float amax_ws     = out_ws.amax();
-  float amax_ws2    = out_ws2.amax();
 
   compareResults("amax_consistency", amax_atomic, amax_ws, /*atol=*/0.0f, /*rtol=*/0.0f);
-  compareResults("amax_consistency", amax_atomic, amax_ws2, /*atol=*/0.0f, /*rtol=*/0.0f);
 }
 
 

--- a/tests/cpp/operator/test_cast_current_scaling.cu
+++ b/tests/cpp/operator/test_cast_current_scaling.cu
@@ -197,6 +197,7 @@ TEST_P(CastCSTestSuite, TestCastCS) {
   );
 }
 
+#ifdef __HIP_PLATFORM_AMD__
 
 TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   using namespace transformer_engine;
@@ -216,7 +217,6 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   nvte_compute_amax(input.data(), out_atomic.data(), 0);
 
   // Path 2: two-stage amax using workspace
-  // Use a workspace capacity >= number of blocks
   std::vector<size_t> ws_shape{N};
   Tensor workspace("workspace", ws_shape, DType::kFloat32);
   nvte_compute_amax_with_workspace(input.data(), out_ws.data(), workspace.data(), 0);
@@ -231,6 +231,8 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
 
   compareResults("amax_consistency", amax_atomic, amax_ws, /*atol=*/0.0f, /*rtol=*/0.0f);
 }
+
+#endif
 
 
 

--- a/tests/cpp/operator/test_cast_current_scaling.cu
+++ b/tests/cpp/operator/test_cast_current_scaling.cu
@@ -209,6 +209,7 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   Tensor input("input", shape, DType::kFloat32);
   Tensor out_atomic("out_atomic", shape, DType::kFloat8E4M3, true, false);
   Tensor out_ws("out_ws", shape, DType::kFloat8E4M3, true, false);
+  Tensor out_ws2("out_ws2", shape, DType::kFloat8E4M3, true, false);
 
   fillUniform(&input);
 
@@ -216,10 +217,12 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   nvte_compute_amax(input.data(), out_atomic.data(), 0);
 
   // Path 2: two-stage amax using workspace
-  // Use a workspace capacity >= number of blocks
   std::vector<size_t> ws_shape{N};
   Tensor workspace("workspace", ws_shape, DType::kFloat32);
   nvte_compute_amax_with_workspace(input.data(), out_ws.data(), workspace.data(), 0);
+
+  // Path 3: Use workspace allocator
+  nvte_compute_amax_with_workspace(input.data(), out_ws2.data(), allocate_amax_workspace(input).data(), 0);
 
   cudaDeviceSynchronize();
   auto err = cudaGetLastError();
@@ -228,8 +231,10 @@ TEST(AmaxConsistencyTest, AtomicVsWorkspace) {
   // Compare the resulting amax values
   float amax_atomic = out_atomic.amax();
   float amax_ws     = out_ws.amax();
+  float amax_ws2    = out_ws2.amax();
 
   compareResults("amax_consistency", amax_atomic, amax_ws, /*atol=*/0.0f, /*rtol=*/0.0f);
+  compareResults("amax_consistency", amax_atomic, amax_ws2, /*atol=*/0.0f, /*rtol=*/0.0f);
 }
 
 

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -97,6 +97,9 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
  *  \param[in]     config           Quantization configuration.
  *  \param[in]     stream           CUDA stream used for the operation.
  */
+
+constexpr int amax_kernel_threads = 512;
+
 void nvte_compute_scale_from_amax(NVTETensor output, const NVTEQuantizationConfig config,
                                   cudaStream_t stream);
 

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -75,6 +75,8 @@ void nvte_delayed_scaling_recipe_amax_and_scale_update_after_reduction(
     std::vector<NVTETensor> scales, const char* amax_compute_algo, NVTEDType fp8_dtype,
     float margin, cudaStream_t stream);
 
+#ifdef __HIP_PLATFORM_AMD__
+
 constexpr int amax_kernel_threads = 512;
 
 inline bool nvte_use_atomic_amax() {
@@ -89,6 +91,8 @@ inline bool nvte_use_atomic_amax() {
   return cached == 1;
 }
 
+#endif
+
 /*! \brief Compute an FP8 tensor's amax.
  *
  *  The amax (maximum absolute value) of the input tensor is computed
@@ -100,7 +104,21 @@ inline bool nvte_use_atomic_amax() {
  */
 void nvte_compute_amax(const NVTETensor input, NVTETensor output, cudaStream_t stream);
 
-void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor output_, const NVTETensor workspace_, cudaStream_t stream);
+#ifdef __HIP_PLATFORM_AMD__
+
+/*! \brief Compute an FP8 tensor's amax.
+ *
+ *  The amax (maximum absolute value) of the input tensor is computed
+ *  and written to the amax buffer of the output tensor.
+ *
+ *  \param[in]     input            Input tensor. Must be unquantized.
+ *  \param[in,out] output           Output tensor. Must be an FP8 tensor with per-tensor scaling.
+ *  \param[out]    workspace        Output tensor. Must be FP32.
+ *  \param[in]     stream           CUDA stream used for the operation.
+ */
+void nvte_compute_amax_with_workspace(const NVTETensor input, NVTETensor output, NVTETensor workspace, cudaStream_t stream);
+
+#endif
 
 /*! \brief Update an FP8 tensor's scale based on its amax.
  *
@@ -111,7 +129,6 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
  *  \param[in]     config           Quantization configuration.
  *  \param[in]     stream           CUDA stream used for the operation.
  */
-
 void nvte_compute_scale_from_amax(NVTETensor output, const NVTEQuantizationConfig config,
                                   cudaStream_t stream);
 

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -94,7 +94,7 @@ void nvte_compute_amax(const NVTETensor input, NVTETensor output, cudaStream_t s
 
 #ifdef __HIP_PLATFORM_AMD__
 
-size_t nvte_amax_workspace_size(size_t N);
+size_t nvte_amax_workspace_num_blocks(size_t N);
 
 /*! \brief Compute an FP8 tensor's amax.
  *

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -79,18 +79,6 @@ void nvte_delayed_scaling_recipe_amax_and_scale_update_after_reduction(
 
 constexpr int amax_kernel_threads = 512;
 
-inline bool nvte_use_atomic_amax() {
-  static int cached = -1;
-  if (cached == -1) {
-    cached = 0;
-    const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");
-    if (env_p && std::string(env_p) == "1") {
-      cached = 1;
-    }
-  }
-  return cached == 1;
-}
-
 #endif
 
 /*! \brief Compute an FP8 tensor's amax.

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -94,6 +94,8 @@ void nvte_compute_amax(const NVTETensor input, NVTETensor output, cudaStream_t s
 
 #ifdef __HIP_PLATFORM_AMD__
 
+size_t nvte_amax_workspace_size(size_t N);
+
 /*! \brief Compute an FP8 tensor's amax.
  *
  *  The amax (maximum absolute value) of the input tensor is computed

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -84,6 +84,8 @@ void nvte_delayed_scaling_recipe_amax_and_scale_update_after_reduction(
  */
 void nvte_compute_amax(const NVTETensor input, NVTETensor output, cudaStream_t stream);
 
+void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor output_, const NVTETensor workspace_, cudaStream_t stream);
+
 /*! \brief Update an FP8 tensor's scale based on its amax.
  *
  *  This is only supported for FP8 tensors with per-tensor scaling.

--- a/transformer_engine/common/include/transformer_engine/recipe.h
+++ b/transformer_engine/common/include/transformer_engine/recipe.h
@@ -75,6 +75,20 @@ void nvte_delayed_scaling_recipe_amax_and_scale_update_after_reduction(
     std::vector<NVTETensor> scales, const char* amax_compute_algo, NVTEDType fp8_dtype,
     float margin, cudaStream_t stream);
 
+constexpr int amax_kernel_threads = 512;
+
+inline bool nvte_use_atomic_amax() {
+  static int cached = -1;
+  if (cached == -1) {
+    cached = 0;
+    const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");
+    if (env_p && std::string(env_p) == "1") {
+      cached = 1;
+    }
+  }
+  return cached == 1;
+}
+
 /*! \brief Compute an FP8 tensor's amax.
  *
  *  The amax (maximum absolute value) of the input tensor is computed
@@ -97,8 +111,6 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
  *  \param[in]     config           Quantization configuration.
  *  \param[in]     stream           CUDA stream used for the operation.
  */
-
-constexpr int amax_kernel_threads = 512;
 
 void nvte_compute_scale_from_amax(NVTETensor output, const NVTEQuantizationConfig config,
                                   cudaStream_t stream);

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -114,11 +114,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
-  const bool UseBlockAmax = (block_amax != nullptr);
-
-  if (UseBlockAmax) {
-    NVTE_CHECK(block_capacity >= num_blocks);
-  }
+  const bool UseBlockAmax = (block_amax != nullptr) && (block_capacity >= num_blocks);
 
   // Launch kernel
   switch (align) {
@@ -167,6 +163,10 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
 }  // namespace transformer_engine
 
 void nvte_compute_amax(const NVTETensor input_, const NVTETensor output_, cudaStream_t stream) {
+  nvte_compute_amax_with_workspace(input_, output_, /*workspace=*/nullptr, stream);
+}
+
+void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor output_, const NVTETensor workspace_, cudaStream_t stream) {
   NVTE_API_CALL(nvte_compute_amax);
   using namespace transformer_engine;
 
@@ -202,12 +202,19 @@ void nvte_compute_amax(const NVTETensor input_, const NVTETensor output_, cudaSt
              to_string(output.amax.dtype), ")");
   CheckOutputTensor(output, "output_compute_amax", true);
 
-  // Interpret output.data as workspace if present
-  float *block_amax = nullptr;
+  // Optional workspace
+  float* block_amax = nullptr;
   size_t block_capacity = 0;
-  if (output.data.dptr != nullptr) {
-    block_amax     = reinterpret_cast<float*>(output.data.dptr);
-    block_capacity = output.data.numel();     // #floats in workspace
+
+  if (workspace_ != nullptr) {
+    auto &workspace = *reinterpret_cast<Tensor *>(workspace_);
+    NVTE_CHECK(workspace.data.dptr != nullptr,
+               "Workspace tensor for amax computation has no data");
+    NVTE_CHECK(workspace.data.dtype == DType::kFloat32,
+               "Workspace tensor for amax computation must be FP32, got dtype=",
+               to_string(workspace.data.dtype));
+    block_amax     = reinterpret_cast<float*>(workspace.data.dptr);
+    block_capacity = workspace.data.numel();
   }
 
   // Compute amax

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -28,9 +28,28 @@ using bf16__ = __hip_bfloat16;
 
 constexpr int amax_kernel_threads = 512;
 
+template <int BLOCK_THREADS>
+__global__ void amax_final_reduce(const float* __restrict__ block_amax,
+                                  float* __restrict__ global_amax,
+                                  int num_blocks) {
+  float val = 0.f;
+
+  for (int i = threadIdx.x; i < num_blocks; i += BLOCK_THREADS) {
+    val = fmaxf(val, block_amax[i]);
+  }
+
+  const int warp_id = threadIdx.x / THREADS_PER_WARP;
+  const float block_max =
+      reduce_max<BLOCK_THREADS / THREADS_PER_WARP>(val, warp_id);
+
+  if (threadIdx.x == 0) {
+    *global_amax = block_max;
+  }
+}
+
 template <int nvec, bool aligned, typename InputType>
 __launch_bounds__(amax_kernel_threads) __global__
-    void amax_kernel(const InputType *input, float *amax, const size_t N,
+    void amax_kernel(const InputType *input, float* __restrict__ block_amax, const size_t N,
                      const size_t num_aligned_elements) {
   VectorizedLoader<InputType, nvec, aligned> loader(input, N);
   InputType max{0.f};
@@ -39,9 +58,10 @@ __launch_bounds__(amax_kernel_threads) __global__
 
   for (size_t tid = blockIdx.x * blockDim.x + threadIdx.x; tid < M; tid += gridDim.x * blockDim.x) {
     loader.load(tid, N);
+    auto v = loader.separate();
 #pragma unroll
     for (int i = 0; i < nvec; ++i) {
-      const InputType val = static_cast<InputType>(loader.separate()[i]);
+      const InputType val = static_cast<InputType>(v[i]);
       __builtin_assume(max >= InputType{0.f});
       if constexpr (std::is_same_v<InputType, bf16__>) {
 #ifndef __HIP_PLATFORM_AMD__
@@ -65,7 +85,7 @@ __launch_bounds__(amax_kernel_threads) __global__
   // Reduce amax over block
   max = reduce_max<amax_kernel_threads / THREADS_PER_WARP>(max, warp_id);
   if (threadIdx.x == 0) {
-    atomicMaxFloat(amax, max);
+    block_amax[blockIdx.x] = max;
   }
 }
 
@@ -89,22 +109,34 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cud
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
+  float* block_amax = nullptr;
+  NVTE_CHECK_CUDA(cudaMalloc(&block_amax, num_blocks * sizeof(float)));
+
   // Launch kernel
   switch (align) {
     case Alignment::SAME_ALIGNED:
       amax_kernel<nvec, true, InputType>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, N, num_aligned_elements);
+          <<<num_blocks, threads, 0, stream>>>(input, block_amax, N, num_aligned_elements);
       break;
     case Alignment::SAME_UNALIGNED:
       amax_kernel<nvec, false, InputType>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, N, num_aligned_elements);
+          <<<num_blocks, threads, 0, stream>>>(input,  block_amax, N, num_aligned_elements);
       break;
     case Alignment::DIFFERENT: {
       // This case is a logic error, since there is only one pointer (input)
       // in the alignment check. Still safe to process without vectorization.
-      amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input, amax, N, N);
+      amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input,  block_amax, N, N);
       break;
     }
+  }
+
+  {
+    constexpr int FINAL_REDUCE_THREADS = 256;
+    dim3 fr_block(FINAL_REDUCE_THREADS);
+    dim3 fr_grid(1);
+
+    amax_final_reduce<FINAL_REDUCE_THREADS>
+        <<<fr_grid, fr_block, 0, stream>>>(block_amax, amax, static_cast<int>(num_blocks));
   }
 
   // Check results

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -233,13 +233,13 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
 
   if (workspace_ != nullptr) {
     auto &workspace = *reinterpret_cast<Tensor *>(workspace_);
-    NVTE_CHECK(workspace.data.dptr != nullptr,
-               "Workspace tensor for amax computation has no data");
-    NVTE_CHECK(workspace.data.dtype == DType::kFloat32,
-               "Workspace tensor for amax computation must be FP32, got dtype=",
-               to_string(workspace.data.dtype));
-    block_amax     = reinterpret_cast<float*>(workspace.data.dptr);
-    block_capacity = workspace.data.numel();
+    if (workspace.data.dptr != nullptr) {
+      NVTE_CHECK(workspace.data.dtype == DType::kFloat32,
+                "Workspace tensor for amax computation must be FP32, got dtype=",
+                to_string(workspace.data.dtype));
+      block_amax     = reinterpret_cast<float*>(workspace.data.dptr);
+      block_capacity = workspace.data.numel();
+    }
   }
 #endif
 

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -26,10 +26,7 @@ using bf16__ = __nv_bfloat16;
 using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
-#ifndef __HIP_PLATFORM_AMD__
-// Defined in include/transformer_engine/recipe.h for AMD
 constexpr int amax_kernel_threads = 512;
-#endif
 
 #ifdef __HIP_PLATFORM_AMD__
 
@@ -125,13 +122,16 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   auto align = CheckAlignment(N, nvec, input);
   size_t num_aligned_elements = get_num_aligned_elements(input, N, nvec, sizeof(InputType));
 
+#ifndef __HIP_PLATFORM_AMD__
   // Figure out CUDA blocks
   constexpr size_t threads = amax_kernel_threads;
   size_t num_blocks = DIVUP(num_aligned_elements, threads);
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
-#ifdef __HIP_PLATFORM_AMD__
+#else
+  constexpr size_t threads = amax_kernel_threads;
+  size_t num_blocks = nvte_amax_workspace_size(num_aligned_elements);
   if (block_capacity < num_blocks)
     block_amax = nullptr;
 #endif
@@ -185,6 +185,19 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
 
 }  // namespace
 }  // namespace transformer_engine
+
+
+#ifdef __HIP_PLATFORM_AMD__
+
+size_t nvte_amax_workspace_size(size_t N) {
+  constexpr size_t max_blocks_hw = 65535;
+
+  size_t max_blocks = transformer_engine::DIVUP(N, static_cast<size_t>(amax_kernel_threads));
+  size_t workspace_blocks = std::min(max_blocks, max_blocks_hw);
+  return workspace_blocks;
+}
+
+#endif
 
 void nvte_compute_amax(const NVTETensor input_, const NVTETensor output_, cudaStream_t stream) {
 #ifdef __HIP_PLATFORM_AMD__

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -110,7 +110,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cud
   num_blocks = std::min(num_blocks, max_blocks);
 
   float* block_amax = nullptr;
-  NVTE_CHECK_CUDA(cudaMalloc(&block_amax, num_blocks * sizeof(float)));
+  NVTE_CHECK_CUDA(cudaMallocAsync(&block_amax, num_blocks * sizeof(float), stream));
 
   // Launch kernel
   switch (align) {
@@ -141,6 +141,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cud
 
   // Check results
   NVTE_CHECK_CUDA(cudaGetLastError());
+  NVTE_CHECK_CUDA(cudaFreeAsync(block_amax, stream));
 }
 
 }  // namespace

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -26,6 +26,10 @@ using bf16__ = __nv_bfloat16;
 using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
+#ifndef __HIP_PLATFORM_AMD__
+// Defined in include/transformer_engine/recipe.h for AMD
+constexpr int amax_kernel_threads = 512;
+#endif
 
 #ifdef __HIP_PLATFORM_AMD__
 

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <limits>
 #include <type_traits>
-#include <cstdlib>
 
 #include "../common.h"
 #include "../util/logging.h"
@@ -46,10 +45,11 @@ __global__ void amax_final_reduce(const float* __restrict__ block_amax,
     *global_amax = block_max;
   }
 }
+
 template <int nvec, bool aligned, typename InputType>
 __launch_bounds__(amax_kernel_threads) __global__
     void amax_kernel(const InputType *input, float *amax, float* __restrict__ block_amax, const size_t N,
-                     const size_t num_aligned_elements, bool use_block_amax) {
+                     const size_t num_aligned_elements) {
   VectorizedLoader<InputType, nvec, aligned> loader(input, N);
   InputType max{0.f};
   const int warp_id = threadIdx.x / THREADS_PER_WARP;
@@ -57,10 +57,9 @@ __launch_bounds__(amax_kernel_threads) __global__
 
   for (size_t tid = blockIdx.x * blockDim.x + threadIdx.x; tid < M; tid += gridDim.x * blockDim.x) {
     loader.load(tid, N);
-    auto v = loader.separate();
 #pragma unroll
     for (int i = 0; i < nvec; ++i) {
-      const InputType val = static_cast<InputType>(v[i]);
+      const InputType val = static_cast<InputType>(loader.separate()[i]);
       __builtin_assume(max >= InputType{0.f});
       if constexpr (std::is_same_v<InputType, bf16__>) {
 #ifndef __HIP_PLATFORM_AMD__
@@ -84,9 +83,11 @@ __launch_bounds__(amax_kernel_threads) __global__
   // Reduce amax over block
   max = reduce_max<amax_kernel_threads / THREADS_PER_WARP>(max, warp_id);
   if (threadIdx.x == 0) {
-    if (use_block_amax) {
+    if (block_amax != nullptr) {
+      // 2-stage: write per-block result
       block_amax[blockIdx.x] = max;
     } else {
+      // Atomic path: directly update global amax
       atomicMaxFloat(amax, max);
     }
   }
@@ -122,20 +123,16 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   switch (align) {
     case Alignment::SAME_ALIGNED:
       amax_kernel<nvec, true, InputType>
-          <<<num_blocks, threads, 0, stream>>>(
-              input, amax, block_amax, N, num_aligned_elements, UseBlockAmax);
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
       break;
     case Alignment::SAME_UNALIGNED:
       amax_kernel<nvec, false, InputType>
-          <<<num_blocks, threads, 0, stream>>>(
-              input, amax, block_amax, N, num_aligned_elements, UseBlockAmax);
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
       break;
     case Alignment::DIFFERENT: {
       // This case is a logic error, since there is only one pointer (input)
       // in the alignment check. Still safe to process without vectorization.
-      amax_kernel<1, true, InputType>
-          <<<num_blocks, threads, 0, stream>>>(
-              input, amax, block_amax, N, N, UseBlockAmax);
+      amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
       break;
     }
   }

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -47,9 +47,9 @@ __global__ void amax_final_reduce(const float* __restrict__ block_amax,
   }
 }
 
-template <int nvec, bool aligned, typename InputType>
+template <int nvec, bool aligned, typename InputType, bool UseBlockAmax>
 __launch_bounds__(amax_kernel_threads) __global__
-    void amax_kernel(const InputType *input, float* __restrict__ block_amax, const size_t N,
+    void amax_kernel(const InputType *input, float *amax, float* __restrict__ block_amax, const size_t N,
                      const size_t num_aligned_elements) {
   VectorizedLoader<InputType, nvec, aligned> loader(input, N);
   InputType max{0.f};
@@ -85,12 +85,17 @@ __launch_bounds__(amax_kernel_threads) __global__
   // Reduce amax over block
   max = reduce_max<amax_kernel_threads / THREADS_PER_WARP>(max, warp_id);
   if (threadIdx.x == 0) {
-    block_amax[blockIdx.x] = max;
+    if constexpr (UseBlockAmax) {
+      block_amax[blockIdx.x] = max;
+    } else {
+      atomicMaxFloat(amax, max);
+    }
   }
 }
 
 template <int nvec, typename InputType>
-void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cudaStream_t stream) {
+void launch_amax_kernel(const InputType *input, float *amax, const size_t N, float *block_amax,
+                        size_t block_capacity, cudaStream_t stream) {
   // Zero out amax so we can update with atomic max
   (void)cudaMemsetAsync(amax, 0, sizeof(float), stream);
 
@@ -109,28 +114,43 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cud
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
-  float* block_amax = nullptr;
-  NVTE_CHECK_CUDA(cudaMallocAsync(&block_amax, num_blocks * sizeof(float), stream));
+  const bool UseBlockAmax = (block_amax != nullptr);
+
+  if (UseBlockAmax) {
+    NVTE_CHECK(block_capacity >= num_blocks);
+  }
 
   // Launch kernel
   switch (align) {
     case Alignment::SAME_ALIGNED:
-      amax_kernel<nvec, true, InputType>
-          <<<num_blocks, threads, 0, stream>>>(input, block_amax, N, num_aligned_elements);
+      // FIXME: this code is clumsy. Perhaps don't use the UseBlockAmax extra template argument
+      if (UseBlockAmax)
+        amax_kernel<nvec, true, InputType, true>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+      else
+        amax_kernel<nvec, true, InputType, false>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
       break;
     case Alignment::SAME_UNALIGNED:
-      amax_kernel<nvec, false, InputType>
-          <<<num_blocks, threads, 0, stream>>>(input,  block_amax, N, num_aligned_elements);
+      if (UseBlockAmax)
+        amax_kernel<nvec, false, InputType, true>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+      else
+        amax_kernel<nvec, false, InputType, false>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
       break;
     case Alignment::DIFFERENT: {
       // This case is a logic error, since there is only one pointer (input)
       // in the alignment check. Still safe to process without vectorization.
-      amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input,  block_amax, N, N);
+      if (UseBlockAmax)
+        amax_kernel<1, true, InputType, true><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
+      else
+        amax_kernel<1, true, InputType, false><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
       break;
     }
   }
 
-  {
+  if (UseBlockAmax) {
     constexpr int FINAL_REDUCE_THREADS = 256;
     dim3 fr_block(FINAL_REDUCE_THREADS);
     dim3 fr_grid(1);
@@ -141,7 +161,6 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, cud
 
   // Check results
   NVTE_CHECK_CUDA(cudaGetLastError());
-  NVTE_CHECK_CUDA(cudaFreeAsync(block_amax, stream));
 }
 
 }  // namespace
@@ -183,11 +202,20 @@ void nvte_compute_amax(const NVTETensor input_, const NVTETensor output_, cudaSt
              to_string(output.amax.dtype), ")");
   CheckOutputTensor(output, "output_compute_amax", true);
 
+  // Interpret output.data as workspace if present
+  float *block_amax = nullptr;
+  size_t block_capacity = 0;
+  if (output.data.dptr != nullptr) {
+    block_amax     = reinterpret_cast<float*>(output.data.dptr);
+    block_capacity = output.data.numel();     // #floats in workspace
+  }
+
   // Compute amax
   TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
       input.data.dtype, IType, constexpr int nvec = 32 / sizeof(IType);
       launch_amax_kernel<nvec>(reinterpret_cast<const IType *>(input.data.dptr),
-                               reinterpret_cast<float *>(output.amax.dptr), input.data.numel(),
+                               reinterpret_cast<float *>(output.amax.dptr), input.data.numel(), block_amax,
+          block_capacity,
                                stream););  // NOLINT(*)
 }
 

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -101,7 +101,7 @@ __launch_bounds__(amax_kernel_threads) __global__
       atomicMaxFloat(amax, max);
     }
 #else
-  atomicMaxFloat(amax, max);
+    atomicMaxFloat(amax, max);
 #endif
   }
 }

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <limits>
 #include <type_traits>
+#include <cstdlib>
 
 #include "../common.h"
 #include "../util/logging.h"
@@ -27,6 +28,19 @@ using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
 constexpr int amax_kernel_threads = 512;
+
+// FIXME: Should this be covered by __HIP_PLATFORM_AMD__ ?
+inline bool nvte_use_atomic_amax() {
+  static int cached = -1;
+  if (cached == -1) {
+    cached = 0;
+    const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");
+    if (env_p && std::string(env_p) == "1") {
+      cached = 1;
+    }
+  }
+  return cached == 1;
+}
 
 template <int BLOCK_THREADS>
 __global__ void amax_final_reduce(const float* __restrict__ block_amax,
@@ -114,7 +128,10 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
-  const bool UseBlockAmax = (block_amax != nullptr) && (block_capacity >= num_blocks);
+  const bool UseBlockAmax =
+      (block_amax != nullptr) &&
+      (block_capacity >= num_blocks) &&
+      !nvte_use_atomic_amax();
 
   // Launch kernel
   switch (align) {

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -27,9 +27,8 @@ using bf16__ = __nv_bfloat16;
 using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
-constexpr int amax_kernel_threads = 512;
 
-inline bool nvte_use_atomic_amax() {
+static inline bool nvte_use_atomic_amax() {
   static int cached = -1;
   if (cached == -1) {
     cached = 0;

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -28,18 +28,6 @@ using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
 
-static inline bool nvte_use_atomic_amax() {
-  static int cached = -1;
-  if (cached == -1) {
-    cached = 0;
-    const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");
-    if (env_p && std::string(env_p) == "1") {
-      cached = 1;
-    }
-  }
-  return cached == 1;
-}
-
 template <int BLOCK_THREADS>
 __global__ void amax_final_reduce(const float* __restrict__ block_amax,
                                   float* __restrict__ global_amax,

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -27,6 +27,8 @@ using bf16__ = __hip_bfloat16;
 #endif //__HIP_PLATFORM_AMD__
 
 
+#ifdef __HIP_PLATFORM_AMD__
+
 template <int BLOCK_THREADS>
 __global__ void amax_final_reduce(const float* __restrict__ block_amax,
                                   float* __restrict__ global_amax,
@@ -46,10 +48,17 @@ __global__ void amax_final_reduce(const float* __restrict__ block_amax,
   }
 }
 
+#endif
+
 template <int nvec, bool aligned, typename InputType>
 __launch_bounds__(amax_kernel_threads) __global__
+#ifdef __HIP_PLATFORM_AMD__
     void amax_kernel(const InputType *input, float *amax, float* __restrict__ block_amax, const size_t N,
                      const size_t num_aligned_elements) {
+#else
+    void amax_kernel(const InputType *input, float *amax, const size_t N,
+                     const size_t num_aligned_elements) {
+#endif
   VectorizedLoader<InputType, nvec, aligned> loader(input, N);
   InputType max{0.f};
   const int warp_id = threadIdx.x / THREADS_PER_WARP;
@@ -83,6 +92,7 @@ __launch_bounds__(amax_kernel_threads) __global__
   // Reduce amax over block
   max = reduce_max<amax_kernel_threads / THREADS_PER_WARP>(max, warp_id);
   if (threadIdx.x == 0) {
+#ifdef __HIP_PLATFORM_AMD__
     if (block_amax != nullptr) {
       // 2-stage: write per-block result
       block_amax[blockIdx.x] = max;
@@ -90,6 +100,9 @@ __launch_bounds__(amax_kernel_threads) __global__
       // Atomic path: directly update global amax
       atomicMaxFloat(amax, max);
     }
+#else
+  atomicMaxFloat(amax, max);
+#endif
   }
 }
 
@@ -114,29 +127,46 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   constexpr size_t max_blocks = 65535;
   num_blocks = std::min(num_blocks, max_blocks);
 
+#ifdef __HIP_PLATFORM_AMD__
   const bool UseBlockAmax =
       (block_amax != nullptr) &&
       (block_capacity >= num_blocks) &&
       !nvte_use_atomic_amax();
+#endif
 
   // Launch kernel
   switch (align) {
     case Alignment::SAME_ALIGNED:
+#ifdef __HIP_PLATFORM_AMD__
       amax_kernel<nvec, true, InputType>
           <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+#else
+      amax_kernel<nvec, true, InputType>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, N, num_aligned_elements);
+#endif
       break;
     case Alignment::SAME_UNALIGNED:
+#ifdef __HIP_PLATFORM_AMD__
       amax_kernel<nvec, false, InputType>
           <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+#else
+      amax_kernel<nvec, false, InputType>
+          <<<num_blocks, threads, 0, stream>>>(input, amax, N, num_aligned_elements);
+#endif
       break;
     case Alignment::DIFFERENT: {
       // This case is a logic error, since there is only one pointer (input)
       // in the alignment check. Still safe to process without vectorization.
+#ifdef __HIP_PLATFORM_AMD__
       amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
+#else
+      amax_kernel<1, true, InputType><<<num_blocks, threads, 0, stream>>>(input, amax, N, N);
+#endif
       break;
     }
   }
 
+#ifdef __HIP_PLATFORM_AMD__
   if (UseBlockAmax) {
     constexpr int FINAL_REDUCE_THREADS = 256;
     dim3 fr_block(FINAL_REDUCE_THREADS);
@@ -145,6 +175,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
     amax_final_reduce<FINAL_REDUCE_THREADS>
         <<<fr_grid, fr_block, 0, stream>>>(block_amax, amax, static_cast<int>(num_blocks));
   }
+#endif
 
   // Check results
   NVTE_CHECK_CUDA(cudaGetLastError());
@@ -154,10 +185,12 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
 }  // namespace transformer_engine
 
 void nvte_compute_amax(const NVTETensor input_, const NVTETensor output_, cudaStream_t stream) {
+#ifdef __HIP_PLATFORM_AMD__
   nvte_compute_amax_with_workspace(input_, output_, /*workspace=*/nullptr, stream);
 }
 
 void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor output_, const NVTETensor workspace_, cudaStream_t stream) {
+#endif
   NVTE_API_CALL(nvte_compute_amax);
   using namespace transformer_engine;
 
@@ -193,6 +226,7 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
              to_string(output.amax.dtype), ")");
   CheckOutputTensor(output, "output_compute_amax", true);
 
+#ifdef __HIP_PLATFORM_AMD__
   // Optional workspace
   float* block_amax = nullptr;
   size_t block_capacity = 0;
@@ -207,13 +241,16 @@ void nvte_compute_amax_with_workspace(const NVTETensor input_, const NVTETensor 
     block_amax     = reinterpret_cast<float*>(workspace.data.dptr);
     block_capacity = workspace.data.numel();
   }
+#endif
 
   // Compute amax
   TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
       input.data.dtype, IType, constexpr int nvec = 32 / sizeof(IType);
       launch_amax_kernel<nvec>(reinterpret_cast<const IType *>(input.data.dptr),
-                               reinterpret_cast<float *>(output.amax.dptr), input.data.numel(), block_amax,
-          block_capacity,
+                               reinterpret_cast<float *>(output.amax.dptr), input.data.numel(),
+#ifdef __HIP_PLATFORM_AMD__
+                               block_amax, block_capacity,
+#endif
                                stream););  // NOLINT(*)
 }
 

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -131,7 +131,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
 
 #else
   constexpr size_t threads = amax_kernel_threads;
-  size_t num_blocks = nvte_amax_workspace_size(num_aligned_elements);
+  size_t num_blocks = nvte_amax_workspace_num_blocks(num_aligned_elements);
   if (block_capacity < num_blocks)
     block_amax = nullptr;
 #endif
@@ -189,7 +189,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
 
 #ifdef __HIP_PLATFORM_AMD__
 
-size_t nvte_amax_workspace_size(size_t N) {
+size_t nvte_amax_workspace_num_blocks(size_t N) {
   constexpr size_t max_blocks_hw = 65535;
 
   size_t max_blocks = transformer_engine::DIVUP(N, static_cast<size_t>(amax_kernel_threads));

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -128,10 +128,8 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   num_blocks = std::min(num_blocks, max_blocks);
 
 #ifdef __HIP_PLATFORM_AMD__
-  const bool UseBlockAmax =
-      (block_amax != nullptr) &&
-      (block_capacity >= num_blocks) &&
-      !nvte_use_atomic_amax();
+  if (block_capacity < num_blocks)
+    block_amax = nullptr;
 #endif
 
   // Launch kernel
@@ -167,7 +165,7 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   }
 
 #ifdef __HIP_PLATFORM_AMD__
-  if (UseBlockAmax) {
+  if (block_amax != nullptr) {
     constexpr int FINAL_REDUCE_THREADS = 256;
     dim3 fr_block(FINAL_REDUCE_THREADS);
     dim3 fr_grid(1);

--- a/transformer_engine/common/recipe/current_scaling.cu
+++ b/transformer_engine/common/recipe/current_scaling.cu
@@ -29,7 +29,6 @@ using bf16__ = __hip_bfloat16;
 
 constexpr int amax_kernel_threads = 512;
 
-// FIXME: Should this be covered by __HIP_PLATFORM_AMD__ ?
 inline bool nvte_use_atomic_amax() {
   static int cached = -1;
   if (cached == -1) {
@@ -60,11 +59,10 @@ __global__ void amax_final_reduce(const float* __restrict__ block_amax,
     *global_amax = block_max;
   }
 }
-
-template <int nvec, bool aligned, typename InputType, bool UseBlockAmax>
+template <int nvec, bool aligned, typename InputType>
 __launch_bounds__(amax_kernel_threads) __global__
     void amax_kernel(const InputType *input, float *amax, float* __restrict__ block_amax, const size_t N,
-                     const size_t num_aligned_elements) {
+                     const size_t num_aligned_elements, bool use_block_amax) {
   VectorizedLoader<InputType, nvec, aligned> loader(input, N);
   InputType max{0.f};
   const int warp_id = threadIdx.x / THREADS_PER_WARP;
@@ -99,7 +97,7 @@ __launch_bounds__(amax_kernel_threads) __global__
   // Reduce amax over block
   max = reduce_max<amax_kernel_threads / THREADS_PER_WARP>(max, warp_id);
   if (threadIdx.x == 0) {
-    if constexpr (UseBlockAmax) {
+    if (use_block_amax) {
       block_amax[blockIdx.x] = max;
     } else {
       atomicMaxFloat(amax, max);
@@ -136,29 +134,21 @@ void launch_amax_kernel(const InputType *input, float *amax, const size_t N, flo
   // Launch kernel
   switch (align) {
     case Alignment::SAME_ALIGNED:
-      // FIXME: this code is clumsy. Perhaps don't use the UseBlockAmax extra template argument
-      if (UseBlockAmax)
-        amax_kernel<nvec, true, InputType, true>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
-      else
-        amax_kernel<nvec, true, InputType, false>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+      amax_kernel<nvec, true, InputType>
+          <<<num_blocks, threads, 0, stream>>>(
+              input, amax, block_amax, N, num_aligned_elements, UseBlockAmax);
       break;
     case Alignment::SAME_UNALIGNED:
-      if (UseBlockAmax)
-        amax_kernel<nvec, false, InputType, true>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
-      else
-        amax_kernel<nvec, false, InputType, false>
-          <<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, num_aligned_elements);
+      amax_kernel<nvec, false, InputType>
+          <<<num_blocks, threads, 0, stream>>>(
+              input, amax, block_amax, N, num_aligned_elements, UseBlockAmax);
       break;
     case Alignment::DIFFERENT: {
       // This case is a logic error, since there is only one pointer (input)
       // in the alignment check. Still safe to process without vectorization.
-      if (UseBlockAmax)
-        amax_kernel<1, true, InputType, true><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
-      else
-        amax_kernel<1, true, InputType, false><<<num_blocks, threads, 0, stream>>>(input, amax, block_amax, N, N);
+      amax_kernel<1, true, InputType>
+          <<<num_blocks, threads, 0, stream>>>(
+              input, amax, block_amax, N, N, UseBlockAmax);
       break;
     }
   }

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -11,7 +11,10 @@
 #include "c10/util/ArrayRef.h"
 #include "pybind.h"
 #include "transformer_engine/transformer_engine.h"
+
+#ifdef __HIP_PLATFORM_AMD__
 #include "common/common.h"
+#endif
 
 namespace transformer_engine::pytorch {
 
@@ -280,6 +283,7 @@ int roundup(const int value, const int multiple) {
   return ((value + multiple - 1) / multiple) * multiple;
 }
 
+#ifdef __HIP_PLATFORM_AMD__
 TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
   if (nvte_use_atomic_amax() || input_tensor.numel() == 0) {
     // User chose atomic path, or empty tensor -> no need for workspace
@@ -296,5 +300,6 @@ TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
 
   return makeTransformerEngineTensor(ws);
 }
+#endif
 
 }  // namespace transformer_engine::pytorch

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -12,10 +12,6 @@
 #include "pybind.h"
 #include "transformer_engine/transformer_engine.h"
 
-#ifdef __HIP_PLATFORM_AMD__
-#include "common/common.h"
-#endif
-
 namespace transformer_engine::pytorch {
 
 std::vector<size_t> getTensorShape(at::Tensor t) {
@@ -284,6 +280,11 @@ int roundup(const int value, const int multiple) {
 }
 
 #ifdef __HIP_PLATFORM_AMD__
+
+template <typename T>
+constexpr T DIVUP(const T &x, const T &y) {
+  return (((x) + ((y)-1)) / (y));
+}
 
 inline bool nvte_use_atomic_amax() {
   const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -299,10 +299,7 @@ TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
   }
 
   const auto N = input_tensor.numel();
-  constexpr size_t max_blocks_hw = 65535;
-
-  size_t max_blocks = DIVUP(N, static_cast<size_t>(amax_kernel_threads));
-  size_t workspace_blocks = std::min(max_blocks, max_blocks_hw);
+  size_t workspace_blocks = nvte_amax_workspace_size(N);
 
   at::Tensor ws = at::empty(workspace_blocks, at::CUDA(at::kFloat));
 

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -12,6 +12,10 @@
 #include "pybind.h"
 #include "transformer_engine/transformer_engine.h"
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "common/common.h"
+#endif
+
 namespace transformer_engine::pytorch {
 
 std::vector<size_t> getTensorShape(at::Tensor t) {
@@ -280,11 +284,6 @@ int roundup(const int value, const int multiple) {
 }
 
 #ifdef __HIP_PLATFORM_AMD__
-
-template <typename T>
-constexpr T DIVUP(const T &x, const T &y) {
-  return (((x) + ((y)-1)) / (y));
-}
 
 inline bool nvte_use_atomic_amax() {
   const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -298,13 +298,13 @@ TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
     return TensorWrapper{};
   }
 
-  const auto N = static_cast<size_t>(input_tensor.numel());
+  const auto N = input_tensor.numel();
   constexpr size_t max_blocks_hw = 65535;
 
   size_t max_blocks = DIVUP(N, static_cast<size_t>(amax_kernel_threads));
   size_t workspace_blocks = std::min(max_blocks, max_blocks_hw);
 
-  at::Tensor ws = at::empty({static_cast<long>(workspace_blocks)}, at::CUDA(at::kFloat));
+  at::Tensor ws = at::empty(workspace_blocks, at::CUDA(at::kFloat));
 
   return makeTransformerEngineTensor(ws);
 }

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -284,6 +284,14 @@ int roundup(const int value, const int multiple) {
 }
 
 #ifdef __HIP_PLATFORM_AMD__
+
+inline bool nvte_use_atomic_amax() {
+  const char *env_p = std::getenv("NVTE_USE_ATOMIC_AMAX");
+  if (env_p && std::string(env_p) == "1")
+    return true;
+  return false;
+}
+
 TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
   if (nvte_use_atomic_amax() || input_tensor.numel() == 0) {
     // User chose atomic path, or empty tensor -> no need for workspace
@@ -300,6 +308,7 @@ TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
 
   return makeTransformerEngineTensor(ws);
 }
+
 #endif
 
 }  // namespace transformer_engine::pytorch

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -299,7 +299,7 @@ TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
   }
 
   const auto N = input_tensor.numel();
-  size_t workspace_blocks = nvte_amax_workspace_size(N);
+  size_t workspace_blocks = nvte_amax_workspace_num_blocks(N);
 
   at::Tensor ws = at::empty(workspace_blocks, at::CUDA(at::kFloat));
 

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.
@@ -9,6 +11,7 @@
 #include "c10/util/ArrayRef.h"
 #include "pybind.h"
 #include "transformer_engine/transformer_engine.h"
+#include "common/common.h"
 
 namespace transformer_engine::pytorch {
 
@@ -275,6 +278,23 @@ std::vector<size_t> convertShape(const NVTEShape& shape) {
 int roundup(const int value, const int multiple) {
   assert(multiple > 0);
   return ((value + multiple - 1) / multiple) * multiple;
+}
+
+TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor) {
+  if (nvte_use_atomic_amax() || input_tensor.numel() == 0) {
+    // User chose atomic path, or empty tensor -> no need for workspace
+    return TensorWrapper{};
+  }
+
+  const auto N = static_cast<size_t>(input_tensor.numel());
+  constexpr size_t max_blocks_hw = 65535;
+
+  size_t max_blocks = DIVUP(N, static_cast<size_t>(amax_kernel_threads));
+  size_t workspace_blocks = std::min(max_blocks, max_blocks_hw);
+
+  at::Tensor ws = at::empty({static_cast<long>(workspace_blocks)}, at::CUDA(at::kFloat));
+
+  return makeTransformerEngineTensor(ws);
 }
 
 }  // namespace transformer_engine::pytorch

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -374,6 +374,8 @@ std::vector<size_t> convertShape(const NVTEShape& shape);
 
 int roundup(const int value, const int multiple);
 
+TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor);
+
 }  // namespace transformer_engine::pytorch
 
 namespace std {

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -374,8 +374,9 @@ std::vector<size_t> convertShape(const NVTEShape& shape);
 
 int roundup(const int value, const int multiple);
 
+#ifdef __HIP_PLATFORM_AMD__
 TensorWrapper allocate_amax_workspace(const TensorWrapper& input_tensor);
-
+#endif
 }  // namespace transformer_engine::pytorch
 
 namespace std {

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -38,13 +38,18 @@ py::object activation_helper(const at::Tensor& input, py::handle quantizer, int 
     auto [te_output_act, out_act] =
         my_quantizer_none->create_tensor(input_shape, GetTransformerEngineDType(fake_tensor_type));
 
+#ifdef __HIP_PLATFORM_AMD__
     auto workspace = allocate_amax_workspace(te_input);
-
+#endif
     NVTE_SCOPED_GIL_RELEASE({
       act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
       // use te_output_act as input to the compute amax and find the amax of activated tensor
+#ifdef __HIP_PLATFORM_AMD__
       nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
                         workspace.data(), at::cuda::getCurrentCUDAStream());
+#else
+      nvte_compute_amax(te_output_act.data(), te_output.data(), at::cuda::getCurrentCUDAStream());
+#endif
     });
 
     // my_quantizer here has to be a Float8CurrentScalingQuantizer

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -38,33 +38,14 @@ py::object activation_helper(const at::Tensor& input, py::handle quantizer, int 
     auto [te_output_act, out_act] =
         my_quantizer_none->create_tensor(input_shape, GetTransformerEngineDType(fake_tensor_type));
 
-    if (nvte_use_atomic_amax()) {
-       NVTE_SCOPED_GIL_RELEASE({
-        act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
-        // use te_output_act as input to the compute amax and find the amax of activated tensor
-        nvte_compute_amax(te_output_act.data(), te_output.data(),
-                          at::cuda::getCurrentCUDAStream());
-      });
-    } else {
-      // Workspace for nvte_compute_amax_with_workspace
-      const auto N = static_cast<size_t>(input_tensor.numel());
-      constexpr size_t max_blocks_hw = 65535;
+    auto workspace = allocate_amax_workspace(te_input);
 
-      // Worst-case (nvec = 1) upper bound on number of blocks
-      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
-
-      // Allocate FP32 workspace for block-wise amax
-      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
-
-      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
-
-      NVTE_SCOPED_GIL_RELEASE({
-        act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
-        // use te_output_act as input to the compute amax and find the amax of activated tensor
-        nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
-                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
-      });
-    }
+    NVTE_SCOPED_GIL_RELEASE({
+      act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
+      // use te_output_act as input to the compute amax and find the amax of activated tensor
+      nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
+                        workspace.data(), at::cuda::getCurrentCUDAStream());
+    });
 
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -36,10 +36,23 @@ py::object activation_helper(const at::Tensor& input, py::handle quantizer, int 
     auto [te_output_act, out_act] =
         my_quantizer_none->create_tensor(input_shape, GetTransformerEngineDType(fake_tensor_type));
 
+    // Workspace for nvte_compute_amax_with_workspace
+    const auto N = static_cast<size_t>(input_tensor.numel());
+    constexpr size_t max_blocks_hw = 65535;
+
+    // Worst-case (nvec = 1) upper bound on number of blocks
+    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+
+    // Allocate FP32 workspace for block-wise amax
+    auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+
+    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
     NVTE_SCOPED_GIL_RELEASE({
       act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
       // use te_output_act as input to the compute amax and find the amax of activated tensor
-      nvte_compute_amax(te_output_act.data(), te_output.data(), at::cuda::getCurrentCUDAStream());
+      nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
+                        te_workspace.data(), at::cuda::getCurrentCUDAStream());
     });
 
     // my_quantizer here has to be a Float8CurrentScalingQuantizer

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -38,24 +38,33 @@ py::object activation_helper(const at::Tensor& input, py::handle quantizer, int 
     auto [te_output_act, out_act] =
         my_quantizer_none->create_tensor(input_shape, GetTransformerEngineDType(fake_tensor_type));
 
-    // Workspace for nvte_compute_amax_with_workspace
-    const auto N = static_cast<size_t>(input_tensor.numel());
-    constexpr size_t max_blocks_hw = 65535;
+    if (nvte_use_atomic_amax()) {
+       NVTE_SCOPED_GIL_RELEASE({
+        act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
+        // use te_output_act as input to the compute amax and find the amax of activated tensor
+        nvte_compute_amax(te_output_act.data(), te_output.data(),
+                          at::cuda::getCurrentCUDAStream());
+      });
+    } else {
+      // Workspace for nvte_compute_amax_with_workspace
+      const auto N = static_cast<size_t>(input_tensor.numel());
+      constexpr size_t max_blocks_hw = 65535;
 
-    // Worst-case (nvec = 1) upper bound on number of blocks
-    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+      // Worst-case (nvec = 1) upper bound on number of blocks
+      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
-    // Allocate FP32 workspace for block-wise amax
-    auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+      // Allocate FP32 workspace for block-wise amax
+      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
 
-    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
 
-    NVTE_SCOPED_GIL_RELEASE({
-      act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
-      // use te_output_act as input to the compute amax and find the amax of activated tensor
-      nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
-                        te_workspace.data(), at::cuda::getCurrentCUDAStream());
-    });
+      NVTE_SCOPED_GIL_RELEASE({
+        act_func(te_input.data(), te_output_act.data(), at::cuda::getCurrentCUDAStream());
+        // use te_output_act as input to the compute amax and find the amax of activated tensor
+        nvte_compute_amax_with_workspace(te_output_act.data(), te_output.data(),
+                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
+      });
+    }
 
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());

--- a/transformer_engine/pytorch/csrc/extensions/bias.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/bias.cpp
@@ -51,22 +51,28 @@ std::vector<py::object> bgrad_quantize(const at::Tensor& input, py::handle py_qu
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(quantizer.get());
 
-    // Workspace for nvte_compute_amax_with_workspace
-    const auto N = static_cast<size_t>(input_tensor.numel());
-    constexpr size_t max_blocks_hw = 65535;
+    if (nvte_use_atomic_amax()) {
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax(input_tensor.data(), out_tensor.data(), at::cuda::getCurrentCUDAStream());
+      });
+    } else {
+      // Workspace for nvte_compute_amax_with_workspace
+      const auto N = static_cast<size_t>(input_tensor.numel());
+      constexpr size_t max_blocks_hw = 65535;
 
-    // Worst-case (nvec = 1) upper bound on number of blocks
-    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+      // Worst-case (nvec = 1) upper bound on number of blocks
+      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
-    // Allocate FP32 workspace for block-wise amax
-    auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+      // Allocate FP32 workspace for block-wise amax
+      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
 
-    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
 
-    NVTE_SCOPED_GIL_RELEASE({
-      nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
-                        te_workspace.data(), at::cuda::getCurrentCUDAStream());
-    });
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
+                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
+      });
+    }
 
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/bias.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/bias.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/pytorch/csrc/extensions/bias.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/bias.cpp
@@ -51,9 +51,13 @@ std::vector<py::object> bgrad_quantize(const at::Tensor& input, py::handle py_qu
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(quantizer.get());
     NVTE_SCOPED_GIL_RELEASE({
+#ifdef __HIP_PLATFORM_AMD__
       nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
                                        allocate_amax_workspace(input_tensor).data(),
                                        at::cuda::getCurrentCUDAStream());
+#else
+      nvte_compute_amax(input_tensor.data(), out_tensor.data(), at::cuda::getCurrentCUDAStream());
+#endif
     });
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/bias.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/bias.cpp
@@ -48,9 +48,24 @@ std::vector<py::object> bgrad_quantize(const at::Tensor& input, py::handle py_qu
   if (detail::IsFloat8CurrentScalingQuantizers(py_quantizer.ptr())) {
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(quantizer.get());
+
+    // Workspace for nvte_compute_amax_with_workspace
+    const auto N = static_cast<size_t>(input_tensor.numel());
+    constexpr size_t max_blocks_hw = 65535;
+
+    // Worst-case (nvec = 1) upper bound on number of blocks
+    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+
+    // Allocate FP32 workspace for block-wise amax
+    auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+
+    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
     NVTE_SCOPED_GIL_RELEASE({
-      nvte_compute_amax(input_tensor.data(), out_tensor.data(), at::cuda::getCurrentCUDAStream());
+      nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
+                        te_workspace.data(), at::cuda::getCurrentCUDAStream());
     });
+
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {
       c10::intrusive_ptr<dist_group_type> process_group_ptr = my_quantizer_cs->amax_reduction_group;

--- a/transformer_engine/pytorch/csrc/extensions/bias.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/bias.cpp
@@ -50,30 +50,11 @@ std::vector<py::object> bgrad_quantize(const at::Tensor& input, py::handle py_qu
   if (detail::IsFloat8CurrentScalingQuantizers(py_quantizer.ptr())) {
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(quantizer.get());
-
-    if (nvte_use_atomic_amax()) {
-      NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax(input_tensor.data(), out_tensor.data(), at::cuda::getCurrentCUDAStream());
-      });
-    } else {
-      // Workspace for nvte_compute_amax_with_workspace
-      const auto N = static_cast<size_t>(input_tensor.numel());
-      constexpr size_t max_blocks_hw = 65535;
-
-      // Worst-case (nvec = 1) upper bound on number of blocks
-      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
-
-      // Allocate FP32 workspace for block-wise amax
-      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
-
-      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
-
-      NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
-                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
-      });
-    }
-
+    NVTE_SCOPED_GIL_RELEASE({
+      nvte_compute_amax_with_workspace(input_tensor.data(), out_tensor.data(),
+                                       allocate_amax_workspace(input_tensor).data(),
+                                       at::cuda::getCurrentCUDAStream());
+    });
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {
       c10::intrusive_ptr<dist_group_type> process_group_ptr = my_quantizer_cs->amax_reduction_group;

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -55,13 +55,12 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());
 
-    // workspace for nvte_compute_amax_with_workspace
+    // Workspace for nvte_compute_amax_with_workspace
     const auto N = static_cast<size_t>(input_tensor.numel());
-    constexpr size_t threads = 512;          // FIXME: should match amax_kernel_threads
     constexpr size_t max_blocks_hw = 65535;
 
-    // Worst-case (nvec = 1) upper bound on number of blocks.
-    size_t max_blocks = std::min(DIVUP(N, threads), max_blocks_hw);
+    // Worst-case (nvec = 1) upper bound on number of blocks
+    size_t max_blocks = std::min(DIVUP(N, amax_kernel_threads), max_blocks_hw);
 
     // Allocate FP32 workspace for block-wise amax
     auto ws = at::empty({static_cast<long>(max_blocks)},

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -55,9 +55,13 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());
     NVTE_SCOPED_GIL_RELEASE({
+#ifdef __HIP_PLATFORM_AMD__
       nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
                                        allocate_amax_workspace(te_input).data(),
                                        at::cuda::getCurrentCUDAStream());
+#else
+      nvte_compute_amax(te_input.data(), te_output.data(), at::cuda::getCurrentCUDAStream());
+#endif
     });
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -52,8 +52,25 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
   if (detail::IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());
+
+    // workspace for nvte_compute_amax_with_workspace
+    const auto N = static_cast<size_t>(input_tensor.numel());
+    constexpr size_t threads = 512;          // FIXME: should match amax_kernel_threads
+    constexpr size_t max_blocks_hw = 65535;
+
+    // Worst-case (nvec = 1) upper bound on number of blocks.
+    size_t max_blocks = std::min(DIVUP(N, threads), max_blocks_hw);
+
+    // Allocate FP32 workspace for block-wise amax
+    auto ws = at::empty({static_cast<long>(max_blocks)},
+                        tensor.options().dtype(at::kFloat));
+
+    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
     NVTE_SCOPED_GIL_RELEASE({
-      nvte_compute_amax(te_input.data(), te_output.data(), at::cuda::getCurrentCUDAStream());
+      nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
+          te_workspace.data(),
+          at::cuda::getCurrentCUDAStream());
     });
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -55,24 +55,32 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());
 
-    // Workspace for nvte_compute_amax_with_workspace
-    const auto N = static_cast<size_t>(input_tensor.numel());
-    constexpr size_t max_blocks_hw = 65535;
+    if (nvte_use_atomic_amax()) {
+       NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax(te_input.data(), te_output.data(),
+            at::cuda::getCurrentCUDAStream());
+      });
+    } else {
+      // Workspace for nvte_compute_amax_with_workspace
+      const auto N = static_cast<size_t>(input_tensor.numel());
+      constexpr size_t max_blocks_hw = 65535;
 
-    // Worst-case (nvec = 1) upper bound on number of blocks
-    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+      // Worst-case (nvec = 1) upper bound on number of blocks
+      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
-    // Allocate FP32 workspace for block-wise amax
-    auto ws = at::empty({static_cast<long>(max_blocks)},
-                        tensor.options().dtype(at::kFloat));
+      // Allocate FP32 workspace for block-wise amax
+      auto ws = at::empty({static_cast<long>(max_blocks)},
+                          tensor.options().dtype(at::kFloat));
 
-    TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
 
-    NVTE_SCOPED_GIL_RELEASE({
-      nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
-          te_workspace.data(),
-          at::cuda::getCurrentCUDAStream());
-    });
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
+            te_workspace.data(),
+            at::cuda::getCurrentCUDAStream());
+      });
+    }
+
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {
       c10::intrusive_ptr<dist_group_type> process_group_ptr = my_quantizer_cs->amax_reduction_group;

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -54,33 +54,11 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
   if (detail::IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
     // my_quantizer here has to be a Float8CurrentScalingQuantizer
     auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer*>(my_quantizer.get());
-
-    if (nvte_use_atomic_amax()) {
-       NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax(te_input.data(), te_output.data(),
-            at::cuda::getCurrentCUDAStream());
-      });
-    } else {
-      // Workspace for nvte_compute_amax_with_workspace
-      const auto N = static_cast<size_t>(input_tensor.numel());
-      constexpr size_t max_blocks_hw = 65535;
-
-      // Worst-case (nvec = 1) upper bound on number of blocks
-      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
-
-      // Allocate FP32 workspace for block-wise amax
-      auto ws = at::empty({static_cast<long>(max_blocks)},
-                          tensor.options().dtype(at::kFloat));
-
-      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
-
-      NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
-            te_workspace.data(),
-            at::cuda::getCurrentCUDAStream());
-      });
-    }
-
+    NVTE_SCOPED_GIL_RELEASE({
+      nvte_compute_amax_with_workspace(te_input.data(), te_output.data(),
+                                       allocate_amax_workspace(te_input).data(),
+                                       at::cuda::getCurrentCUDAStream());
+    });
     // check if we need to do amax reudction (depending on model parallel configs)
     if (my_quantizer_cs->with_amax_reduction) {
       c10::intrusive_ptr<dist_group_type> process_group_ptr = my_quantizer_cs->amax_reduction_group;

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -60,7 +60,7 @@ py::object quantize(const at::Tensor& tensor, py::handle quantizer, const py::ob
     constexpr size_t max_blocks_hw = 65535;
 
     // Worst-case (nvec = 1) upper bound on number of blocks
-    size_t max_blocks = std::min(DIVUP(N, amax_kernel_threads), max_blocks_hw);
+    size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
     // Allocate FP32 workspace for block-wise amax
     auto ws = at::empty({static_cast<long>(max_blocks)},

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -144,22 +144,29 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
 
-      // Workspace for nvte_compute_amax_with_workspace
-      const auto N = static_cast<size_t>(unquantized_out_cu.numel());
-      constexpr size_t max_blocks_hw = 65535;
+      if (nvte_use_atomic_amax()) {
+        NVTE_SCOPED_GIL_RELEASE({
+          nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+                          at::cuda::getCurrentCUDAStream());
+        });
+      } else {
+        // Workspace for nvte_compute_amax_with_workspace
+        const auto N = static_cast<size_t>(unquantized_out_cu.numel());
+        constexpr size_t max_blocks_hw = 65535;
 
-      // Worst-case (nvec = 1) upper bound on number of blocks
-      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+        // Worst-case (nvec = 1) upper bound on number of blocks
+        size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
-      // Allocate FP32 workspace for block-wise amax
-      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+        // Allocate FP32 workspace for block-wise amax
+        auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
 
-      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+        TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
 
-      NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
-                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
-      });
+        NVTE_SCOPED_GIL_RELEASE({
+          nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                            te_workspace.data(), at::cuda::getCurrentCUDAStream());
+        });
+      }
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
         c10::intrusive_ptr<dist_group_type> process_group_ptr =
@@ -315,22 +322,30 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
 
-      // Workspace for nvte_compute_amax_with_workspace
-      const auto N = static_cast<size_t>(unquantized_out_cu.numel());
-      constexpr size_t max_blocks_hw = 65535;
+      if (nvte_use_atomic_amax()) {
+        NVTE_SCOPED_GIL_RELEASE({
+          nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+                          at::cuda::getCurrentCUDAStream());
+        });
+      } else {
 
-      // Worst-case (nvec = 1) upper bound on number of blocks
-      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+        // Workspace for nvte_compute_amax_with_workspace
+        const auto N = static_cast<size_t>(unquantized_out_cu.numel());
+        constexpr size_t max_blocks_hw = 65535;
 
-      // Allocate FP32 workspace for block-wise amax
-      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+        // Worst-case (nvec = 1) upper bound on number of blocks
+        size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
 
-      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+        // Allocate FP32 workspace for block-wise amax
+        auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
 
-      NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
-                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
-      });
+        TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
+        NVTE_SCOPED_GIL_RELEASE({
+          nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                            te_workspace.data(), at::cuda::getCurrentCUDAStream());
+        });
+      }
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
         c10::intrusive_ptr<dist_group_type> process_group_ptr =

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -144,9 +144,14 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       NVTE_SCOPED_GIL_RELEASE({
+#ifdef __HIP_PLATFORM_AMD__
         nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
                                          allocate_amax_workspace(unquantized_out_cu).data(),
                           at::cuda::getCurrentCUDAStream());
+#else
+        nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+                          at::cuda::getCurrentCUDAStream());
+#endif
       });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
@@ -303,9 +308,14 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       NVTE_SCOPED_GIL_RELEASE({
+#ifdef __HIP_PLATFORM_AMD__
         nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
                                          allocate_amax_workspace(unquantized_out_cu).data(),
                           at::cuda::getCurrentCUDAStream());
+#else
+        nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+                          at::cuda::getCurrentCUDAStream());
+#endif
       });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -143,30 +143,11 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
-
-      if (nvte_use_atomic_amax()) {
-        NVTE_SCOPED_GIL_RELEASE({
-          nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                                         allocate_amax_workspace(unquantized_out_cu).data(),
                           at::cuda::getCurrentCUDAStream());
-        });
-      } else {
-        // Workspace for nvte_compute_amax_with_workspace
-        const auto N = static_cast<size_t>(unquantized_out_cu.numel());
-        constexpr size_t max_blocks_hw = 65535;
-
-        // Worst-case (nvec = 1) upper bound on number of blocks
-        size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
-
-        // Allocate FP32 workspace for block-wise amax
-        auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
-
-        TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
-
-        NVTE_SCOPED_GIL_RELEASE({
-          nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
-                            te_workspace.data(), at::cuda::getCurrentCUDAStream());
-        });
-      }
+      });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
         c10::intrusive_ptr<dist_group_type> process_group_ptr =
@@ -321,31 +302,11 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
-
-      if (nvte_use_atomic_amax()) {
-        NVTE_SCOPED_GIL_RELEASE({
-          nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                                         allocate_amax_workspace(unquantized_out_cu).data(),
                           at::cuda::getCurrentCUDAStream());
-        });
-      } else {
-
-        // Workspace for nvte_compute_amax_with_workspace
-        const auto N = static_cast<size_t>(unquantized_out_cu.numel());
-        constexpr size_t max_blocks_hw = 65535;
-
-        // Worst-case (nvec = 1) upper bound on number of blocks
-        size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
-
-        // Allocate FP32 workspace for block-wise amax
-        auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
-
-        TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
-
-        NVTE_SCOPED_GIL_RELEASE({
-          nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
-                            te_workspace.data(), at::cuda::getCurrentCUDAStream());
-        });
-      }
+      });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
         c10::intrusive_ptr<dist_group_type> process_group_ptr =

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -143,9 +143,22 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
+
+      // Workspace for nvte_compute_amax_with_workspace
+      const auto N = static_cast<size_t>(unquantized_out_cu.numel());
+      constexpr size_t max_blocks_hw = 65535;
+
+      // Worst-case (nvec = 1) upper bound on number of blocks
+      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+
+      // Allocate FP32 workspace for block-wise amax
+      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+
+      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
       NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
-                          at::cuda::getCurrentCUDAStream());
+        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
       });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {
@@ -301,9 +314,22 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
       // my_quantizer here has to be a Float8CurrentScalingQuantizer
       auto my_quantizer_cs = static_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
+
+      // Workspace for nvte_compute_amax_with_workspace
+      const auto N = static_cast<size_t>(unquantized_out_cu.numel());
+      constexpr size_t max_blocks_hw = 65535;
+
+      // Worst-case (nvec = 1) upper bound on number of blocks
+      size_t max_blocks = std::min(DIVUP(N, static_cast<size_t>(amax_kernel_threads)), max_blocks_hw);
+
+      // Allocate FP32 workspace for block-wise amax
+      auto ws = at::empty({static_cast<long>(max_blocks)}, at::CUDA(at::kFloat));
+
+      TensorWrapper te_workspace = makeTransformerEngineTensor(ws);
+
       NVTE_SCOPED_GIL_RELEASE({
-        nvte_compute_amax(unquantized_out_cu.data(), out_cu.data(),
-                          at::cuda::getCurrentCUDAStream());
+        nvte_compute_amax_with_workspace(unquantized_out_cu.data(), out_cu.data(),
+                          te_workspace.data(), at::cuda::getCurrentCUDAStream());
       });
       // check if we need to do amax reudction (depending on model parallel configs)
       if (my_quantizer_cs->with_amax_reduction) {

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -1,4 +1,6 @@
 /*************************************************************************
+ * This file was modified for portability to AMDGPU
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -20,8 +20,25 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
 
   TORCH_CHECK(amax.scalar_type() == at::kFloat, "amax must be a float tensor");
   TORCH_CHECK(amax.numel() == 1, "amax must have exactly one element");
+
+  // Compute an upper bound on the number of blocks for this input.
+  const auto N = input_tensor.numel();
+  constexpr size_t threads = 512;  // FIXME: should grab amax_kernel_threads here
+  constexpr size_t max_blocks_hw = 65535;
+
+  // Assume worst-case vectorization (nvec = 1) as an upper bound.
+  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), threads),
+                               max_blocks_hw);
+
+  // Allocate workspace for the fake output tensor.
+  // This will be the block_amax buffer.
+  auto ws = at::empty({static_cast<long>(max_blocks)},
+                      tensor.options().dtype(at::kFloat));
+
+  std::vector<size_t> ws_shape{static_cast<size_t>(max_blocks)};
+
   TensorWrapper fake_te_output(
-      nullptr, te_input.shape(),
+      ws.data_ptr(), ws_shape,
       DType::kFloat8E4M3,  // It doesn't matter because we only compute amax.
       amax.data_ptr<float>());
 

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -28,7 +28,7 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
   constexpr size_t max_blocks_hw = 65535;
 
   // Assume worst-case vectorization (nvec = 1) as an upper bound.
-  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), amax_kernel_threads),
+  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), static_cast<size_t>(amax_kernel_threads)),
                                max_blocks_hw);
 
   // Allocate workspace for the block_amax buffer.

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -22,37 +22,14 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
 
   TORCH_CHECK(amax.scalar_type() == at::kFloat, "amax must be a float tensor");
   TORCH_CHECK(amax.numel() == 1, "amax must have exactly one element");
-
   TensorWrapper fake_te_output(
       nullptr, te_input.shape(),
       DType::kFloat8E4M3,  // It doesn't matter because we only compute amax.
       amax.data_ptr<float>());
 
-  if (nvte_use_atomic_amax()) {
-    nvte_compute_amax(te_input.data(), fake_te_output.data(),at::cuda::getCurrentCUDAStream());
-  } else {
-    // Compute an upper bound on the number of blocks for this input
-    const auto N = input_tensor.numel();
-    constexpr size_t max_blocks_hw = 65535;
-
-    // Assume worst-case vectorization (nvec = 1) as an upper bound
-    size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), static_cast<size_t>(amax_kernel_threads)),
-                                max_blocks_hw);
-
-    // Allocate workspace for the block_amax buffer
-    auto ws = at::empty({static_cast<long>(max_blocks)},
-                        tensor.options().dtype(at::kFloat));
-
-    std::vector<size_t> ws_shape{static_cast<size_t>(max_blocks)};
-
-    TensorWrapper te_workspace(
-        ws.data_ptr(), ws_shape,
-        DType::kFloat32,
-        nullptr
-    );
-
-    nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(), te_workspace.data(), at::cuda::getCurrentCUDAStream());
-  }
+  nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(),
+                                   allocate_amax_workspace(te_input).data(),
+                                   at::cuda::getCurrentCUDAStream());
 }
 
 void fused_amax_and_scale_update_after_reduction(const at::Tensor& amax_reduction_buffer,

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -27,9 +27,13 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
       DType::kFloat8E4M3,  // It doesn't matter because we only compute amax.
       amax.data_ptr<float>());
 
+#ifdef __HIP_PLATFORM_AMD__
   nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(),
                                    allocate_amax_workspace(te_input).data(),
                                    at::cuda::getCurrentCUDAStream());
+#else
+  nvte_compute_amax(te_input.data(), fake_te_output.data(), at::cuda::getCurrentCUDAStream());
+#endif
 }
 
 void fused_amax_and_scale_update_after_reduction(const at::Tensor& amax_reduction_buffer,

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -25,11 +25,10 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
 
   // Compute an upper bound on the number of blocks for this input.
   const auto N = input_tensor.numel();
-  constexpr size_t threads = 512;  // FIXME: should grab amax_kernel_threads here
   constexpr size_t max_blocks_hw = 65535;
 
   // Assume worst-case vectorization (nvec = 1) as an upper bound.
-  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), threads),
+  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), amax_kernel_threads),
                                max_blocks_hw);
 
   // Allocate workspace for the block_amax buffer.

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -23,32 +23,36 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
   TORCH_CHECK(amax.scalar_type() == at::kFloat, "amax must be a float tensor");
   TORCH_CHECK(amax.numel() == 1, "amax must have exactly one element");
 
-  // Compute an upper bound on the number of blocks for this input.
-  const auto N = input_tensor.numel();
-  constexpr size_t max_blocks_hw = 65535;
-
-  // Assume worst-case vectorization (nvec = 1) as an upper bound.
-  size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), static_cast<size_t>(amax_kernel_threads)),
-                               max_blocks_hw);
-
-  // Allocate workspace for the block_amax buffer.
-  auto ws = at::empty({static_cast<long>(max_blocks)},
-                      tensor.options().dtype(at::kFloat));
-
-  std::vector<size_t> ws_shape{static_cast<size_t>(max_blocks)};
-
   TensorWrapper fake_te_output(
       nullptr, te_input.shape(),
       DType::kFloat8E4M3,  // It doesn't matter because we only compute amax.
       amax.data_ptr<float>());
 
-  TensorWrapper te_workspace(
-      ws.data_ptr(), ws_shape,
-      DType::kFloat32,
-      nullptr
-  );
+  if (nvte_use_atomic_amax()) {
+    nvte_compute_amax(te_input.data(), fake_te_output.data(),at::cuda::getCurrentCUDAStream());
+  } else {
+    // Compute an upper bound on the number of blocks for this input
+    const auto N = input_tensor.numel();
+    constexpr size_t max_blocks_hw = 65535;
 
-  nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(), te_workspace.data(), at::cuda::getCurrentCUDAStream());
+    // Assume worst-case vectorization (nvec = 1) as an upper bound
+    size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), static_cast<size_t>(amax_kernel_threads)),
+                                max_blocks_hw);
+
+    // Allocate workspace for the block_amax buffer
+    auto ws = at::empty({static_cast<long>(max_blocks)},
+                        tensor.options().dtype(at::kFloat));
+
+    std::vector<size_t> ws_shape{static_cast<size_t>(max_blocks)};
+
+    TensorWrapper te_workspace(
+        ws.data_ptr(), ws_shape,
+        DType::kFloat32,
+        nullptr
+    );
+
+    nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(), te_workspace.data(), at::cuda::getCurrentCUDAStream());
+  }
 }
 
 void fused_amax_and_scale_update_after_reduction(const at::Tensor& amax_reduction_buffer,

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cpp
@@ -30,19 +30,24 @@ void compute_amax(const at::Tensor& tensor, at::Tensor& amax) {
   size_t max_blocks = std::min(DIVUP(static_cast<size_t>(N), threads),
                                max_blocks_hw);
 
-  // Allocate workspace for the fake output tensor.
-  // This will be the block_amax buffer.
+  // Allocate workspace for the block_amax buffer.
   auto ws = at::empty({static_cast<long>(max_blocks)},
                       tensor.options().dtype(at::kFloat));
 
   std::vector<size_t> ws_shape{static_cast<size_t>(max_blocks)};
 
   TensorWrapper fake_te_output(
-      ws.data_ptr(), ws_shape,
+      nullptr, te_input.shape(),
       DType::kFloat8E4M3,  // It doesn't matter because we only compute amax.
       amax.data_ptr<float>());
 
-  nvte_compute_amax(te_input.data(), fake_te_output.data(), at::cuda::getCurrentCUDAStream());
+  TensorWrapper te_workspace(
+      ws.data_ptr(), ws_shape,
+      DType::kFloat32,
+      nullptr
+  );
+
+  nvte_compute_amax_with_workspace(te_input.data(), fake_te_output.data(), te_workspace.data(), at::cuda::getCurrentCUDAStream());
 }
 
 void fused_amax_and_scale_update_after_reduction(const at::Tensor& amax_reduction_buffer,


### PR DESCRIPTION
# Description

Implements a two-stage HIP kernel for the amax operation, as an alternative to the original implementation that uses atomic reductions. Make the two-stage kernel the default implementation. Users can use `export NVTE_USE_ATOMIC_AMAX=1` to use the atomic amax kernel.

The corresponding Triton kernel is at #385.

Fixes https://github.com/ROCm/frameworks-internal/issues/14303.

See https://github.com/ROCm/frameworks-internal/issues/14303#issuecomment-3554900809 for a performance analysis.

**TODO:**
- [x] Fix other call sites of `nvte_compute_amax`
- [x] Address `FIXME`s in the code

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
