### PR TITLE
[Distributed Optimizer] Fix transpose creation when keep_fp8_weight_transpose_cache=False

### DIFF
--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -33,7 +33,7 @@ from transformer_engine.pytorch import (
 )
 from transformer_engine.pytorch.tensor import cast_master_weights_to_fp8
 from transformer_engine.pytorch.tensor.utils import post_all_gather_processing, replace_raw_data
-
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
 
 def _get_quantization_recipe(quantization) -> Recipe:
     """Quantization recipe setup"""
@@ -710,7 +710,9 @@ def run_parallel_tests() -> None:
         quantizations.append("fp8_block")
 
     manual_post_all_gather_processings = [False, True]
-    keep_fp8_weight_transpose_caches = [True, False]
+    keep_fp8_weight_transpose_cache = [True]
+    if IS_HIP_EXTENSION:
+        keep_fp8_weight_transpose_cache.append(False)
 
     _test_mini_optimizer(dp_group)
 

--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -496,7 +496,9 @@ def _test_mini_optimizer(dp_group):
             torch.testing.assert_close(w1, w3, atol=0, rtol=0)
 
 
-def _test_cast_master_weights_to_fp8(quantization, dp_group, manual_post_all_gather_processing):
+def _test_cast_master_weights_to_fp8(
+    quantization, dp_group, manual_post_all_gather_processing, keep_fp8_weight_transpose_cache
+):
     rank = dist.get_rank(dp_group)
     world_size = dist.get_world_size(dp_group)
 
@@ -506,7 +508,12 @@ def _test_cast_master_weights_to_fp8(quantization, dp_group, manual_post_all_gat
     mock_groups = [dist.new_group(ranks=[i]) for i in range(world_size)]
     mock_group = mock_groups[rank]
 
-    linear_kwargs = {"params_dtype": torch.bfloat16, "bias": False, "fuse_wgrad_accumulation": True}
+    linear_kwargs = {
+        "params_dtype": torch.bfloat16,
+        "bias": False,
+        "fuse_wgrad_accumulation": True,
+        "keep_fp8_weight_transpose_cache": keep_fp8_weight_transpose_cache,
+    }
 
     # Create model with FP8 weights
     with te.quantized_model_init(
@@ -583,7 +590,7 @@ def _test_cast_master_weights_to_fp8(quantization, dp_group, manual_post_all_gat
 
 
 def _test_fsdp_cast_master_weights_to_fp8(
-    quantization, dp_group, manual_post_all_gather_processing
+    quantization, dp_group, manual_post_all_gather_processing, keep_fp8_weight_transpose_cache
 ):
     rank = dist.get_rank(dp_group)
     world_size = dist.get_world_size(dp_group)
@@ -602,6 +609,7 @@ def _test_fsdp_cast_master_weights_to_fp8(
         "params_dtype": torch.bfloat16,
         "bias": False,
         "fuse_wgrad_accumulation": True,
+        "keep_fp8_weight_transpose_cache": keep_fp8_weight_transpose_cache,
     }
 
     # Create model with FP8 weights
@@ -702,13 +710,19 @@ def run_parallel_tests() -> None:
         quantizations.append("fp8_block")
 
     manual_post_all_gather_processings = [False, True]
+    keep_fp8_weight_transpose_caches = [True, False]
 
     _test_mini_optimizer(dp_group)
 
     for quantization in quantizations:
         for post_ag_processing in manual_post_all_gather_processings:
-            _test_cast_master_weights_to_fp8(quantization, dp_group, post_ag_processing)
-            _test_fsdp_cast_master_weights_to_fp8(quantization, dp_group, post_ag_processing)
+            for keep_fp8_weight_transpose_cache in keep_fp8_weight_transpose_caches:
+                _test_cast_master_weights_to_fp8(
+                    quantization, dp_group, post_ag_processing, keep_fp8_weight_transpose_cache
+                )
+                _test_fsdp_cast_master_weights_to_fp8(
+                    quantization, dp_group, post_ag_processing, keep_fp8_weight_transpose_cache
+                )
 
     dist.destroy_process_group()
 

--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -710,9 +710,9 @@ def run_parallel_tests() -> None:
         quantizations.append("fp8_block")
 
     manual_post_all_gather_processings = [False, True]
-    keep_fp8_weight_transpose_cache = [True]
+    keep_fp8_weight_transpose_caches = [True]
     if IS_HIP_EXTENSION:
-        keep_fp8_weight_transpose_cache.append(False)
+        keep_fp8_weight_transpose_caches.append(False)
 
     _test_mini_optimizer(dp_group)
 

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -482,6 +482,7 @@ def post_all_gather_processing(model_weights: Union[torch.Tensor, List[torch.Ten
         if isinstance(model_weight, Float8Tensor):
             # Delayed scaling and per-tensor current scaling: if backend does not support
             # non-transposed FP8 GEMM, pre-create the transpose.
+            # ROCm: add check for columnwise_usage from the quantizer since keep_fp8_weight_transpose_cache can be false.
             if model_weight._quantizer.columnwise_usage and not is_non_tn_fp8_gemm_supported():
                 model_weight._create_transpose()
         elif isinstance(model_weight, Float8BlockwiseQTensor):

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -482,7 +482,7 @@ def post_all_gather_processing(model_weights: Union[torch.Tensor, List[torch.Ten
         if isinstance(model_weight, Float8Tensor):
             # Delayed scaling and per-tensor current scaling: if backend does not support
             # non-transposed FP8 GEMM, pre-create the transpose.
-            if not is_non_tn_fp8_gemm_supported():
+            if model_weight._quantizer.columnwise_usage and not is_non_tn_fp8_gemm_supported():
                 model_weight._create_transpose()
         elif isinstance(model_weight, Float8BlockwiseQTensor):
             # Blockwise scaling: create column-wise storage.


### PR DESCRIPTION
## Summary
Fixes a bug where `post_all_gather_processing` created transpose for Float8Tensor weights even when `keep_fp8_weight_transpose_cache=False`, leading to assertion failures in Linear forward.

## Problem
With `keep_fp8_weight_transpose_cache=False`, `quantizer.columnwise_usage` is set to False (e.g. on ROCm/AMD). `post_all_gather_processing` was still creating transpose via `_create_transpose()` because it did not respect `columnwise_usage`. This triggered the assertion in Linear forward: `expected _transpose to be None or an empty tensor when transpose cache is disabled`.

## Solution
- Update `post_all_gather_processing` in `utils.py` so it only creates transpose when `model_weight._quantizer.columnwise_usage` is True.
- Parametrize `test_cast_master_weights_to_fp8` with `keep_fp8_weight_transpose_cache=True` and `False` to cover both cases.

## Testing
- `test_cast_master_weights_to_fp8` with `keep_fp8_weight_transpose_cache=False` now passes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
