### PR TITLE
Add ROCm mismatch bypass env flag

### DIFF
--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -384,7 +384,16 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
                 build_rocm_version = build_rocm_version[0].split(":")[1].strip().split('.')[:2]
             # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
             allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
-            if not allow_rocm_mismatch and rocm_version != build_rocm_version:
+            mismatch_detected = rocm_version != build_rocm_version
+            if allow_rocm_mismatch:
+                _logger.warning(
+                    "NVTE_ALLOW_ROCM_MISMATCH is enabled. ROCm runtime/build mismatch detected=%s "
+                    "(runtime=%s, build=%s).",
+                    mismatch_detected,
+                    ".".join(rocm_version),
+                    ".".join(build_rocm_version),
+                )
+            elif mismatch_detected:
                 raise RuntimeError(
                     f"ROCm {'.'.join(rocm_version)} is detected but the library is built for "
                     f"{'.'.join(build_rocm_version)}. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass "

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -382,7 +382,10 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
             build_rocm_version = list(filter(lambda f: f.startswith("ROCM_VERSION:"), build_info))
             if build_rocm_version:
                 build_rocm_version = build_rocm_version[0].split(":")[1].strip().split('.')[:2]
-            assert (rocm_version == build_rocm_version), f"ROCm {'.'.join(rocm_version)} is detected but the library is built for {'.'.join(build_rocm_version)}"
+            # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
+            allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
+            if not allow_rocm_mismatch:
+                assert (rocm_version == build_rocm_version), f"ROCm {'.'.join(rocm_version)} is detected but the library is built for {'.'.join(build_rocm_version)}"
         except FileNotFoundError:
             pass
 

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -385,7 +385,11 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
             # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
             allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
             if not allow_rocm_mismatch:
-                assert (rocm_version == build_rocm_version), f"ROCm {'.'.join(rocm_version)} is detected but the library is built for {'.'.join(build_rocm_version)}"
+                assert rocm_version == build_rocm_version, (
+                    f"ROCm {'.'.join(rocm_version)} is detected but the library is built for "
+                    f"{'.'.join(build_rocm_version)}. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass "
+                    "this check at your own risk."
+                )
         except FileNotFoundError:
             pass
 

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -383,7 +383,7 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
             if build_rocm_version:
                 build_rocm_version = build_rocm_version[0].split(":")[1].strip().split('.')[:2]
             # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
-            allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
+            allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").strip().lower() in ("1", "true", "yes")
             mismatch_detected = rocm_version != build_rocm_version
             if allow_rocm_mismatch and mismatch_detected:
                 _logger.warning(

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -384,8 +384,8 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
                 build_rocm_version = build_rocm_version[0].split(":")[1].strip().split('.')[:2]
             # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
             allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
-            if not allow_rocm_mismatch:
-                assert rocm_version == build_rocm_version, (
+            if not allow_rocm_mismatch and rocm_version != build_rocm_version:
+                raise RuntimeError(
                     f"ROCm {'.'.join(rocm_version)} is detected but the library is built for "
                     f"{'.'.join(build_rocm_version)}. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass "
                     "this check at your own risk."

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -385,11 +385,10 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
             # Strict by default. Set NVTE_ALLOW_ROCM_MISMATCH=1 to bypass.
             allow_rocm_mismatch = os.getenv("NVTE_ALLOW_ROCM_MISMATCH", "0").lower() in ("1", "true", "yes")
             mismatch_detected = rocm_version != build_rocm_version
-            if allow_rocm_mismatch:
+            if allow_rocm_mismatch and mismatch_detected:
                 _logger.warning(
-                    "NVTE_ALLOW_ROCM_MISMATCH is enabled. ROCm runtime/build mismatch detected=%s "
-                    "(runtime=%s, build=%s).",
-                    mismatch_detected,
+                    "NVTE_ALLOW_ROCM_MISMATCH is enabled. Proceeding despite ROCm runtime/build "
+                    "version mismatch (runtime=%s, build=%s).",
                     ".".join(rocm_version),
                     ".".join(build_rocm_version),
                 )


### PR DESCRIPTION
## Summary
- Make the ROCm runtime/build version check configurable at import time.
- Keep strict validation as the default behavior.
- Allow an explicit bypass via `NVTE_ALLOW_ROCM_MISMATCH=1` for environments that accept mismatch risk.

## Test plan
- [ ] Build/install TransformerEngine in an environment where ROCm runtime and build versions match; verify import succeeds.
- [ ] Simulate a mismatch and verify import fails by default.
- [ ] Set `NVTE_ALLOW_ROCM_MISMATCH=1` and verify import succeeds despite mismatch.

Made with [Cursor](https://cursor.com)