### PR TITLE
CI: Fix failures on forked PRs and centralize Docker image config

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -50,28 +50,6 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
         
-      - name: Merge origin/dev
-        # Only run on PRs targeting dev, or manual runs where we didn't skip it
-        if: |
-          (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
-          (github.event_name == 'workflow_dispatch' && inputs.skip_dev_merge != 'true' && github.ref == 'refs/heads/dev')
-        run: |
-          echo "Attempting to merge origin/dev..."
-          git config --global user.email "amd@amd.com"
-          git config --global user.name "AMD CI"
-          
-          # Fetch dev specifically
-          git fetch origin dev
-
-          # Attempt merge; this will exit with error code 1 if there is a conflict, failing the job
-          git merge origin/dev
-
-          # Update submodules after merge to ensure new files are present
-          echo "Updating submodules after merge..."
-          git submodule update --init --recursive
-
-          echo "Merge successful."
-
       - name: Host Diagnostics & Environment Setup
         id: host-setup
         run: |
@@ -96,13 +74,17 @@ jobs:
           # Default to input (or '1' if input is missing/null)
           CALC_LEVEL="${{ inputs.test_level || '1' }}"
 
-          # If this is a Push event to 'dev', force Level 3
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
-            echo "::notice::Push to dev detected. Forcing Test Level to 3."
-            CALC_LEVEL="3"
+          # Check for scenarios that require forcing Level 3
+          #    Scenario A: Push event to dev or one of the monitored branches
+          #    Scenario B: PR event targeting dev
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+             if [[ "${{ github.ref_name }}" == "dev" || "${{ github.ref_name }}" =~ ^release_v.*_rocm$ ]]; then
+                echo "::notice::Push to monitored branch (${{ github.ref_name }}) detected. Forcing Level 3."
+                CALC_LEVEL="3"
+             fi
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" ]]; then
-            echo "::notice::PR targeting dev detected. Forcing Test Level to 3."
-            CALC_LEVEL="3"
+             echo "::notice::PR targeting dev detected. Forcing Level 3."
+             CALC_LEVEL="3"
           fi
           
           echo "TEST_LEVEL=$CALC_LEVEL" >> $GITHUB_ENV
@@ -112,6 +94,7 @@ jobs:
           echo "Final Test Level: $CALC_LEVEL"
           echo "Event Name: ${{ github.event_name }}"
           echo "Ref Name: ${{ github.ref_name }}"
+          echo "Base Ref: ${{ github.base_ref }}"
           env | sort
           echo "::endgroup::"
 

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Select Docker Image Tag
         id: select-image
         run: |
-          # Donload config from the dev branch
+          # Download config from the dev branch
           # We force fetch from 'dev' so all release branches/forks get the latest image tags instantly
-          CONFIG_URL="https://raw.githubusercontent.com/Your-Org/Your-Repo/dev/ci/ci_config.json"
+          CONFIG_URL="https://raw.githubusercontent.com/ROCm/TransformerEngine/dev/ci/ci_config.json"
           
           echo "Fetching image config from: $CONFIG_URL"
           curl -s -f -o docker_config.json "$CONFIG_URL" || { echo "::error::Failed to fetch config from dev branch"; exit 1; }

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -29,6 +29,10 @@ on:
         description: 'Manual Docker Image (Leave empty to use config file value)'
         required: false
         type: string
+      test_config_from_source:
+        description: 'DEBUG: Use config.json from current source branch instead of dev'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -68,52 +72,87 @@ jobs:
 
           echo "Merge successful."
 
-      - name: Print Environment and Variables
+      - name: Host Diagnostics & Environment Setup
+        id: host-setup
         run: |
-          echo "::group::Shell Environment Variables"
-          env | sort
+          # Host Activity Checks
+          echo "::group::Host Diagnostics"
+
+          echo ">>> Active Containers:"
+          docker ps -a
+
+          echo ">>> ROCm Installation:"
+          ls -l /opt/rocm* || echo "No /opt/rocm found"
+          echo ">>> GPU info:"
+          ls -l /dev/dri
+          ls -l /dev/kfd
+          rocm-smi
+
+          echo ">>> Kernel Command Line:"
+          cat /proc/cmdline
           echo "::endgroup::"
 
-          echo "::group::Repository Variables (vars context)"
-          echo '${{ toJSON(vars) }}'
+          # Calculate Test Level
+          # Default to input (or '1' if input is missing/null)
+          CALC_LEVEL="${{ inputs.test_level || '1' }}"
+
+          # If this is a Push event to 'dev', force Level 3
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
+            echo "::notice::Push to dev detected. Forcing Test Level to 3."
+            CALC_LEVEL="3"
+          fi
+          echo "TEST_LEVEL=$CALC_LEVEL" >> $GITHUB_ENV
+
+          # Print Final Environment
+          echo "::group::Environment & Parameters"
+          echo "Final Test Level: $CALC_LEVEL"
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Ref Name: ${{ github.ref_name }}"
+          env | sort
           echo "::endgroup::"
 
       - name: Select Docker Image Tag
         id: select-image
         run: |
-          # Download config from the dev branch
-          # We force fetch from 'dev' so all release branches/forks get the latest image tags instantly
-          CONFIG_URL="https://raw.githubusercontent.com/ROCm/TransformerEngine/dev/ci/ci_config.json"
+          # Determine config source
+          # Default to fetching from 'dev' branch
+          CONFIG_BRANCH="dev"
+          
+          # If manual run requesting source config, switch branch
+          if [[ "${{ inputs.test_config_from_source }}" == "true" ]]; then
+             CONFIG_BRANCH="${{ github.ref_name }}"
+             echo "::notice::Debugging mode: Fetching config from current branch ($CONFIG_BRANCH)"
+          fi
+
+          # Download config
+          CONFIG_URL="https://raw.githubusercontent.com/ROCm/TransformerEngine/${CONFIG_BRANCH}/ci/ci_config.json"
           
           echo "Fetching image config from: $CONFIG_URL"
-          curl -s -f -o docker_config.json "$CONFIG_URL" || { echo "::error::Failed to fetch config from dev branch"; exit 1; }
+          curl -s -f -o docker_config.json "$CONFIG_URL" || { echo "::error::Failed to fetch config"; exit 1; }
 
-          # Extract vars
-          DEV_DOCKER_IMAGE=$(jq -r '.dev_docker_image' ci_config.json)
-          REL613_DOCKER_IMAGE=$(jq -r '.rel613_docker_image' ci_config.json)
-
-          # Determine branch and read json
+          # Determine image key
           BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
           echo "Determining image for branch: $BRANCH_NAME"
           
-          # Default to dev image
-          IMAGE_TO_USE="$DEV_DOCKER_IMAGE"
+          # Logic: Check if branch matches "release_vX.X". 
+          # If so, look for that key in JSON. Otherwise default.
+          JSON_KEY="default"
           
-          # Check for release patterns
-          if [[ $BRANCH_NAME =~ ^release_v([0-9]+)\.([0-9]+)_rocm$ ]]; then
-            MAJOR_VERSION=${BASH_REMATCH[1]}
-            MINOR_VERSION=${BASH_REMATCH[2]}
-            if (( MAJOR_VERSION == 1 )); then
-              # If 1.13 or 1.14, switch to the REL613 image
-              if (( MINOR_VERSION == 13 || MINOR_VERSION == 14 )); then 
-                IMAGE_TO_USE="$REL613_DOCKER_IMAGE"
-              fi
+          if [[ $BRANCH_NAME =~ ^release_v([0-9]+\.[0-9]+)_rocm$ ]]; then
+            VERSION_KEY="release_v${BASH_REMATCH[1]}"
+            # Check if this specific version key exists in the JSON
+            if [[ $(jq "(.docker_images | has(\"$VERSION_KEY\"))" docker_config.json) == "true" ]]; then
+               JSON_KEY="$VERSION_KEY"
             fi
           fi
+          
+          echo "Selected config key: $JSON_KEY"
 
-          # Check for manual override
+          # Extract image name from json
+          IMAGE_TO_USE=$(jq -r ".docker_images.\"$JSON_KEY\"" docker_config.json)
+
+          # Check input from workflow_dispatch overriding the image
           MANUAL_OVERRIDE="${{ inputs.docker_image_override }}"
-
           if [[ -n "$MANUAL_OVERRIDE" ]]; then
             echo "::notice::Manual override detected: $MANUAL_OVERRIDE"
             IMAGE_TO_USE="$MANUAL_OVERRIDE"
@@ -140,31 +179,41 @@ jobs:
             -w /workspace \
             ${{ steps.select-image.outputs.image-tag}}
 
-      - name: ROCM Diagnostics
+      - name: Container Diagnostics & GPU Setup
+        id: container-diag
         run: |
-          # On the runner
-          rocm-smi
-          # In the container
-          docker exec te-runner rocm-smi
+          echo "::group::Container Configuration"
+          # Check Shared Memory Size inside container
+          echo ">>> /dev/shm size:"
+          docker exec te-runner df -h /dev/shm
+          
+          # Check OS/Kernel inside container
+          echo ">>> Container OS:"
+          docker exec te-runner cat /etc/os-release | grep PRETTY_NAME
+          echo "::endgroup::"
 
-      - name: Determine GPU Architecture via rocminfo
-        id: gpu-arch
-        run: |
+          echo "::group::ROCm Diagnostics (Host vs Container)"
+          echo ">>> CONTAINER rocm-smi:"
+          docker exec te-runner rocm-smi || true
+          echo "::endgroup::"
+
+          # Determine Architecture
           # Run rocminfo inside the container and capture the output
           ARCH=$(docker exec te-runner bash -c "rocminfo | grep -m 1 -oP 'gfx[0-9a-fA-F]+'")
+          
           if [ -z "$ARCH" ]; then
             echo "::error::Could not determine GPU architecture using rocminfo inside the container."
-            # Optional: Print full rocminfo output for debugging
             docker exec te-runner rocminfo
             exit 1
           fi
+          
           echo "Detected GPU Arch: $ARCH"
           echo "arch=$ARCH" >> $GITHUB_OUTPUT
 
       - name: Build Project
         run: |
           docker exec \
-            -e GPU_ARCH=${{ steps.gpu-arch.outputs.arch }} \
+            -e GPU_ARCH=${{ steps.container-diag.outputs.arch }} \
             te-runner bash -c "$(cat <<'EOF'
           set -ex
           
@@ -186,7 +235,7 @@ jobs:
 
           docker exec \
             -e TEST_SGPU=1 \
-            -e TEST_LEVEL=${{ inputs.test_level || '1' }} \
+            -e TEST_LEVEL=${{ env.TEST_LEVEL }} \
             te-runner bash -c "$(cat <<'EOF'
           #!/usr/bin/bash
           set -x -o pipefail
@@ -253,7 +302,7 @@ jobs:
         run: |
           docker exec \
             -e TEST_MGPU=1 \
-            -e TEST_LEVEL=${{ inputs.test_level || '1' }} \
+            -e TEST_LEVEL=${{ env.TEST_LEVEL }} \
             te-runner bash -c "$(cat <<'EOF'
           #!/usr/bin/bash
           set -x -o pipefail

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -115,7 +115,7 @@ jobs:
         id: select-image
         run: |
           # Determine config source
-          # Default to fetching from 'dev' branch
+          # Default we are fetching from 'dev' branch
           CONFIG_BRANCH="dev"
           
           # If manual run requesting source config, switch branch
@@ -126,9 +126,22 @@ jobs:
 
           # Download config
           CONFIG_URL="https://raw.githubusercontent.com/ROCm/TransformerEngine/${CONFIG_BRANCH}/ci/ci_config.json"
+          echo "Attempting to fetch image config from: $CONFIG_URL"
           
-          echo "Fetching image config from: $CONFIG_URL"
-          curl -s -f -o docker_config.json "$CONFIG_URL" || { echo "::error::Failed to fetch config"; exit 1; }
+          if curl -s -f -o docker_config.json "$CONFIG_URL"; then
+             echo "Successfully downloaded config from $CONFIG_BRANCH."
+          else
+             echo "::warning::Failed to fetch config from $CONFIG_BRANCH (File might not exist yet)."
+             
+             # Fallback: Check source branch file
+             if [[ -f "ci/ci_config.json" ]]; then
+                echo "::notice::Falling back to local 'ci/ci_config.json' from checkout."
+                cp ci/ci_config.json docker_config.json
+             else
+                echo "::error::Config file not found in $CONFIG_BRANCH OR locally."
+                exit 1
+             fi
+          fi
 
           # Determine image key
           BRANCH_NAME="${{ github.base_ref || github.ref_name }}"

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -76,22 +76,37 @@ jobs:
 
       - name: Select Docker Image Tag
         id: select-image
-        env:
-          DEV_IMAGE: ${{ vars.DEV_DOCKER_IMAGE }}
-          REL_IMAGE: ${{ vars.REL613_DOCKER_IMAGE }}
         run: |
+          # Donload config from the dev branch
+          # We force fetch from 'dev' so all release branches/forks get the latest image tags instantly
+          CONFIG_URL="https://raw.githubusercontent.com/Your-Org/Your-Repo/dev/ci/ci_config.json"
+          
+          echo "Fetching image config from: $CONFIG_URL"
+          curl -s -f -o docker_config.json "$CONFIG_URL" || { echo "::error::Failed to fetch config from dev branch"; exit 1; }
+
+          # Extract vars
+          DEV_DOCKER_IMAGE=$(jq -r '.dev_docker_image' ci_config.json)
+          REL613_DOCKER_IMAGE=$(jq -r '.rel613_docker_image' ci_config.json)
+
+          # Determine branch and read json
           BRANCH_NAME="${{ github.base_ref || github.ref_name }}"
           echo "Determining image for branch: $BRANCH_NAME"
-          DEV_DOCKER_IMAGE="$DEV_IMAGE"
-          REL613_DOCKER_IMAGE="$REL_IMAGE"
+          
+          # Default to dev image
           IMAGE_TO_USE="$DEV_DOCKER_IMAGE"
+          
+          # Check for release patterns
           if [[ $BRANCH_NAME =~ ^release_v([0-9]+)\.([0-9]+)_rocm$ ]]; then
             MAJOR_VERSION=${BASH_REMATCH[1]}
             MINOR_VERSION=${BASH_REMATCH[2]}
             if (( MAJOR_VERSION == 1 )); then
-              if (( MINOR_VERSION == 13 || MINOR_VERSION == 14 )); then IMAGE_TO_USE="$REL613_DOCKER_IMAGE"; fi
+              # If 1.13 or 1.14, switch to the REL613 image
+              if (( MINOR_VERSION == 13 || MINOR_VERSION == 14 )); then 
+                IMAGE_TO_USE="$REL613_DOCKER_IMAGE"
+              fi
             fi
           fi
+          
           echo "Selected image: $IMAGE_TO_USE"
           echo "image-tag=$IMAGE_TO_USE" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -25,6 +25,10 @@ on:
         description: 'Skip merging dev branch'
         type: boolean
         default: false
+      docker_image_override:
+        description: 'Manual Docker Image (Leave empty to use config file value)'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -105,6 +109,14 @@ jobs:
                 IMAGE_TO_USE="$REL613_DOCKER_IMAGE"
               fi
             fi
+          fi
+
+          # Check for manual override
+          MANUAL_OVERRIDE="${{ inputs.docker_image_override }}"
+
+          if [[ -n "$MANUAL_OVERRIDE" ]]; then
+            echo "::notice::Manual override detected: $MANUAL_OVERRIDE"
+            IMAGE_TO_USE="$MANUAL_OVERRIDE"
           fi
           
           echo "Selected image: $IMAGE_TO_USE"

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -60,7 +60,7 @@ jobs:
           docker ps -a
 
           echo ">>> ROCm Installation:"
-          ls -l /opt/rocm* || echo "No /opt/rocm found"
+          ls -d /opt/rocm* || echo "No /opt/rocm found"
           echo ">>> GPU info:"
           ls -l /dev/dri
           ls -l /dev/kfd

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -100,7 +100,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
             echo "::notice::Push to dev detected. Forcing Test Level to 3."
             CALC_LEVEL="3"
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" ]]; then
+            echo "::notice::PR targeting dev detected. Forcing Test Level to 3."
+            CALC_LEVEL="3"
           fi
+          
           echo "TEST_LEVEL=$CALC_LEVEL" >> $GITHUB_ENV
 
           # Print Final Environment

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -74,17 +74,12 @@ jobs:
           # Default to input (or '1' if input is missing/null)
           CALC_LEVEL="${{ inputs.test_level || '1' }}"
 
-          # Check for scenarios that require forcing Level 3
-          #    Scenario A: Push event to dev or one of the monitored branches
-          #    Scenario B: PR event targeting dev
+          # COnly force Level 3 if this is a direct PUSH to dev or a release branch
           if [[ "${{ github.event_name }}" == "push" ]]; then
              if [[ "${{ github.ref_name }}" == "dev" || "${{ github.ref_name }}" =~ ^release_v.*_rocm$ ]]; then
                 echo "::notice::Push to monitored branch (${{ github.ref_name }}) detected. Forcing Level 3."
                 CALC_LEVEL="3"
              fi
-          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" ]]; then
-             echo "::notice::PR targeting dev detected. Forcing Level 3."
-             CALC_LEVEL="3"
           fi
           
           echo "TEST_LEVEL=$CALC_LEVEL" >> $GITHUB_ENV

--- a/ci/ci_config.json
+++ b/ci/ci_config.json
@@ -1,0 +1,4 @@
+{
+  "dev_docker_image": "registry-sc-harbor.amd.com/framework/te-ci:rocm-7.0.2_ubuntu22.04_py3.10_pytorch_release-2.7_9015dfdf_jax_v0.6.0_fa-v2.8.0",
+  "rel613_docker_image": "compute-artifactory.amd.com:5000/rocm-plus-docker/framework/private/te-ci:rocm-6.4_0_ubuntu22_py310_torch25_jax0435qa_fa273"
+}

--- a/ci/ci_config.json
+++ b/ci/ci_config.json
@@ -1,4 +1,7 @@
 {
-  "dev_docker_image": "registry-sc-harbor.amd.com/framework/te-ci:rocm-7.0.2_ubuntu22.04_py3.10_pytorch_release-2.7_9015dfdf_jax_v0.6.0_fa-v2.8.0",
-  "rel613_docker_image": "compute-artifactory.amd.com:5000/rocm-plus-docker/framework/private/te-ci:rocm-6.4_0_ubuntu22_py310_torch25_jax0435qa_fa273"
+  "docker_images": {
+    "default": "registry-sc-harbor.amd.com/framework/te-ci:rocm-7.0.2_ubuntu22.04_py3.10_pytorch_release-2.7_9015dfdf_jax_v0.6.0_fa-v2.8.0",
+    "release_v1.13": "compute-artifactory.amd.com:5000/rocm-plus-docker/framework/private/te-ci:rocm-6.4_0_ubuntu22_py310_torch25_jax0435qa_fa273",
+    "release_v1.14": "compute-artifactory.amd.com:5000/rocm-plus-docker/framework/private/te-ci:rocm-6.4_0_ubuntu22_py310_torch25_jax0435qa_fa273"
+  }
 }


### PR DESCRIPTION
Description:
This PR addresses an issue where the TransformerEngine CI workflow fails when triggered from forked repositories. GitHub Actions security policies prevent forked PRs from accessing repository variables (`vars`), causing the Docker image name to resolve to an empty string during `docker pull`.

Changes:
1. Introduced `ci/ci_config.json`:
   - Moves Docker image tags out of repository variables and into a version-controlled JSON file.
   - Could be used for other configurations as well.

2. Updated `Select Docker Image Tag` step in CI workflow:
   - Removed dependency on `${{ vars }}` context.
   - Now fetches `ci/docker_config.json` dynamically from the upstream `dev` branch via `curl`.
   - Uses `jq` to parse the JSON and populate the necessary environment variables.

Benefits:
- Fixes CI for external contributors (forks).
- Centralizes configuration: Updating the Docker image in the `dev` branch instantly propagates the new image to all release branches (since they fetch the config dynamically), eliminating the need to cherry-pick image tag updates across multiple branches.