### PR TITLE
[ROCm] use at::empty(0, fp32) as amax workspace for makeTransformerEngineTensor

### DIFF
--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -68,6 +68,7 @@ run_test_config(){
     NVTE_USE_DEQUANTIZE_TRITON=1 NVTE_USE_CAST_TRANSPOSE_TRITON=1 NVTE_USE_RMSNORM_TRITON=1 NVTE_USE_LAYERNORM_TRITON=1 run_default_fa_lbl "triton" 3 test_numerics.py
     NVTE_USE_RMSNORM_TRITON=1 run_default_fa_lbl "triton" 1 test_fusible_ops.py
     NVTE_USE_CAST_TRANSPOSE_TRITON=1 run_default_fa_lbl "triton" 1 test_float8_current_scaling_exact.py
+    NVTE_USE_ATOMIC_AMAX=1 run_default_fa 3 test_numerics.py
     NVTE_USE_ATOMIC_AMAX=1 run_default_fa 3 test_fusible_ops.py
 }
 

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -294,8 +294,8 @@ inline bool nvte_use_atomic_amax() {
 
 at::Tensor allocate_amax_workspace(const TensorWrapper& input_tensor) {
   if (nvte_use_atomic_amax() || input_tensor.numel() == 0) {
-    // User chose atomic path, or empty tensor -> no need for workspace
-    return at::Tensor();
+    // User chose atomic path, or empty tensor -> return a size-0 empty tensor
+    return at::empty(0, at::CUDA(at::kFloat));
   }
 
   const auto N = input_tensor.numel();


### PR DESCRIPTION
# Description

Otherwise https://github.com/ROCm/TransformerEngine/blob/9a82851158236080d9f57e2112f8e239cce5837f/transformer_engine/pytorch/csrc/common.cpp#L99 will error out with input at::Tensor(): https://github.com/ROCm/TransformerEngine/blob/9a82851158236080d9f57e2112f8e239cce5837f/transformer_engine/pytorch/csrc/common.h#L313

Fixes https://github.com/ROCm/frameworks-internal/issues/14303

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
