### PR TITLE
Update ROCm Dockerfile to include hiprand-devel and rocrand-devel packages

### DIFF
--- a/build_tools/wheel_utils/Dockerfile.rocm.manylinux.x86
+++ b/build_tools/wheel_utils/Dockerfile.rocm.manylinux.x86
@@ -22,7 +22,7 @@ ARG ROCM_REPO_URL=https://repo.radeon.com/rocm/rhel8/latest/main/
 RUN echo -e "[rocm]\nname=ROCm\nbaseurl=${ROCM_REPO_URL}\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/rocm.repo
 
 # Setup packages
-RUN dnf install -y --disablerepo=epel rocm-dev hipblaslt hipblaslt-devel hipcub hipcub-devel
+RUN dnf install -y --disablerepo=epel rocm-dev hipblaslt hipblaslt-devel hipcub hipcub-devel hiprand-devel rocrand-devel
 RUN dnf group install -y "Development Tools" && dnf install -y git cmake llvm-toolset gcc-toolset-12
 
 #Uncomment the next line for ROCm 6.4 cmake workaround: remove newer incomnpatible cmake preinstalled on base image


### PR DESCRIPTION
# Description

This PR fixes TE wheel build issue while using builder image.
```
/TransformerEngine/transformer_engine/common/dropout/dropout.hip:11:10: fatal error: 'hiprand/hiprand.h' file not found

   11 | #include <hiprand/hiprand.h>

 
```

```
/opt/rocm-7.1.0/lib/llvm/bin/../../../include/hiprand/hiprand_rocm.h:24:10: fatal error: 'rocrand/rocrand.h' file not found
   24 | #include <rocrand/rocrand.h>
      |          ^~~~~~~~~~~~~~~~~~~
1 error generated when compiling for gfx942.
```

Steps to reproduce:
https://amd.atlassian.net/wiki/spaces/MLSE/pages/979996230/TE+deploying


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Adds installation of hiprand-devel rocrand-devel packages to the docker file.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
