### PR TITLE
Improved Triton Norms Tuning Configs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,6 +332,9 @@ At runtime, you can enable specific triton kernels using the specific environmen
 * NVTE_USE_CAST_TRANSPOSE_TRITON=1 can be used to enable cast transpose (bgrad) triton kernels;
 * NVTE_USE_LAYERNORM_TRITON=1 can be used to enable layernorm triton kernels.
 * NVTE_USE_RMSNORM_TRITON=1 can be used to enable rmsnorm triton kernels.
+* NVTE_TRITON_SAFE_TUNING=0 can be used to enable aggressive tuning configs for layernorm and
+  rmsnorm triton kernels, which may provide better performance on some workloads at the risk
+  of memory access issues on larger workloads.
 
 MXFP8 support on ROCm (gfx95x only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -6,8 +6,9 @@ from itertools import product
 
 import triton
 import triton.language as tl
+from .utils import SAFE_TUNING
 
-def get_autotune_config(safe_tuning=False, full_tuning_space=False):
+def get_autotune_config(safe_tuning=SAFE_TUNING, full_tuning_space=False):
     if full_tuning_space:
         tuning_space = product([1, 2, 4], [4, 8, 16])
     else:
@@ -161,7 +162,7 @@ def _layernorm_fwd_triton_impl(
         else:
             tl.store(q_amax_ptr + pid, amax)
 
-autotune_dec = triton.autotune(configs=get_autotune_config(safe_tuning=True), key=["n_rows", "n_cols"], use_cuda_graph=True)
+autotune_dec = triton.autotune(configs=get_autotune_config(), key=["n_rows", "n_cols"], use_cuda_graph=True)
 _layernorm_fwd_triton = autotune_dec(_layernorm_fwd_triton_impl)
 
 @triton.jit

--- a/transformer_engine/pytorch/triton_kernels/layernorm.py
+++ b/transformer_engine/pytorch/triton_kernels/layernorm.py
@@ -7,11 +7,13 @@ from itertools import product
 import triton
 import triton.language as tl
 
-def get_autotune_config(full_tuning_space=False):
+def get_autotune_config(safe_tuning=False, full_tuning_space=False):
     if full_tuning_space:
         tuning_space = product([1, 2, 4], [4, 8, 16])
     else:
         tuning_space = [(1, 8), (1, 16), (2, 16), (4, 4), (4, 8), (4, 16)]
+    if safe_tuning:
+        tuning_space = [(w, nw) for (w, nw) in tuning_space if w <= 2 and nw <= 8]
     return [
         triton.Config({"waves_per_eu": waves_per_eu}, num_warps=num_warps, num_stages=1)
         for waves_per_eu, num_warps in tuning_space
@@ -159,7 +161,7 @@ def _layernorm_fwd_triton_impl(
         else:
             tl.store(q_amax_ptr + pid, amax)
 
-autotune_dec = triton.autotune(configs=get_autotune_config(), key=["n_rows", "n_cols"], use_cuda_graph=True)
+autotune_dec = triton.autotune(configs=get_autotune_config(safe_tuning=True), key=["n_rows", "n_cols"], use_cuda_graph=True)
 _layernorm_fwd_triton = autotune_dec(_layernorm_fwd_triton_impl)
 
 @triton.jit

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -5,10 +5,15 @@ import torch
 import triton
 import triton.language as tl
 from itertools import product
+from .utils import SAFE_TUNING
 
-def get_autotune_config():
-    return [triton.Config({'waves_per_eu': we}, num_warps=nw) for (we, nw) in product([0, 1, 2, 4], [4, 8, 16])]
-
+def get_autotune_config(safe_tuning=SAFE_TUNING):
+    waves_per_eu = [0, 1, 2]
+    num_warps = [4, 8]
+    if not safe_tuning:
+        waves_per_eu.append(4)
+        num_warps.append(16)
+    return [triton.Config({'waves_per_eu': we}, num_warps=nw) for (we, nw) in product(waves_per_eu, num_warps)]
 
 # TODO(micky774) Implement fused MXFP8 quantization within the kernel
 @triton.jit

--- a/transformer_engine/pytorch/triton_kernels/utils.py
+++ b/transformer_engine/pytorch/triton_kernels/utils.py
@@ -8,6 +8,8 @@ from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor, Float8
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor, MXFP8Quantizer
 from .common import te_dtype_to_torch_dtype
 
+SAFE_TUNING = os.environ.get("NVTE_TRITON_SAFE_TUNING", "1") == "1"
+
 def get_ln_sm_margin(sm_margin_type):
     assert sm_margin_type in {"FWD", "BWD", "INF"}
     try:


### PR DESCRIPTION
# Description

Trimmed Triton layernorm autotune configs to account for large block size mem safety by default, while introducing `NVTE_TRITON_SAFE_TUNING` to mediate the choice at runtime. Too large a block size paired with too many warps/waves-per-eu resulted in illegal memory access behavior.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
