### PR TITLE
IFU 2.12 Common merge conflict resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,11 +52,8 @@ compile_commands.json
 .nfs
 tensor_dumps/
 artifacts/
-<<<<<<< HEAD
 **/profiler_outputs/
 **/times.csv
 transformer_engine/build_info.txt
 transformer_engine/common/util/hip_nvml.*
-=======
 *.DS_Store
->>>>>>> 99df88

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -390,7 +390,7 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
             _CUBLAS_LIB_CTYPES = _load_cuda_library_from_python("cublas", strict=True)
             _CUDART_LIB_CTYPES = _load_cuda_library_from_python("cudart", strict=True)
             _CUDNN_ALL_LIB_CTYPES = _load_cuda_library_from_python("cudnn", strict=True)
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, RuntimeError, subprocess.CalledProcessError):
         pass
     finally:
         _TE_LIB_CTYPES = _load_core_library()

--- a/transformer_engine/common/swizzle/swizzle.cu
+++ b/transformer_engine/common/swizzle/swizzle.cu
@@ -25,9 +25,9 @@ namespace {
 #endif
 
 constexpr int MXFP8_BLOCK_SIZE = 32;
-#ifndef __HIP_PLATFORM_AMD__
 constexpr int NVFP4_BLOCK_SIZE = 16;
 
+#ifndef __HIP_PLATFORM_AMD__
 constexpr __device__ __host__ int TB_DIM = 32;
 constexpr __device__ __host__ int NEW_SF_TILE_DIM_K = 16;
 constexpr __device__ __host__ int N_SF_PER_TD_PER_TILE = 4;

--- a/transformer_engine/common/swizzle/swizzle_block_scaling.cu
+++ b/transformer_engine/common/swizzle/swizzle_block_scaling.cu
@@ -17,6 +17,11 @@
 namespace transformer_engine {
 namespace {
 constexpr uint32_t WARP_SIZE = 32;
+#ifdef __HIP_PLATFORM_AMD__
+using warp_mask_t = uint64_t;
+#else
+using warp_mask_t = uint32_t;
+#endif
 }  // namespace
 namespace swizzle_kernel_1d {
 constexpr uint32_t WARPS_X_PER_TB = 2;  // configurable
@@ -36,7 +41,7 @@ constexpr uint32_t WARPS_Y_PER_TB = 2;  // configurable
 //   lane3.row = 0x03070b0f
 uint32_t __device__ __forceinline__ transpose_4x4_byte_matrix(const uint32_t row,
                                                               const uint32_t lane,
-                                                              const uint32_t active_mask) {
+                                                              const warp_mask_t active_mask) {
   using cu = const uint32_t;
 
   // Threads operate in groups of 4, and each thread stores 4 bytes at a time.
@@ -118,7 +123,7 @@ void __global__ __launch_bounds__(WARPS_X_PER_TB* WARPS_Y_PER_TB* WARP_SIZE)
                               (((sf.z >> 23) & 0xFF) << 16) | (((sf.w >> 23) & 0xFF) << 24);
 
   // partially swizzle the scaling factors
-  constexpr uint32_t ACTIVE_MASK = 0xFFFFFFFF;  // no divergent branches
+  constexpr warp_mask_t ACTIVE_MASK = ~warp_mask_t(0);  // no divergent branches
   const uint32_t lane_load_idx = (lane % 4) * 8 + (lane / 4);
   packed_exponents = __shfl_sync(ACTIVE_MASK, packed_exponents, lane_load_idx);
 


### PR DESCRIPTION
# Description

This PR focuses on the resolutions to merge conflicts located in the common section, as introduced as part of the main IFU branch. This merge resolution is performed in separate PRs to limit the scope of each PR and simplify the review process, while preserving commit history and conversation readability.

This is one of three PRs which target the common components of TE, as well as the JAX and PyTorch integrations. Once all three PRs are resolved and merged into the IFU branch, a new IFU PR will be created with a focus on ensuring a successful total build as well as CI validation. In the meanwhile, the PRs will be partially validated via local testing.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

The changelog is generated with assistance from Claude.

1. `setup.py` — smarter submodule init — only runs `git submodule update --init --recursive` when a submodule is actually uninitialized (prefix -), avoiding unnecessary re-init on every build (can be a significant pain point when connection is slow)
2. CMakeLists.txt — three changes:
    - Added `GIT_CONFIG` env vars to trust all directories (fixes "dubious ownership" errors in Docker containers)
    - Moved swizzle/swizzle.cu and swizzle_block_scaling.cu from the CUDA-only source list to the shared source list (so they compile on ROCm too)
    - Simplified `get_git_commit` — removed the temp-file `GIT_CONFIG_GLOBAL` hack, relying on the new env vars instead
3. Added `RuntimeError` to the exception catch in `common/__init__.py` when loading CUDA libraries (prevents crashes in ROCm environments)
4. aotriton/CMakeLists.txt — added 30s download timeout for prebuilt aotriton, and DOWNLOAD_COMMAND "" / UPDATE_COMMAND "" for source builds to avoid unnecessary re-downloads of the repo (another pain point for slow connections)
5. `swizzle.cu` — moved `NVFP4_BLOCK_SIZE` constant outside `#ifndef __HIP_PLATFORM_AMD__` guard. It's less invasive than duplicating large code paths, and our higher-level APIs guarantee we never "use" it.
6. `swizzle_block_scaling.cu` — added `warp_mask_t` typedef (`uint64_t` on ROCm, `uint32_t` on CUDA) to fix warp shuffle mask type mismatches for AMD's 64-wide wavefronts.


# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
