### PR TITLE
MXFP4: Add GEMM kernel tuning and MXFP4Quantizer.copy()

### DIFF
--- a/transformer_engine/pytorch/module/fp4_handler_gemm.py
+++ b/transformer_engine/pytorch/module/fp4_handler_gemm.py
@@ -1,20 +1,48 @@
 # Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # See LICENSE for license information.
 
-"""FP4 GEMM handler using AITER ASM a4w4 kernels.
+"""FP4 GEMM handler with shape-aware kernel tuning via AITER CSV lookup.
 
-Kernel selection and split-K tuning are handled by AITER internally
-via CSV-based GEMM config lookup (see aiter.ops.gemm_op_a4w4).
+When NVTE_FP4_GEMM_TUNING=1 (default), selects the optimal AITER a4w4
+kernel per (M, N, K) shape from the tuned CSV pointed to by
+AITER_CONFIG_GEMM_A4W4. Falls back to layout-based defaults otherwise.
 """
 
+import os
 import torch
 import aiter
 from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.gemm_op_a4w4 import get_GEMM_config
 from ..utils import cast_if_needed
+
+_FP4_GEMM_TUNING = int(os.environ.get("NVTE_FP4_GEMM_TUNING", "1"))
+_FP4_LOG_SHAPES = int(os.environ.get("NVTE_FP4_LOG_GEMM_SHAPES", "0"))
+
+_DEFAULT_FPROP_DGRAD = "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_128x512E"
+_DEFAULT_WGRAD = "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E"
+
+
+def _select_kernel(layout: str, grad: bool, M: int, N: int, K: int):
+    """Select kernel via tuned CSV lookup, falling back to layout-based default."""
+    kernel_name = _DEFAULT_WGRAD if (layout == "NT" and grad) else _DEFAULT_FPROP_DGRAD
+    split_k = 0
+
+    if _FP4_GEMM_TUNING:
+        cfg = get_GEMM_config(M, N, K)
+        if cfg is not None:
+            kernel_name = cfg["kernelName"]
+            split_k = int(cfg.get("splitK", 0))
+
+    if _FP4_LOG_SHAPES:
+        tag = "256x256" if "256x256" in kernel_name else "128x512"
+        print(f"[FP4-GEMM] {layout} grad={grad} M={M} N={N} K={K} "
+              f"kernel={tag} splitK={split_k}", flush=True)
+
+    return kernel_name, split_k
 
 
 def _fp4_gemm_core(A_fp4, A_scales, B_fp4, B_scales, out_dtype=torch.bfloat16,
-                    out_buffer=None, b_pre_shuffled=True):
+                    out_buffer=None, kernel_name="", b_pre_shuffled=True, log2_k_split=0):
     """Core FP4 GEMM via AITER ASM a4w4 kernel."""
     _fp4_dtype = torch.float4_e2m1fn_x2
     A_fp4 = A_fp4.view(_fp4_dtype) if A_fp4.dtype != _fp4_dtype else A_fp4
@@ -35,8 +63,8 @@ def _fp4_gemm_core(A_fp4, A_scales, B_fp4, B_scales, out_dtype=torch.bfloat16,
 
     result = aiter.gemm_a4w4_asm(
         A_fp4, B_shuffled, A_scales_uint8, B_scales_uint8,
-        out_hp, "", None,
-        bpreshuffle=True,
+        out_hp, kernel_name, None,
+        bpreshuffle=True, log2_k_split=log2_k_split,
     )
 
     return result[:M, :] if result.shape[0] > M else result
@@ -93,11 +121,14 @@ def fp4_gemm_layout(
         else:
             raise ValueError(f"Unsupported layout for FP4 GEMM: {layout}")
 
+        kernel_name, split_k = _select_kernel(layout, grad, gemm_M, gemm_N, gemm_K)
+
         if accumulate and out is not None:
             result = _fp4_gemm_core(
                 A_fp4, A_scales, B_fp4, B_scales,
                 out_dtype=out.dtype, out_buffer=None,
-                b_pre_shuffled=b_pre_shuffled,
+                kernel_name=kernel_name, b_pre_shuffled=b_pre_shuffled,
+                log2_k_split=split_k,
             )
             out.add_(result)
             result = None
@@ -105,7 +136,8 @@ def fp4_gemm_layout(
             result = _fp4_gemm_core(
                 A_fp4, A_scales, B_fp4, B_scales,
                 out_dtype=out_dtype, out_buffer=out,
-                b_pre_shuffled=b_pre_shuffled,
+                kernel_name=kernel_name, b_pre_shuffled=b_pre_shuffled,
+                log2_k_split=split_k,
             )
 
         if bias is not None and layout == "TN" and not grad:

--- a/transformer_engine/pytorch/tensor/mxfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp4_tensor.py
@@ -67,6 +67,19 @@ class MXFP4Quantizer(Quantizer):
         self.use_hadamard = use_hadamard
         assert self.dtype == tex.DType.kFloat4E2M1, "Only E2M1 format supported for MXFP4"
 
+    def copy(self) -> "MXFP4Quantizer":
+        """Create shallow copy"""
+        quantizer = MXFP4Quantizer(
+            fp4_dtype=self.dtype,
+            rowwise=self.rowwise_usage,
+            columnwise=self.columnwise_usage,
+            shuffle_B_matrix_for_aiter=self.shuffle_B_matrix_for_aiter,
+            use_hadamard=self.use_hadamard,
+        )
+        quantizer.internal = self.internal
+        quantizer.optimize_for_gemm = self.optimize_for_gemm
+        return quantizer
+
     def update_quantized(
         self,
         src: torch.Tensor,


### PR DESCRIPTION
## Summary

- **fp4_handler_gemm.py**: Add CSV-based kernel selection via AITER `get_GEMM_config(M, N, K)` for optimal a4w4 kernel per GEMM shape. Controlled by `NVTE_FP4_GEMM_TUNING` (default 1) and `NVTE_FP4_LOG_GEMM_SHAPES`. Falls back to layout-based defaults (128x512 for fprop/dgrad, 256x256 for wgrad) when tuning is disabled or no CSV match.

- **mxfp4_tensor.py**: Add missing `MXFP4Quantizer.copy()` method, matching the pattern used by all other Quantizer subclasses (`Float8Quantizer`, `MXFP8Quantizer`, `NVFP4Quantizer`, `Float8BlockQuantizer`). Without this, any codepath that clones a quantizer (e.g. weight pre-quantization for SFT LORA healing) hits `AttributeError`.

## Motivation

The MLPerf Llama2 SFT MXFP4 recipe currently carries two build-time patches to work around these issues. This PR eliminates both by fixing them upstream.

## Test plan

- [x] Verified GEMM tuning selects correct kernels from CSV for all Llama2 SFT MXFP4 shapes (fprop/dgrad/wgrad)
- [x] Verified `MXFP4Quantizer.copy()` produces correct shallow copies with all attributes preserved
- [x] E2E Llama2 SFT MXFP4 training converges (eval_accuracy target hit, TTT 8.5 min on 1x8 MI355X)
- [ ] CI passes


Made with [Cursor](https://cursor.com)