### PR TITLE
Updated test to include CK/AITER V2/V3 test in single backend case

### DIFF
--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -1301,8 +1301,7 @@ def test_transformer_layer(
                 RoPE,
                 is_training,
             )
-        elif len(fused_attn_backends) == 2:
-            os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
+        elif IS_HIP_EXTENSION and len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_CK"] = "1"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
             fused_attn_fwd, fused_attn_bwd = _run_transformer_layer(
@@ -1316,7 +1315,6 @@ def test_transformer_layer(
                 RoPE,
                 is_training,
             )
-            os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
             os.environ["NVTE_FUSED_ATTN_CK"] = "0"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
             fused_attn_fwd_1, fused_attn_bwd_1 = _run_transformer_layer(

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -258,7 +258,7 @@ def test_dot_product_attention(
 
     # FusedAttention backend
     if fused_attn_supported:
-        if len(fused_attn_backends) == 1 and FusedAttnBackend["CK"] not in fused_attn_backends:
+        if len(fused_attn_backends) == 1:
             fused_attn_fwd, fused_attn_bwd = _run_dot_product_attention(
                 dtype,
                 config,
@@ -269,32 +269,20 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-        # We can consider the CK backend as being two, since we have V2/V3 kernels
-        elif len(fused_attn_backends) == 1:
-            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
-            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
-            fused_attn_fwd, fused_attn_bwd = _run_dot_product_attention(
-                dtype,
-                config,
-                "FusedAttention",
-                ckpt_attn,
-                qkv_layout,
-                workspace_opt,
-                pad_between_seqs,
-                is_training,
-            )
-            os.environ["NVTE_CK_USES_FWD_V3"] = "0"
-            os.environ["NVTE_CK_USES_BWD_V3"] = "0"
-            fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
-                dtype,
-                config,
-                "FusedAttention",
-                ckpt_attn,
-                qkv_layout,
-                workspace_opt,
-                pad_between_seqs,
-                is_training,
-            )
+            # We can consider the CK backend as being two, since we have V2/V3 kernels
+            if IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends:
+                os.environ["NVTE_CK_USES_FWD_V3"] = "0"
+                os.environ["NVTE_CK_USES_BWD_V3"] = "0"
+                fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
+                    dtype,
+                    config,
+                    "FusedAttention",
+                    ckpt_attn,
+                    qkv_layout,
+                    workspace_opt,
+                    pad_between_seqs,
+                    is_training,
+                )
         elif len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
             os.environ["NVTE_FUSED_ATTN_CK"] = "0"

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -240,7 +240,12 @@ def test_dot_product_attention(
         flash_attn_supported = True
 
     # Skip if only unfused backend is supported
-    if (len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported) < 2:
+    # Double-count the CK backend since we want to compare V2/V3 kernels
+    if (
+        len(fused_attn_backends) +
+        int(IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends) +
+        flash_attn_supported + unfused_attn_supported
+    ) < 2:
         pytest.skip("Less than two backends to compare.")
 
     # UnfusedDotProductAttention backend
@@ -1276,7 +1281,12 @@ def test_transformer_layer(
         flash_attn_supported, fused_attn_supported, unfused_attn_supported = available_backends
 
     # Skip if only unfused backend is supported
-    if (len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported) < 2:
+    # Double-count the CK backend since we want to compare V2/V3 kernels
+    if (
+        len(fused_attn_backends) +
+        int(IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends) +
+        flash_attn_supported + unfused_attn_supported
+    ) < 2:
         pytest.skip("Less than two backends to compare.")
     # Skip if qkv_format = thd and "padding" not in attn_mask_type
     if qkv_format == "thd" and "padding" not in config.attn_mask_type:

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -241,10 +241,9 @@ def test_dot_product_attention(
 
     # Skip if only unfused backend is supported
     # Double-count the CK backend since we want to compare V2/V3 kernels
-    if (
-        len(fused_attn_backends) +
-        int(IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends) +
-        flash_attn_supported + unfused_attn_supported
+    has_ck_backend = IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends
+    if not has_ck_backend and (
+        len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported
     ) < 2:
         pytest.skip("Less than two backends to compare.")
 
@@ -274,21 +273,7 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-            # We can consider the CK backend as being two, since we have V2/V3 kernels
-            if IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends:
-                os.environ["NVTE_CK_USES_FWD_V3"] = "0"
-                os.environ["NVTE_CK_USES_BWD_V3"] = "0"
-                fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
-                    dtype,
-                    config,
-                    "FusedAttention",
-                    ckpt_attn,
-                    qkv_layout,
-                    workspace_opt,
-                    pad_between_seqs,
-                    is_training,
-                )
-        elif len(fused_attn_backends) == 2:
+        if len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
             os.environ["NVTE_FUSED_ATTN_CK"] = "0"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
@@ -302,9 +287,12 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
+        if len(fused_attn_backends) == 2 or has_ck_backend:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
             os.environ["NVTE_FUSED_ATTN_CK"] = "1"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+            os.environ["NVTE_CK_USES_FWD_V3"] = "0"
+            os.environ["NVTE_CK_USES_BWD_V3"] = "0"
             fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
                 dtype,
                 config,
@@ -315,19 +303,19 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-            if IS_HIP_EXTENSION:
-                os.environ["NVTE_CK_USES_FWD_V3"] = "0"
-                os.environ["NVTE_CK_USES_BWD_V3"] = "0"
-                fused_attn_fwd_2, fused_attn_bwd_2 = _run_dot_product_attention(
-                    dtype,
-                    config,
-                    "FusedAttention",
-                    ckpt_attn,
-                    qkv_layout,
-                    workspace_opt,
-                    pad_between_seqs,
-                    is_training,
-                )
+        if IS_HIP_EXTENSION and len(fused_attn_backends) == 2:
+            os.environ["NVTE_CK_USES_FWD_V3"] = "1"
+            os.environ["NVTE_CK_USES_BWD_V3"] = "1"
+            fused_attn_fwd_2, fused_attn_bwd_2 = _run_dot_product_attention(
+                dtype,
+                config,
+                "FusedAttention",
+                ckpt_attn,
+                qkv_layout,
+                workspace_opt,
+                pad_between_seqs,
+                is_training,
+            )
 
 
     # FlashAttention backend

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -369,7 +369,12 @@ def test_dot_product_attention(
             torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
             for i, _ in enumerate(fused_attn_bwd):
                 torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
-    if fused_attn_supported and len(fused_attn_backends) == 1 and FusedAttnBackend["CK"] in fused_attn_backends:
+    if (
+        fused_attn_supported and
+        len(fused_attn_backends) == 1 and
+        IS_HIP_EXTENSION and
+        FusedAttnBackend["CK"] in fused_attn_backends
+    ):
         logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
         torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
         for i, _ in enumerate(fused_attn_bwd):
@@ -1320,6 +1325,20 @@ def test_transformer_layer(
                 RoPE,
                 is_training,
             )
+            if IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends:
+                os.environ["NVTE_CK_USES_FWD_V3"] = "0"
+                os.environ["NVTE_CK_USES_BWD_V3"] = "0"
+                fused_attn_fwd_1, fused_attn_bwd_1 = _run_transformer_layer(
+                    dtype,
+                    config,
+                    "FusedAttention",
+                    ckpt_attn,
+                    qkv_format,
+                    workspace_opt,
+                    fused_qkv_params,
+                    RoPE,
+                    is_training,
+                )
         elif len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_CK"] = "0"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
@@ -1390,15 +1409,24 @@ def test_transformer_layer(
         logging.info("[test_transformer_layer]: fused attn vs flash attn")
         torch.testing.assert_close(fused_attn_fwd, flash_attn_fwd, **tols)
         torch.testing.assert_close(fused_attn_bwd, flash_attn_bwd, **tols)
-    if IS_HIP_EXTENSION and fused_attn_supported and len(fused_attn_backends) == 2:
-        logging.info("[test_transformer_layer]: fused attn backend 0 vs 1")
-        torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
-        for i, _ in enumerate(fused_attn_bwd):
-            torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
-        logging.info("[test_transformer_layer]: fused attn backend 0 vs 2")
-        torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
-        for i, _ in enumerate(fused_attn_bwd):
-            torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
+    if IS_HIP_EXTENSION and fused_attn_supported:
+        if len(fused_attn_backends) == 2:
+            logging.info("[test_transformer_layer]: fused attn backend 0 vs 1")
+            torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
+            for i, _ in enumerate(fused_attn_bwd):
+                torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
+            logging.info("[test_transformer_layer]: fused attn backend 0 vs 2")
+            torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
+            for i, _ in enumerate(fused_attn_bwd):
+                torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
+        elif (
+            len(fused_attn_backends) == 1 and
+            FusedAttnBackend["CK"] in fused_attn_backends
+        ):
+            logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
+            torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
+            for i, _ in enumerate(fused_attn_bwd):
+                torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -351,16 +351,7 @@ def test_dot_product_attention(
         torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
         for i, _ in enumerate(fused_attn_bwd):
             torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
-        if has_ck_backend:  # Compare CK V2/V3 if both are available
-            logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
-            torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
-            for i, _ in enumerate(fused_attn_bwd):
-                torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
-    if (
-        fused_attn_supported and
-        len(fused_attn_backends) == 1 and
-        has_ck_backend
-    ): # Compare CK V2/V3 if both are available
+    if has_ck_backend: # Compare CK V2/V3 if both are available
         logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
         torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
         for i, _ in enumerate(fused_attn_bwd):
@@ -1298,7 +1289,7 @@ def test_transformer_layer(
 
     # FusedAttention backend
     if fused_attn_supported:
-        if len(fused_attn_backends) == 1 or not IS_HIP_EXTENSION:
+        if len(fused_attn_backends) == 1:
             fused_attn_fwd, fused_attn_bwd = _run_transformer_layer(
                 dtype,
                 config,
@@ -1310,36 +1301,24 @@ def test_transformer_layer(
                 RoPE,
                 is_training,
             )
-            if has_ck_backend:
-                os.environ["NVTE_CK_USES_FWD_V3"] = "0"
-                os.environ["NVTE_CK_USES_BWD_V3"] = "0"
-                fused_attn_fwd_1, fused_attn_bwd_1 = _run_transformer_layer(
-                    dtype,
-                    config,
-                    "FusedAttention",
-                    ckpt_attn,
-                    qkv_format,
-                    workspace_opt,
-                    fused_qkv_params,
-                    RoPE,
-                    is_training,
-                )
         elif len(fused_attn_backends) == 2:
-            os.environ["NVTE_FUSED_ATTN_CK"] = "0"
-            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
-            fused_attn_fwd, fused_attn_bwd = _run_transformer_layer(
-                dtype,
-                config,
-                "FusedAttention",
-                ckpt_attn,
-                qkv_format,
-                workspace_opt,
-                fused_qkv_params,
-                RoPE,
-                is_training,
-            )
+            os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
             os.environ["NVTE_FUSED_ATTN_CK"] = "1"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+            fused_attn_fwd, fused_attn_bwd = _run_transformer_layer(
+                dtype,
+                config,
+                "FusedAttention",
+                ckpt_attn,
+                qkv_format,
+                workspace_opt,
+                fused_qkv_params,
+                RoPE,
+                is_training,
+            )
+            os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
+            os.environ["NVTE_FUSED_ATTN_CK"] = "0"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
             fused_attn_fwd_1, fused_attn_bwd_1 = _run_transformer_layer(
                 dtype,
                 config,
@@ -1352,6 +1331,9 @@ def test_transformer_layer(
                 is_training,
             )
 
+        if has_ck_backend:
+            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
             os.environ["NVTE_CK_USES_FWD_V3"] = "0"
             os.environ["NVTE_CK_USES_BWD_V3"] = "0"
             fused_attn_fwd_2, fused_attn_bwd_2 = _run_transformer_layer(
@@ -1400,18 +1382,11 @@ def test_transformer_layer(
             torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
             for i, _ in enumerate(fused_attn_bwd):
                 torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
-            logging.info("[test_transformer_layer]: fused attn backend 0 vs 2")
+        if has_ck_backend:
+            logging.info("[test_transformer_layer]: CK fused attn V2 vs V3")
             torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
             for i, _ in enumerate(fused_attn_bwd):
                 torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
-        elif (
-            len(fused_attn_backends) == 1 and
-            FusedAttnBackend["CK"] in fused_attn_backends
-        ):
-            logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
-            torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
-            for i, _ in enumerate(fused_attn_bwd):
-                torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -258,7 +258,7 @@ def test_dot_product_attention(
 
     # FusedAttention backend
     if fused_attn_supported:
-        if len(fused_attn_backends) == 1:
+        if len(fused_attn_backends) == 1 and FusedAttnBackend["CK"] not in fused_attn_backends:
             fused_attn_fwd, fused_attn_bwd = _run_dot_product_attention(
                 dtype,
                 config,
@@ -269,7 +269,33 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-        if len(fused_attn_backends) == 2:
+        # We can consider the CK backend as being two, since we have V2/V3 kernels
+        elif len(fused_attn_backends) == 1:
+            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+            fused_attn_fwd, fused_attn_bwd = _run_dot_product_attention(
+                dtype,
+                config,
+                "FusedAttention",
+                ckpt_attn,
+                qkv_layout,
+                workspace_opt,
+                pad_between_seqs,
+                is_training,
+            )
+            os.environ["NVTE_CK_USES_FWD_V3"] = "0"
+            os.environ["NVTE_CK_USES_BWD_V3"] = "0"
+            fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
+                dtype,
+                config,
+                "FusedAttention",
+                ckpt_attn,
+                qkv_layout,
+                workspace_opt,
+                pad_between_seqs,
+                is_training,
+            )
+        elif len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
             os.environ["NVTE_FUSED_ATTN_CK"] = "0"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
@@ -286,8 +312,6 @@ def test_dot_product_attention(
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
             os.environ["NVTE_FUSED_ATTN_CK"] = "1"
             os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
-            os.environ["NVTE_CK_USES_FWD_V3"] = "1"
-            os.environ["NVTE_CK_USES_BWD_V3"] = "1"
             fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
                 dtype,
                 config,
@@ -352,6 +376,11 @@ def test_dot_product_attention(
             torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
             for i, _ in enumerate(fused_attn_bwd):
                 torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
+    if fused_attn_supported and len(fused_attn_backends) == 1 and FusedAttnBackend["CK"] in fused_attn_backends:
+        logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
+        torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
+        for i, _ in enumerate(fused_attn_bwd):
+            torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -275,8 +275,8 @@ def test_dot_product_attention(
             )
         if len(fused_attn_backends) == 2:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "0"
-            os.environ["NVTE_FUSED_ATTN_CK"] = "0"
-            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
+            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
             fused_attn_fwd, fused_attn_bwd = _run_dot_product_attention(
                 dtype,
                 config,
@@ -287,12 +287,9 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-        if len(fused_attn_backends) == 2 or has_ck_backend:
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
-            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
-            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
-            os.environ["NVTE_CK_USES_FWD_V3"] = "0"
-            os.environ["NVTE_CK_USES_BWD_V3"] = "0"
+            os.environ["NVTE_FUSED_ATTN_CK"] = "0"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "1"
             fused_attn_fwd_1, fused_attn_bwd_1 = _run_dot_product_attention(
                 dtype,
                 config,
@@ -303,9 +300,11 @@ def test_dot_product_attention(
                 pad_between_seqs,
                 is_training,
             )
-        if IS_HIP_EXTENSION and len(fused_attn_backends) == 2:
-            os.environ["NVTE_CK_USES_FWD_V3"] = "1"
-            os.environ["NVTE_CK_USES_BWD_V3"] = "1"
+        if has_ck_backend:
+            os.environ["NVTE_FUSED_ATTN_CK"] = "1"
+            os.environ["NVTE_FUSED_ATTN_AOTRITON"] = "0"
+            os.environ["NVTE_CK_USES_FWD_V3"] = "0"
+            os.environ["NVTE_CK_USES_BWD_V3"] = "0"
             fused_attn_fwd_2, fused_attn_bwd_2 = _run_dot_product_attention(
                 dtype,
                 config,
@@ -352,21 +351,20 @@ def test_dot_product_attention(
         torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
         for i, _ in enumerate(fused_attn_bwd):
             torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
-        if IS_HIP_EXTENSION:
-            logging.info("[test_dot_product_attention]: fused attn backend 0 vs 2")
+        if has_ck_backend:  # Compare CK V2/V3 if both are available
+            logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
             torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
             for i, _ in enumerate(fused_attn_bwd):
                 torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
     if (
         fused_attn_supported and
         len(fused_attn_backends) == 1 and
-        IS_HIP_EXTENSION and
-        FusedAttnBackend["CK"] in fused_attn_backends
-    ):
+        has_ck_backend
+    ): # Compare CK V2/V3 if both are available
         logging.info("[test_dot_product_attention]: CK fused attn V2 vs V3")
-        torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_1, **tols)
+        torch.testing.assert_close(fused_attn_fwd, fused_attn_fwd_2, **tols)
         for i, _ in enumerate(fused_attn_bwd):
-            torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_1[i], **tols)
+            torch.testing.assert_close(fused_attn_bwd[i], fused_attn_bwd_2[i], **tols)
 
 
 @pytest.mark.skipif(get_cudnn_version() < (8, 9, 1), reason="cuDNN 8.9.1+ is required.")
@@ -1275,10 +1273,9 @@ def test_transformer_layer(
 
     # Skip if only unfused backend is supported
     # Double-count the CK backend since we want to compare V2/V3 kernels
-    if (
-        len(fused_attn_backends) +
-        int(IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends) +
-        flash_attn_supported + unfused_attn_supported
+    has_ck_backend = IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends
+    if not has_ck_backend and (
+        len(fused_attn_backends) + flash_attn_supported + unfused_attn_supported
     ) < 2:
         pytest.skip("Less than two backends to compare.")
     # Skip if qkv_format = thd and "padding" not in attn_mask_type
@@ -1313,7 +1310,7 @@ def test_transformer_layer(
                 RoPE,
                 is_training,
             )
-            if IS_HIP_EXTENSION and FusedAttnBackend["CK"] in fused_attn_backends:
+            if has_ck_backend:
                 os.environ["NVTE_CK_USES_FWD_V3"] = "0"
                 os.environ["NVTE_CK_USES_BWD_V3"] = "0"
                 fused_attn_fwd_1, fused_attn_bwd_1 = _run_transformer_layer(


### PR DESCRIPTION
# Description

Modifies pytorch FA tests to essentially treat the CK backend as two virtual backends, thus directly comparing V2/V3 implementations even when no other backend is available.

Note that sometimes V3 will fallback to V2, so it's not a rigorous test and doesn't substitute having another backend to compare against, but it enables more tests that would otherwise be skipped.

Fixes https://github.com/ROCm/frameworks-internal/issues/15114

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
