### PR TITLE
Do not fail CI on known failed JAX test

### DIFF
--- a/ci/_utils.sh
+++ b/ci/_utils.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 
@@ -25,6 +25,8 @@ export CI=1
 
 _script_error_count=0
 _run_error_count=0
+_ignored_error_count=0
+TEST_ERROR_IGNORE=""
 
 script_error() {
     _script_error_count=$((_script_error_count+1))
@@ -32,6 +34,11 @@ script_error() {
 }
 
 test_run_error() {
+    if [ -n "$TEST_ERROR_IGNORE" ]; then
+        _ignored_error_count=$((_ignored_error_count+1))
+        test -n "$@" && echo "Ignore error in test $@" >&2
+        return
+    fi
     _run_error_count=$((_run_error_count+1))
     test -n "$@" && echo "Error in test $@" >&2
 }
@@ -39,6 +46,7 @@ test_run_error() {
 return_run_results() {
     test $_script_error_count -ne 0 && echo Detected $_script_error_count script errors during tests run at level $TEST_LEVEL >&2
     test $_run_error_count -ne 0 && echo Got $_run_error_count test errors during run at level $TEST_LEVEL >&2
+    test $_ignored_error_count -ne 0 && echo Ignored $_ignored_error_count test errors during run at level $TEST_LEVEL >&2
     test $_run_error_count -eq 0 -a $_script_error_count -eq 0
 }
 

--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 
@@ -79,7 +79,13 @@ run_test_config_mgpu() {
     else
         _dfa_level=3
     fi
+    # Do not fail automated CI if test_distributed_fused_attn is hung
+    # If the sctipt run w/o TEST_LEVEL the test error will be honored
+    if [ "$TEST_LEVEL" -le 3 ]; then
+        TEST_ERROR_IGNORE="1"
+    fi
     run $_dfa_level test_distributed_fused_attn.py $_timeout_args
+    TEST_ERROR_IGNORE=""
     run_default_fa 3 test_distributed_layernorm.py
     run_default_fa 2 test_distributed_layernorm_mlp.py $_timeout_args
     run_default_fa 3 test_distributed_softmax.py


### PR DESCRIPTION
# Description

Do not fail CI if test_distributed_fused_attn JAX test fails

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add flag to ignore test error
- Ignore test error for test_distributed_fused_attn JAX test on levels 1..3

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
