### PR TITLE
ck_tile grouped GEMM: re-enable accumulate support

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2993,7 +2993,12 @@ def test_grouped_gemm(shape, dtype, layout, accumulate, use_cutlass):
             # cublas implementation should be bit-wise match
             torch.testing.assert_close(o, o_ref, rtol=0, atol=0)
         else:
-            torch.testing.assert_close(o, o_ref, rtol=1.5e-2, atol=1.5e-2)
+            if accumulate and dtype == torch.bfloat16 and get_device_compute_capability() == (9, 4):
+                # MultiD Add epilogue fuses accumulation into the tile store, producing
+                # a different FP rounding order than sequential GEMMs.
+                torch.testing.assert_close(o, o_ref, rtol=4e-2, atol=4e-2)
+            else:
+                torch.testing.assert_close(o, o_ref, rtol=1.5e-2, atol=1.5e-2)
 
     if use_cutlass:
         os.environ.pop("NVTE_USE_CUTLASS_GROUPED_GEMM", None)

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2992,13 +2992,12 @@ def test_grouped_gemm(shape, dtype, layout, accumulate, use_cutlass):
         if not use_cutlass:
             # cublas implementation should be bit-wise match
             torch.testing.assert_close(o, o_ref, rtol=0, atol=0)
+        elif IS_HIP_EXTENSION and accumulate and dtype == torch.bfloat16 and get_device_compute_capability() == (9, 4):
+            # ck_tile's MultiD Add epilogue fuses accumulation into the tile store, producing
+            # a different FP rounding order than sequential GEMMs.
+            torch.testing.assert_close(o, o_ref, rtol=4e-2, atol=4e-2)
         else:
-            if accumulate and dtype == torch.bfloat16 and get_device_compute_capability() == (9, 4):
-                # MultiD Add epilogue fuses accumulation into the tile store, producing
-                # a different FP rounding order than sequential GEMMs.
-                torch.testing.assert_close(o, o_ref, rtol=4e-2, atol=4e-2)
-            else:
-                torch.testing.assert_close(o, o_ref, rtol=1.5e-2, atol=1.5e-2)
+            torch.testing.assert_close(o, o_ref, rtol=1.5e-2, atol=1.5e-2)
 
     if use_cutlass:
         os.environ.pop("NVTE_USE_CUTLASS_GROUPED_GEMM", None)

--- a/transformer_engine/common/gemm/ck_grouped_gemm.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm.cpp
@@ -35,6 +35,22 @@ static inline bool get_flat_2d_dims(const transformer_engine::Tensor& t,
   return true;
 }
 
+// Selects epilogue traits based on whether we are accumulating (D += A*B) or not (D = A*B).
+// For accumulate=true, the existing D buffer is passed as a MultiD input tensor and combined
+// via element_wise::Add. For accumulate=false, no extra input is needed and PassThrough is used.
+template <typename CType, typename CLayout, bool Accumulate>
+struct EpilogueTraits {
+  using DsDataType = ck_tile::tuple<>;
+  using DsLayout   = ck_tile::tuple<>;
+  using ElemOp     = ck_tile::element_wise::PassThrough;
+};
+template <typename CType, typename CLayout>
+struct EpilogueTraits<CType, CLayout, true> {
+  using DsDataType = ck_tile::tuple<CType>;
+  using DsLayout   = ck_tile::tuple<CLayout>;
+  using ElemOp     = ck_tile::element_wise::Add;
+};
+
 static inline const transformer_engine::SimpleTensor& data_view(const transformer_engine::Tensor& t) {
   return t.data; // rowwise data view
 }
