### PR TITLE
Avoid hipifying code outside TE tree

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -84,7 +84,7 @@ def setup_jax_extension(
     if rocm_build() and not bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
         current_file_path = Path(__file__).parent.resolve()
         base_dir = current_file_path.parent
-        sources = hipify(base_dir, csrc_source_files, sources, include_dirs[1:])
+        sources = hipify(base_dir, csrc_source_files, sources, include_dirs)
 
     # Compile flags
     cxx_flags = ["-O3"]

--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -65,7 +65,7 @@ def setup_pytorch_extension(
     if rocm_build() and not bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
         current_file_path = Path(__file__).parent.resolve()
         base_dir = current_file_path.parent
-        sources = hipify(base_dir, csrc_source_files, sources, include_dirs[1:])
+        sources = hipify(base_dir, csrc_source_files, sources, include_dirs)
 
     # Compiler flags
     cxx_flags = ["-O3", "-fvisibility=hidden"]

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -1,5 +1,5 @@
 # This file was modified for portability to AMDGPU
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -526,7 +526,7 @@ def hipify(base_dir, src_dir, sources, include_dirs):
         output_directory=src_dir,
         includes=["*"],
         ignores=["*/amd_detail/*", "*/aotriton/*", "*/ck_fused_attn/*"],
-        header_include_dirs=include_dirs,
+        header_include_dirs=[d for d in include_dirs if Path(d).is_relative_to(base_dir)],
         custom_map_list=base_dir / "hipify_custom_map.json",
         extra_files=[],
         is_pytorch_extension=True,


### PR DESCRIPTION
# Description

Only pass headers paths to hipify that are part of TE tree
Fixes undesired XLA headers hipification when build JAX extension

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Move headers filtering inside hipify wrapper
- Filter out non-TE header paths

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
