### PR TITLE
export HF_TOKEN for CI

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -342,7 +342,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          docker exec te-runner bash -c "$(cat <<'EOF'
+          docker exec -e HF_TOKEN="$HF_TOKEN" te-runner bash -c "$(cat <<'EOF'
           #!/usr/bin/bash
           set -ex -o pipefail
           ulimit -c 0 # Disable core dumps

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -339,11 +339,16 @@ jobs:
       - name: Run Examples
         id: examples-tests
         continue-on-error: true
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           docker exec te-runner bash -c "$(cat <<'EOF'
           #!/usr/bin/bash
           set -ex -o pipefail
           ulimit -c 0 # Disable core dumps
+
+          # Make sure HF_TOKEN is present
+          python -c "import os; assert os.environ.get('HF_TOKEN')"
 
           cd /workspace/examples/pytorch/mnist
           python main.py 2>&1 | tee /workspace/examples.log

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -347,8 +347,8 @@ jobs:
           set -ex -o pipefail
           ulimit -c 0 # Disable core dumps
 
-          # Make sure HF_TOKEN is present
-          python -c "import os; assert os.environ.get('HF_TOKEN')"
+          # Check whether the HF_TOKEN is present
+          python -c "import os; print('HF_TOKEN set:', bool(os.environ.get('HF_TOKEN')))"
 
           cd /workspace/examples/pytorch/mnist
           python main.py 2>&1 | tee /workspace/examples.log


### PR DESCRIPTION
# Description

Fixes CI errors of the type:

```
+ python test_single_gpu_mnist.py
+ tee -a /workspace/examples.log
Namespace(batch_size=64, test_batch_size=800, epochs=10, lr=0.01, momentum=0.9, dry_run=False, seed=1, use_fp8=False, fp8_recipe='DelayedScaling', use_te=False)
Traceback (most recent call last):
  File "/workspace/examples/jax/mnist/test_single_gpu_mnist.py", line 365, in <module>
    train_and_evaluate(mnist_parser(None))
  File "/workspace/examples/jax/mnist/test_single_gpu_mnist.py", line 182, in train_and_evaluate
    train_ds, test_ds = get_datasets()
                        ^^^^^^^^^^^^^^
  File "/workspace/examples/jax/mnist/test_single_gpu_mnist.py", line 143, in get_datasets
    train_ds = load_dataset("ylecun/mnist", split="train", trust_remote_code=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/datasets/load.py", line 2062, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/datasets/load.py", line 1782, in load_dataset_builder
    dataset_module = dataset_module_factory(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/datasets/load.py", line 1664, in dataset_module_factory
    raise e1 from None
  File "/opt/venv/lib/python3.11/site-packages/datasets/load.py", line 1629, in dataset_module_factory
    ).get_module()
      ^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/datasets/load.py", line 978, in get_module
    standalone_yaml_path = cached_path(
                           ^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/datasets/utils/file_utils.py", line 189, in cached_path
    ).resolve_path(url_or_filename)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/hf_file_system.py", line 282, in resolve_path
    repo_and_revision_exist, err = self._repo_and_revision_exist(repo_type, repo_id, revision)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/hf_file_system.py", line 209, in _repo_and_revision_exist
    self._api.repo_info(
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 2997, in repo_info
    return method(
           ^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 2861, in dataset_info
    hf_raise_for_status(r)
  File "/opt/venv/lib/python3.11/site-packages/huggingface_hub/utils/_http.py", line 743, in hf_raise_for_status
    raise _format(HfHubHTTPError, message, response) from e
huggingface_hub.errors.HfHubHTTPError: (Request ID: Root=1-699e331f-5cf23c0e11020de41b7da4e5;31f28271-bb56-44bd-a6a5-bb381133f2a3)

429 Too Many Requests: you have reached your 'api' rate limit.
Retry after 85 seconds (0/500 requests remaining in current 300s window).
Url: https://huggingface.co/api/datasets/ylecun/mnist/revision/77f3279092a1c1579b2250db8eafed0ad422088c.
We had to rate limit your IP (216.114.73.26). To continue using our service, create a HF account or login to your existing account, and make sure you pass a HF_TOKEN if you're using the API.
##[error]Process completed with exit code 1.
``` 

Note that the HF token provided in the GitHub UI is my personal (readonly) token.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