@@ -79,8 +95,7 @@ struct TileCfg_256x128x64_padding : TileCfg_256x128x64 {
 // See e.g. https://github.com/ROCm/composable_kernel/blob/develop/example/ck_tile/03_gemm/universal_gemm_invoker.hpp for reference.
 template <typename AType, typename BType, typename CType,
           typename ALayout, typename BLayout, typename CLayout,
-          typename TileCfg, ck_tile::memory_operation_enum MemOp,
-          typename AccType = float>
+          typename TileCfg, bool Accumulate, typename AccType = float>
 struct Runner{
   using GemmShape = ck_tile::TileGemmShape<
       ck_tile::sequence<TileCfg::M_Tile, TileCfg::N_Tile, TileCfg::K_Tile>,
@@ -102,21 +117,23 @@ struct Runner{
 
   using Pipeline = ck_tile::GemmPipelineAgBgCrCompV3<Problem>;
 
+  using ET = EpilogueTraits<CType, CLayout, Accumulate>;
+
   using Epilogue = ck_tile::CShuffleEpilogue<
       ck_tile::CShuffleEpilogueProblem<
-          AType, BType, ck_tile::tuple<>, AccType,
-          CType, ck_tile::tuple<>, CLayout,
-          ck_tile::element_wise::PassThrough,
+          AType, BType, typename ET::DsDataType, AccType,
+          CType, typename ET::DsLayout, CLayout,
+          typename ET::ElemOp,
           Partitioner::MPerBlock, Partitioner::NPerBlock,
           TileCfg::M_Warp, TileCfg::N_Warp,
           TileCfg::M_Warp_Tile, TileCfg::N_Warp_Tile, TileCfg::K_Warp_Tile,
-          Problem::TransposeC, MemOp>>;
+          Problem::TransposeC, ck_tile::memory_operation_enum::set>>;
 
   using Kernel = ck_tile::GroupedGemmKernel<Partitioner, Pipeline, Epilogue>;
 };
 
 template <typename T, typename ALayout, typename BLayout, typename CLayout,
-          ck_tile::memory_operation_enum MemOp, typename TileCfg>
+          bool Accumulate, typename TileCfg>
 static bool run_grouped_impl(const NVTETensor* A_use,
                              const NVTETensor* B_use,
                              NVTETensor* D,
@@ -127,7 +144,7 @@ static bool run_grouped_impl(const NVTETensor* A_use,
                              size_t workspace_bytes,
                              hipStream_t stream)
 {
-  using Kernel = typename Runner<T, T, T, ALayout, BLayout, CLayout, TileCfg, MemOp>::Kernel;
+  using Kernel = typename Runner<T, T, T, ALayout, BLayout, CLayout, TileCfg, Accumulate>::Kernel;
 
   const size_t needed = Kernel::GetWorkSpaceSize(group_num);
   if (!workspace || workspace_bytes < needed) {
@@ -135,7 +152,12 @@ static bool run_grouped_impl(const NVTETensor* A_use,
     return false;
   }
 
-  thread_local std::vector<ck_tile::GroupedGemmHostArgs<0>> descs;
+  // GroupedGemmHostArgs<1> for the MultiD accumulate path, <0> for the overwrite path.
+  using HostArgs = std::conditional_t<Accumulate,
+      ck_tile::GroupedGemmHostArgs<1>,
+      ck_tile::GroupedGemmHostArgs<0>>;
+
+  thread_local std::vector<HostArgs> descs;
   descs.clear();
   descs.reserve(group_num);
 
@@ -179,19 +201,26 @@ static bool run_grouped_impl(const NVTETensor* A_use,
     const ck_tile::index_t stride_B = Bd1;
     const ck_tile::index_t stride_E = Dd1;
 
-    descs.emplace_back(
-        a.dptr,
-        b.dptr,
-        std::array<const void*, 0>{},
-        d.dptr,
-        1,
-        M,
-        N,
-        K,
-        stride_A,
-        stride_B,
-        std::array<ck_tile::index_t, 0>{},
-        stride_E);
+    if constexpr (Accumulate) {
+      // MultiD: E = Add(A@B, D1).  D1 and E point to the same buffer for in-place accumulation.
+      descs.emplace_back(
+          a.dptr, b.dptr,
+          std::array<const void*, 1>{d.dptr},  // D1 = existing D contents (read)
+          d.dptr,                               // E  = same buffer (write)
+          1, M, N, K,
+          stride_A, stride_B,
+          std::array<ck_tile::index_t, 1>{stride_E},
+          stride_E);
+    } else {
+      descs.emplace_back(
+          a.dptr, b.dptr,
+          std::array<const void*, 0>{},
+          d.dptr,
+          1, M, N, K,
+          stride_A, stride_B,
+          std::array<ck_tile::index_t, 0>{},
+          stride_E);
+    }
   }
 
   const dim3 grids = Kernel::GridSize(descs);
@@ -280,11 +309,11 @@ bool ck_tile_grouped_gemm(const NVTETensor* A,
 
           if (accumulate) {
             return run_grouped_impl<T, ALayout, BLayout, RowMajor,
-                                  ck_tile::memory_operation_enum::atomic_add, TileCfgSel>(
+                                    true, TileCfgSel>(
                 A_use, B_use, D, group_num, kTransA, kTransB, ws_ptr, ws_bytes, stream);
           } else {
             return run_grouped_impl<T, ALayout, BLayout, RowMajor,
-                                  ck_tile::memory_operation_enum::set, TileCfgSel>(
+                                    false, TileCfgSel>(
                 A_use, B_use, D, group_num, kTransA, kTransB, ws_ptr, ws_bytes, stream);
           }
         });

--- a/transformer_engine/common/gemm/ck_grouped_gemm.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm.cpp
@@ -127,7 +127,7 @@ struct Runner{
           Partitioner::MPerBlock, Partitioner::NPerBlock,
           TileCfg::M_Warp, TileCfg::N_Warp,
           TileCfg::M_Warp_Tile, TileCfg::N_Warp_Tile, TileCfg::K_Warp_Tile,
-          Problem::TransposeC, ck_tile::memory_operation_enum::set>>;
+          Problem::TransposeC>>;
 
   using Kernel = ck_tile::GroupedGemmKernel<Partitioner, Pipeline, Epilogue>;
 };
@@ -265,12 +265,6 @@ bool ck_tile_grouped_gemm(const NVTETensor* A,
 {
   if (group_num <= 0)
     return true;
-
-  // The current CK grouped GEMM path uses CShuffleEpilogueProblem without an explicit
-  // memory-operation template argument, so D accumulation semantics are not guaranteed.
-  // Fall back for accumulate=true to preserve numerics.
-  if (accumulate)
-    return false;
 
   using namespace transformer_engine;
   using namespace transformer_engine::grouped_gemm;

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -1096,8 +1096,7 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
   };
 
 #ifdef __HIP_PLATFORM_AMD__
-  // FIXME: The accumulate path is currently disabled due to instability on MI325.
-  if (!use_cutlass || num_gemms == 1 || accumulate == true) {
+  if (!use_cutlass || num_gemms == 1) {
 #else
   // Currently only support cutlass group gemm on Hopper Arch
   if (!(is_hopper && use_cutlass)) {


### PR DESCRIPTION
## Description

Reactivates the accumulate support that was disabled in the initial implementation in #434.

Thanks to @tenpercent for pointing me in the right direction.

Followup of #434.

Fixes https://github.com/ROCm/frameworks-internal/issues/15791

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
