### PR TITLE
Fix JAX sdist version pinning

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -17,10 +17,15 @@ from typing import List
 
 def install_requirements() -> List[str]:
     """Install dependencies for TE/JAX extensions."""
-    if rocm_build():
-        return jax_install_requires(["flax>=0.7.1"])
-    else:
-        return ["jax", "flax>=0.7.1"]
+    # If NVTE_RELEASE_BUILD is set, we assume not building but sources packaging
+    if rocm_build() and not bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
+        """Update requirements with current JAX version to avoid undesired update."""
+        try:
+            import jax
+            return [f"jax=={jax.__version__}", "flax>=0.7.1"]
+        except ImportError:
+            pass
+    return ["jax", "flax>=0.7.1"]
 
 
 def test_requirements() -> List[str]:
@@ -128,12 +133,3 @@ def setup_jax_extension(
         extra_compile_args=cxx_flags,
         libraries=["nccl"] if not rocm_build() else [],
     )
-
-
-def jax_install_requires(reqs: List[str]) -> List[str]:
-    """Update requirements with current JAX version to avoid undesired update."""
-    try:
-        import jax
-    except ImportError:
-        return []
-    return reqs + [f"jax=={jax.__version__}"]


### PR DESCRIPTION
# Description

Do not pip specific JAX version when create sdist 
Fixes https://amd-hub.atlassian.net/browse/AITRANSENG-43

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Check for NVTE_RELEASE_BUILD when pipping to specific JAX version

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
