### PR TITLE
Corrected CI name for pushing to dev

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -3,7 +3,7 @@
 # See LICENSE for license information.
 
 name: Build and Test Branch
-run-name: CI Level ${{ inputs.test_level || '1' }}
+run-name: CI Level ${{ (github.event_name == 'push' && '3') || inputs.test_level || '1' }}
 
 on:
   push:
@@ -47,7 +47,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    name: Build and Test on GPU (${{ matrix.runner }}) - Level ${{ inputs.test_level || '1' }}
+    name: Build and Test on GPU (${{ matrix.runner }}) - Level ${{ (github.event_name == 'push' && '3') || inputs.test_level || '1' }}
     timeout-minutes: 720
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -86,10 +86,8 @@ jobs:
 
           # Only force Level 3 if this is a direct PUSH to dev or a release branch
           if [[ "${{ github.event_name }}" == "push" ]]; then
-             if [[ "${{ github.ref_name }}" == "dev" || "${{ github.ref_name }}" =~ ^release_v.*_rocm$ ]]; then
-                echo "::notice::Push to monitored branch (${{ github.ref_name }}) detected. Forcing Level 3."
-                CALC_LEVEL="3"
-             fi
+            echo "::notice::Push to monitored branch (${{ github.ref_name }}) detected. Forcing Level 3."
+            CALC_LEVEL="3"
           fi
           
           echo "TEST_LEVEL=$CALC_LEVEL" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

When pushing to `dev`, the CI test level default of 1 is overridden to 3 explicitly. This PR updates the test names to account for that explicit override.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Updates CI run naming

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
