### PR TITLE
[HOTFIX MGPU unit test] for test_cast_master_weights_to_fp8.py

### DIFF
--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -1,3 +1,5 @@
+# This file was modified for portability to AMDGPU.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
@@ -717,7 +719,7 @@ def run_parallel_tests() -> None:
 @pytest.mark.parametrize("world_size", [2])
 def test_cast_master_weights_to_fp8(world_size: int) -> None:
     """Launch parallel job that runs parallel tests"""
-    # Use executable as-is; do not resolve() or a venv symlink may point to system
+    # ROCm: Use executable as-is; do not resolve() or a venv symlink may point to system
     # Python which does not have torch/site-packages.
     python_exe = pathlib.Path(sys.executable)
     current_file = pathlib.Path(__file__).resolve()

--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -717,7 +717,9 @@ def run_parallel_tests() -> None:
 @pytest.mark.parametrize("world_size", [2])
 def test_cast_master_weights_to_fp8(world_size: int) -> None:
     """Launch parallel job that runs parallel tests"""
-    python_exe = pathlib.Path(sys.executable).resolve()
+    # Use executable as-is; do not resolve() or a venv symlink may point to system
+    # Python which does not have torch/site-packages.
+    python_exe = pathlib.Path(sys.executable)
     current_file = pathlib.Path(__file__).resolve()
     command = [
         python_exe,


### PR DESCRIPTION
# Failure
https://github.com/ROCm/TransformerEngine/actions/runs/23202228661/job/67427539244

```
subprocess.CalledProcessError: Command '[PosixPath('/usr/bin/python3.11'), '-m', 'torch.distributed.run', '--nproc_per_node=2', PosixPath('/workspace/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py'), '--parallel']' returned non-zero exit status 1.

/usr/lib/python3.11/subprocess.py:571: CalledProcessError
----------------------------- Captured stderr call -----------------------------
/usr/bin/python3.11: Error while finding module specification for 'torch.distributed.run' (ModuleNotFoundError: No module named 'torch')/usr/bin/python3.11: Error while finding module specification for 'torch.distributed.run' (ModuleNotFoundError: No module named 'torch')
```

# Description

The "No module named 'torch'" error happened because the test builds the subprocess command using pathlib.Path(sys.executable).resolve(). Pytest was run with the venv interpreter (/opt/venv/bin/python), which is a symlink to /usr/bin/python3.11. Calling .resolve() follows that symlink and returns the system Python path. The subprocess was therefore launched as /usr/bin/python3.11 -m torch.distributed.run ..., i.e. using the system Python, which does not have the venv’s site-packages and thus no torch. The fix is to use the executable without resolving (e.g. pathlib.Path(sys.executable) only), so the subprocess keeps using /opt/venv/bin/python and finds torch in the venv.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [ ] 
# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
