### PR TITLE
[CI] Use default checkout depth

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -49,10 +49,10 @@ jobs:
         runner: [linux-mi325-8, linux-mi355-8]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          fetch-depth: 0
+          fetch-tags: 'true'
         
       - name: Host Diagnostics & Environment Setup
         id: host-setup
@@ -78,7 +78,7 @@ jobs:
           # Default to input (or '1' if input is missing/null)
           CALC_LEVEL="${{ inputs.test_level || '1' }}"
 
-          # COnly force Level 3 if this is a direct PUSH to dev or a release branch
+          # Only force Level 3 if this is a direct PUSH to dev or a release branch
           if [[ "${{ github.event_name }}" == "push" ]]; then
              if [[ "${{ github.ref_name }}" == "dev" || "${{ github.ref_name }}" =~ ^release_v.*_rocm$ ]]; then
                 echo "::notice::Push to monitored branch (${{ github.ref_name }}) detected. Forcing Level 3."

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -21,10 +21,6 @@ on:
         description: 'Test Level (1-3)'
         required: true
         default: '1'
-      skip_dev_merge:
-        description: 'Skip merging dev branch'
-        type: boolean
-        default: false
       docker_image_override:
         description: 'Manual Docker Image (Leave empty to use config file value)'
         required: false

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          fetch-tags: 'true'
         
       - name: Host Diagnostics & Environment Setup
         id: host-setup


### PR DESCRIPTION
# Description

This is intended to reduce the time spent on the `git checkout`  step in CI.
Not sure if we need the full checkout depth. Tests seem to pass with the default depth (=1) + tags.

Timings (min:sec) for checkout (not necessarily representative, timings vary quite a bit):

| CI run                                                                 | Checkout time on MI325 | Checkout time on MI355 | Data transferred | Disk size |
|-------------------------------------------------------------------------|-------|-------|-----|-----|
| [This PR](https://github.com/ROCm/TransformerEngine/actions/runs/21531700231)                                                                 | 3:03  | 0:53  | 370 MByte | 880 MByte |
| [CI run w/o this PR](https://github.com/ROCm/TransformerEngine/actions/runs/21530142179/) | 5:55  | 13:36 | 1540 MByte | 2100 MByte| 


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Do not set checkout depth, ~but require git tags~ 
- Update checkout version to v6

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
