### PR TITLE
Ub mpi hotfix

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -353,6 +353,7 @@ target_include_directories(transformer_engine PRIVATE "${CUDNN_FRONTEND_INCLUDE_
 target_include_directories(transformer_engine PRIVATE
                           ${CUTLASS_INCLUDE_DIR}
                           ${CUTLASS_TOOLS_INCLUDE_DIR})
+endif()
 
 # Compiling Userbuffers with native MPI bootstrapping requires linking against MPI
 # Changed
@@ -367,6 +368,7 @@ if (NVTE_UB_WITH_MPI)
     target_compile_definitions(transformer_engine PUBLIC NVTE_UB_WITH_MPI)
 endif()
 
+if(USE_CUDA)
 option(NVTE_ENABLE_NVSHMEM "Compile with NVSHMEM library" OFF)
 if (NVTE_ENABLE_NVSHMEM)
     add_subdirectory(nvshmem_api)


### PR DESCRIPTION
Adds NVTE_UB_WITH_MPI to ROCm build path in CMakeFile.txt, allowing UserBuffers to be built with MPI backend