### PR TITLE
fix JAX distributed tests hang: ROCM-1719

### DIFF
--- a/ci/jax.sh
+++ b/ci/jax.sh
@@ -82,13 +82,8 @@ run_test_config_mgpu() {
     fi
 
     run_default_fa 2 test_distributed_dense.py
-    # Do not fail automated CI if test_distributed_fused_attn is hung
-    # If the script runs w/o TEST_LEVEL the test error will be honored
-    if [ "$TEST_LEVEL" -le 3 ]; then
-        TEST_ERROR_IGNORE="1"
-    fi
-    run $_dfa_level test_distributed_fused_attn.py $_timeout_args
-    TEST_ERROR_IGNORE=""
+    # RCCL_MSCCL_ENABLE=0 is to avoid hangs in some distributed tests (ROCM-1719)
+    RCCL_MSCCL_ENABLE=0 run $_dfa_level test_distributed_fused_attn.py $_timeout_args
     run_default_fa 3 test_distributed_layernorm.py
     run_default_fa 2 test_distributed_layernorm_mlp.py $_timeout_args
     run_default_fa 3 test_distributed_softmax.py


### PR DESCRIPTION
# Description

Add RCCL env variable that prevents TE JAX distributed tests hang

Fixes https://github.com/ROCm/frameworks-internal/issues/11602, 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
