### PR TITLE
Revert "CI: Serialize core sgpu test (#426)", move gemm_sm_count to mGPU

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 
@@ -252,9 +252,10 @@ jobs:
           HIP_VISIBLE_DEVICES=2 ci/jax.sh > /workspace/jax_sgpu.log 2>&1 &
           jax_pid=$!; echo JAX test pid $!
           
-          ci/core.sh > /workspace/core_sgpu.log 2>&1 
-          core_rc=$?
+          HIP_VISIBLE_DEVICES=3 ci/core.sh > /workspace/core_sgpu.log 2>&1 &
+          core_pid=$!; echo Core test pid $!
           
+          wait $core_pid; core_rc=$?
           wait $jax_pid; jax_rc=$?
           wait $torch_pid; torch_rc=$?
           

--- a/ci/core.sh
+++ b/ci/core.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 
@@ -13,7 +13,7 @@ if [ -z "$TEST_SGPU" ]; then
     exit 0
 fi
 
-n_parallel_jobs=8
+n_parallel_jobs=4
 
 configure_omp_threads $n_parallel_jobs
 

--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -56,7 +56,6 @@ run_test_config(){
     run_default_fa 1 test_fused_router.py
     run_default_fa 1 test_fusible_ops.py
     run_default_fa 1 test_gemm_autotune.py
-    run_default_fa 1 test_gemm_sm_count.py
     run 1 test_gqa.py
     run 1 test_jit.py
     run_default_fa 1 test_multi_tensor.py
@@ -88,6 +87,9 @@ run_test_config_mgpu(){
     echo ==== Run mGPU with Fused attention backend: $_fus_attn ====
     configure_omp_threads 8
     run_default_fa 1 test_fused_optimizer.py
+    #this test is not really mGPU but time sensitive so run it here because sGPU tests
+    #run in parallel on CI and it affects timing
+    run_default_fa 1 test_gemm_sm_count.py
     run_default_fa 3 test_sanity_import.py
     run_default_fa 2 distributed/test_fusible_ops.py
     run_default_fa 2 distributed/test_numerics.py


### PR DESCRIPTION
This reverts commit 05707a3a6b8cfd14c239f3234713884693771d1c.

# Description

There are not evidences that the problem that PR#426 addressed is due to GPU oversubscription and the changes have dramati negative impact in CI runtime.
This PR reverts original changes and moves time Pytorch gemm_sm_count test to mGPU not to run it in parallel with core tests

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Revert PR#426
- Move gemm_sm_count test to mGPU section
- Update copyright date

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
