### PR TITLE
CI: Serialize core sgpu test

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -256,7 +256,7 @@ jobs:
           core_pid=$?
           
           wait $jax_pid; jax_rc=$?
-          wait $torch_rc; torch_rc=$?
+          wait $torch_pid; torch_rc=$?
           
           # /workspace/FAIL_* files are for failure markers we can extract to the host runner and process later
           # Check PyTorch

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -246,8 +246,8 @@ jobs:
           python --version
           pip list | egrep "transformer_e|torch|jax|numpy|ml_dtypes|typing_ext"
 
-          HIP_VISIBLE_DEVICES=1 ci/pytorch.sh > /workspace/torch_sgpu.log 2>&1 &
-          torch_pid=$!; echo Pytorch test pid $!
+          HIP_VISIBLE_DEVICES=1 ci/pytorch.sh > /workspace/torch_sgpu.log 2>&1
+          torch_rc=$?
           
           HIP_VISIBLE_DEVICES=2 ci/jax.sh > /workspace/jax_sgpu.log 2>&1 &
           jax_pid=$!; echo JAX test pid $!
@@ -257,7 +257,6 @@ jobs:
           
           wait $core_pid; core_rc=$?
           wait $jax_pid; jax_rc=$?
-          wait $torch_pid; torch_rc=$?
           
           # /workspace/FAIL_* files are for failure markers we can extract to the host runner and process later
           # Check PyTorch

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -253,7 +253,7 @@ jobs:
           jax_pid=$!; echo JAX test pid $!
           
           ci/core.sh > /workspace/core_sgpu.log 2>&1 
-          core_pid=$?
+          core_rc=$?
           
           wait $jax_pid; jax_rc=$?
           wait $torch_pid; torch_rc=$?

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -246,16 +246,16 @@ jobs:
           python --version
           pip list | egrep "transformer_e|torch|jax|numpy|ml_dtypes|typing_ext"
 
-          HIP_VISIBLE_DEVICES=1 ci/pytorch.sh > /workspace/torch_sgpu.log 2>&1
-          torch_rc=$?
+          HIP_VISIBLE_DEVICES=1 ci/pytorch.sh > /workspace/torch_sgpu.log 2>&1 &
+          torch_rc=$!; echo Pytorch test pid $!
           
           HIP_VISIBLE_DEVICES=2 ci/jax.sh > /workspace/jax_sgpu.log 2>&1 &
           jax_pid=$!; echo JAX test pid $!
           
-          HIP_VISIBLE_DEVICES=3 ci/core.sh > /workspace/core_sgpu.log 2>&1 &
-          core_pid=$!; echo Core test pid $!
+          ci/core.sh > /workspace/core_sgpu.log 2>&1 
+          core_pid=$?
           
-          wait $core_pid; core_rc=$?
+          wait $torch_rc; torch_rc=$?
           wait $jax_pid; jax_rc=$?
           
           # /workspace/FAIL_* files are for failure markers we can extract to the host runner and process later

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -247,7 +247,7 @@ jobs:
           pip list | egrep "transformer_e|torch|jax|numpy|ml_dtypes|typing_ext"
 
           HIP_VISIBLE_DEVICES=1 ci/pytorch.sh > /workspace/torch_sgpu.log 2>&1 &
-          torch_rc=$!; echo Pytorch test pid $!
+          torch_pid=$!; echo Pytorch test pid $!
           
           HIP_VISIBLE_DEVICES=2 ci/jax.sh > /workspace/jax_sgpu.log 2>&1 &
           jax_pid=$!; echo JAX test pid $!
@@ -255,8 +255,8 @@ jobs:
           ci/core.sh > /workspace/core_sgpu.log 2>&1 
           core_pid=$?
           
-          wait $torch_rc; torch_rc=$?
           wait $jax_pid; jax_rc=$?
+          wait $torch_rc; torch_rc=$?
           
           # /workspace/FAIL_* files are for failure markers we can extract to the host runner and process later
           # Check PyTorch

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -13,7 +13,7 @@ if [ -z "$TEST_SGPU" ]; then
     exit 0
 fi
 
-n_parallel_jobs=4
+n_parallel_jobs=8
 
 configure_omp_threads $n_parallel_jobs
 


### PR DESCRIPTION
Resolves the "High timing deviation" errors in the CI pipeline by serializing the Core test execution to prevent resource contention from Core workloads hogging all 8 GPUs. Running the hungry tests in the foreground should ensure exclusive host resource acces while keeping the remaining tests parallel.