### PR TITLE
Upcoming ROCm and JAX 0.8 support

### DIFF
--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -21,6 +21,12 @@ install_prerequisites() {
         script_error "Failed to install Flax and dependencies"
         return $rc
     fi
+    pip install pytest-timeout
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        script_error "Failed to install test prerequisites"
+        exit $rc
+    fi
 }
 
 TEST_DIR=${TE_PATH}tests/jax
@@ -62,15 +68,20 @@ run_test_config() {
 run_test_config_mgpu() {
     echo ==== Run mGPU with Fused attention backend: $_fus_attn ====
     configure_omp_threads 8
+
+    # Mitigate distributed tests hang by adding 5min timeout
+    _timeout_args="--timeout 300 --timeout-method thread"
+    # Workaround for some distributed tests hang/abotrion
+    export XLA_FLAGS="--xla_gpu_enable_nccl_comm_splitting=false"
+
     if [ $_fus_attn = $_DEFAULT_FUSED_ATTN ]; then
         _dfa_level=2
     else
         _dfa_level=3
     fi
-    # Workaround for distributed tests hang with xla_flag
-    XLA_FLAGS="--xla_gpu_enable_nccl_comm_splitting=false" run $_dfa_level test_distributed_fused_attn.py
+    run $_dfa_level test_distributed_fused_attn.py $_timeout_args
     run_default_fa 3 test_distributed_layernorm.py
-    XLA_FLAGS="--xla_gpu_enable_nccl_comm_splitting=false" run_default_fa 2 test_distributed_layernorm_mlp.py
+    run_default_fa 2 test_distributed_layernorm_mlp.py $_timeout_args
     run_default_fa 3 test_distributed_softmax.py
 
     run_default_fa 3 test_sanity_import.py

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -8,7 +10,8 @@ from itertools import product
 import pytest
 
 import jax
-from jax.experimental.pjit import pjit, _UNSPECIFIED
+from jax._src.pjit import pjit
+from jax._src.sharding_impls import UNSPECIFIED as _UNSPECIFIED
 
 from transformer_engine.jax.sharding import MeshResource
 

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -157,6 +157,8 @@ bool supports_multicast(int device_id) {
   return false;
 #endif
 }
+#endif // __HIP_PLATFORM_AMD__
+
 
 const std::string &include_directory(bool required) {
   static std::string path;
@@ -169,16 +171,28 @@ const std::string &include_directory(bool required) {
   if (need_to_check_env) {
     // Search for CUDA headers in common paths
     using Path = std::filesystem::path;
+#ifdef __HIP_PLATFORM_AMD__
+    std::vector<std::pair<std::string, Path>> search_paths = {{"ROCM_PATH", ""},
+                                                              {"HIP_PATH", ""},
+                                                              {"", "/opt/rocm"}};
+#else
     std::vector<std::pair<std::string, Path>> search_paths = {{"NVTE_CUDA_INCLUDE_DIR", ""},
                                                               {"CUDA_HOME", ""},
                                                               {"CUDA_DIR", ""},
                                                               {"", string_path_cuda_include},
                                                               {"", "/usr/local/cuda"}};
+#endif
     for (auto &[env, p] : search_paths) {
       if (p.empty()) {
         p = getenv<Path>(env.c_str());
       }
       if (!p.empty()) {
+#ifdef __HIP_PLATFORM_AMD__
+        if (file_exists(p / "include" / "hip" / "hip_runtime.h")) {
+          path = p / "include";
+          break;
+        }
+#else
         if (file_exists(p / "cuda_runtime.h")) {
           path = p;
           break;
@@ -187,6 +201,7 @@ const std::string &include_directory(bool required) {
           path = p / "include";
           break;
         }
+#endif
       }
     }
 
@@ -194,7 +209,11 @@ const std::string &include_directory(bool required) {
     if (path.empty() && required) {
       std::string message;
       message.reserve(2048);
+#ifdef __HIP_PLATFORM_AMD__
+      message += "Could not find hip/hip_runtime.h in";
+#else
       message += "Could not find cuda_runtime.h in";
+#endif
       bool is_first = true;
       for (const auto &[env, p] : search_paths) {
         message += is_first ? " " : ", ";
@@ -209,11 +228,18 @@ const std::string &include_directory(bool required) {
           message += p;
         }
       }
+#ifdef __HIP_PLATFORM_AMD__
+      message +=
+          (". "
+           "Specify path to ROCM headers with ROCM_PATH "
+           "or disable NVRTC support with NVTE_DISABLE_NVRTC=1.");
+#else
       message +=
           (". "
            "Specify path to CUDA Toolkit headers "
            "with NVTE_CUDA_INCLUDE_DIR "
            "or disable NVRTC support with NVTE_DISABLE_NVRTC=1.");
+#endif
       NVTE_ERROR(message);
     }
     need_to_check_env = false;
@@ -223,6 +249,7 @@ const std::string &include_directory(bool required) {
   return path;
 }
 
+#ifndef __HIP_PLATFORM_AMD__
 int cudart_version() {
   auto get_version = []() -> int {
     int version;

--- a/transformer_engine/common/util/cuda_runtime.h
+++ b/transformer_engine/common/util/cuda_runtime.h
@@ -68,10 +68,11 @@ void stream_priority_range(int *low_priority, int *high_priority, int device_id 
  * \return CUDA multicast support flag
  */
 bool supports_multicast(int device_id = -1);
+#endif
 
-/* \brief Path to CUDA Toolkit headers
+/* \brief Path to CUDA/ROCm Toolkit headers
  *
- * The path can be configured by setting NVTE_CUDA_INCLUDE_DIR in the
+ * On CUDA platform the path can be configured by setting NVTE_CUDA_INCLUDE_DIR in the
  * environment. Otherwise searches in common install paths.
  *
  * \param[in] required Whether to throw exception if not found
@@ -80,6 +81,7 @@ bool supports_multicast(int device_id = -1);
  */
 const std::string &include_directory(bool required = false);
 
+#ifndef __HIP_PLATFORM_AMD__
 /* \brief CUDA Runtime version number at run-time
  *
  * Versions may differ between compile-time and run-time.

--- a/transformer_engine/common/util/rtc.cpp
+++ b/transformer_engine/common/util/rtc.cpp
@@ -174,8 +174,8 @@ void KernelManager::compile(const std::string& kernel_label, const std::string& 
   } else {
     opts.push_back(concat_strings("--gpu-architecture=sm_", compile_sm_arch));
   }
-  opts.push_back(concat_strings("-I", cuda::include_directory(true)));
 #endif //__HIP_PLATFORM_AMD__
+  opts.push_back(concat_strings("-I", cuda::include_directory(true)));
 
   std::vector<const char*> opts_ptrs;
   for (const auto& opt : opts) {

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.


### PR DESCRIPTION
# Description

Port changes from TE 2.4 for ROCm and JAX 0.8 support: https://github.com/ROCm/TransformerEngine/pull/383, https://github.com/ROCm/TransformerEngine/pull/395

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix HIPRTC include specification
- JAX 0.8 API change accommodation
- Add pytest timeout to mitigate JAX tests hang

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
