### PR TITLE
Fixed setting safe.directory when call git rev-parse

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -280,6 +280,7 @@ else()
   set(GPU_TARGETS ${CMAKE_HIP_ARCHITECTURES})
 
   function(get_git_commit REPO_DIR COMMIT_ID_VAR)
+    file(REAL_PATH "${REPO_DIR}" REPO_DIR)
     execute_process(
       COMMAND sh -c "export GIT_CONFIG_GLOBAL=$(mktemp /tmp/gitconfig.XXXXXX);
       git config --global --add safe.directory ${REPO_DIR} && git -C ${REPO_DIR} rev-parse HEAD;

--- a/transformer_engine/common/ck_fused_attn/aiter_prebuilt.cmake
+++ b/transformer_engine/common/ck_fused_attn/aiter_prebuilt.cmake
@@ -20,8 +20,7 @@ string(STRIP "${ROCM_VER_CONTENT}" ROCM_VER_CONTENT)
 string(REGEX MATCH "^[0-9]+\\.[0-9]+" ROCM_VER "${ROCM_VER_CONTENT}")
 
 # AITER commit
-file(REAL_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../3rdparty/aiter" AITER_DIR)
-get_git_commit(${AITER_DIR} AITER_SHA)
+get_git_commit("${CMAKE_CURRENT_LIST_DIR}/../../../3rdparty/aiter" AITER_SHA)
 
 # Cache key & local paths
 set(KEY "rocm-${ROCM_VER}_aiter-${AITER_SHA}")
@@ -87,7 +86,7 @@ function(create_upload_files)
   if (NOT EXISTS  "${EXTRACT_DIR}/libmha_fwd.so")
     message(FATAL_ERROR "[AITER-PREBUILT] Missing libmha_fwd.so")
   endif()
-  if (NOT EXISTS  "${EXTRACT_DIR}/libmha_fwd.so")
+  if (NOT EXISTS  "${EXTRACT_DIR}/libmha_bwd.so")
     message(FATAL_ERROR "[AITER-PREBUILT] Missing libmha_bwd.so")
   endif()
 


### PR DESCRIPTION
# Description

Fix on top of #388 - normalize path used for git safe.directory 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
