### PR TITLE
CI: enable CI runs on every PR

### DIFF
--- a/.github/workflows/rocm-ci-dispatch.yml
+++ b/.github/workflows/rocm-ci-dispatch.yml
@@ -6,9 +6,6 @@ name: PR Automatic CI
 
 on:
   pull_request:
-    branches:
-      - 'dev'
-      - 'release_v2.*_rocm'
     types: [ opened, labeled, synchronize, reopened ]
 
 permissions:

--- a/.github/workflows/rocm-ci-dispatch.yml
+++ b/.github/workflows/rocm-ci-dispatch.yml
@@ -6,7 +6,7 @@ name: PR Automatic CI
 
 on:
   pull_request:
-    types: [ opened, labeled, synchronize, reopened ]
+    types: [ labeled, synchronize, reopened ]
 
 permissions:
   contents: read

--- a/.github/workflows/rocm-ci-dispatch.yml
+++ b/.github/workflows/rocm-ci-dispatch.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Determine CI dispatch from labels
         id: set_level
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const parseLevelLabel = (labelName) => {


### PR DESCRIPTION
# Description

Do not limit CI runs to PRs targeting `dev`/release branches.

See https://github.com/ROCm/TransformerEngine/pull/518 for a working demo (after cherry-picking the relevant commits to that PR). 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- remove restrictions to run CI only on dev/release branches
- update github-script version to avoid deprecation in the near future

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
