### PR TITLE
Fix rmsnorm RMSNorm BWD Triton kernel alignment checks

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -382,11 +382,11 @@ def te_rmsnorm_bwd_triton(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma):
     dg_tmp = torch.empty(dg_tmp_rows(x_, sm_margin), N, device=x.device, dtype=torch.float32, requires_grad=False) if need_reduction else None
 
     grid_bwd = lambda meta: (NUM_PRGMS, )
-    input_aligned_16 = (x_.data_ptr() % 16 == 0) and (x_.stride(-1) % 16 == 0)
-    grad_output_aligned_16 = (dz_.data_ptr() % 16 == 0) and (dz_.stride(-1) % 16 == 0)
-    dx_aligned_16 = (dx.data_ptr() % 16 == 0) and (dx.stride(-1) % 16 == 0)
+    input_aligned_16 = (x_.data_ptr() % (16 * x_.element_size()) == 0) and (x_.stride(0) % 16 == 0)
+    grad_output_aligned_16 = (dz_.data_ptr() % (16 * dz_.element_size()) == 0) and (dz_.stride(0) % 16 == 0)
+    dx_aligned_16 = (dx.data_ptr() % (16 * dx.element_size()) == 0) and (dx.stride(0) % 16 == 0)
     dg_target = dg_tmp if need_reduction else dgamma
-    dg_aligned_16 = (dg_target.data_ptr() % 16 == 0) and (dg_target.stride(-1) % 16 == 0)
+    dg_aligned_16 = (dg_target.data_ptr() % (16 * dg_target.element_size()) == 0) and (dg_target.stride(0) % 16 == 0)
     _rmsnorm_bwd_triton[grid_bwd](
         dz_,
         x_,
@@ -492,10 +492,10 @@ def te_rmsnorm_fwd_triton(
     grid_fwd = lambda meta: (NUM_PRGMS, )
     # TODO(micky774) Implement fused MXFP8 quantization within the kernel
     kernel = _rmsnorm_fwd_triton if autotune else _rmsnorm_fwd_triton_impl
-    input_aligned_16 = (input.data_ptr() % 16 == 0) and (input.stride(-1) % 16 == 0)
+    input_aligned_16 = (input.data_ptr() % (16 * input.element_size()) == 0) and (input.stride(0) % 16 == 0)
     out_alignment_tensor = out._data if hasattr(out, "_data") else out
-    output_aligned_16 = (out_alignment_tensor.data_ptr() % 16 == 0) and (
-        out_alignment_tensor.stride(-1) % 16 == 0
+    output_aligned_16 = (out_alignment_tensor.data_ptr() % (16 * out_alignment_tensor.element_size()) == 0) and (
+        out_alignment_tensor.stride(0) % 16 == 0
     )
     kernel[grid_fwd](
         out_ptr,


### PR DESCRIPTION
## Summary

Fix `tl.multiple_of()` vectorization hints in `_rmsnorm_bwd_triton` and `_rmsnorm_fwd_triton_impl` being permanently disabled due to incorrect alignment checks.

`stride(-1)` always returns 1 for contiguous tensors, so `1 % 16 != 0` made all alignment flags False. Replaced with `stride(0)` (row stride) and `element_size()`-scaled pointer checks so `tl.multiple_of()` is correctly applied for aligned, contiguous inputs

