### PR TITLE
Update CI runner in rocm-ci.yml to use linux-te-mi35x-8

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-te-mi325-8, linux-te-mi350-8]
+        runner: [linux-te-mi325-8, linux-te-mi35x-8]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-te-mi325-8, linux-te-mi355-8]
+        runner: [linux-te-mi325-8, linux-te-mi350-8]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION


# Description

Update CI runner in rocm-ci.yml to use linux-te-mi350-8 instead of linux-te-mi355-8.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
