### PR TITLE
Added worktree-friendly git commit SHA1 lookup

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -452,7 +452,9 @@ else()
     else()
       # Real .git directory — run git rev-parse directly
       execute_process(
-        COMMAND git -C ${REPO_DIR} rev-parse HEAD
+        COMMAND sh -c "export GIT_CONFIG_GLOBAL=$(mktemp /tmp/gitconfig.XXXXXX);
+        git config --global --add safe.directory ${REPO_DIR} && git -C ${REPO_DIR} rev-parse HEAD;
+        rm $GIT_CONFIG_GLOBAL"
         OUTPUT_VARIABLE _COMMIT
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -434,14 +434,30 @@ else()
 
   function(get_git_commit REPO_DIR COMMIT_ID_VAR)
     file(REAL_PATH "${REPO_DIR}" REPO_DIR)
-    execute_process(
-      COMMAND sh -c "export GIT_CONFIG_GLOBAL=$(mktemp /tmp/gitconfig.XXXXXX);
-      git config --global --add safe.directory ${REPO_DIR} && git -C ${REPO_DIR} rev-parse HEAD;
-      rm $GIT_CONFIG_GLOBAL"
-      OUTPUT_VARIABLE ${COMMIT_ID_VAR}
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    SET(${COMMIT_ID_VAR} ${${COMMIT_ID_VAR}} PARENT_SCOPE)
+    if(EXISTS "${REPO_DIR}/.git" AND NOT IS_DIRECTORY "${REPO_DIR}/.git")
+      # .git is a file (submodule or worktree) — read HEAD from the gitdir
+      # directly. Running git fails inside containers where worktree metadata
+      # contains host-absolute paths that don't exist in the mount namespace.
+      file(READ "${REPO_DIR}/.git" _GITFILE)
+      string(STRIP "${_GITFILE}" _GITFILE)
+      string(REGEX REPLACE "^gitdir: " "" _GITDIR_REL "${_GITFILE}")
+      file(REAL_PATH "${_GITDIR_REL}" _GITDIR BASE_DIRECTORY "${REPO_DIR}")
+      file(READ "${_GITDIR}/HEAD" _COMMIT)
+      string(STRIP "${_COMMIT}" _COMMIT)
+      if(_COMMIT MATCHES "^ref: ")
+        string(REGEX REPLACE "^ref: " "" _REF "${_COMMIT}")
+        file(READ "${_GITDIR}/${_REF}" _COMMIT)
+        string(STRIP "${_COMMIT}" _COMMIT)
+      endif()
+    else()
+      # Real .git directory — run git rev-parse directly
+      execute_process(
+        COMMAND git -C ${REPO_DIR} rev-parse HEAD
+        OUTPUT_VARIABLE _COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    endif()
+    set(${COMMIT_ID_VAR} "${_COMMIT}" PARENT_SCOPE)
   endfunction()
 
   if(USE_FUSED_ATTN_AOTRITON)


### PR DESCRIPTION
# Description

Currently when working inside a git worktree + docker container w/o access to the host-path base of the git worktree (e.g. the `dev` worktree) `git rev-parse HEAD` fails due to the inability to access host-only git files. This solution instead reads local git files to lookup the commit sha without going through `git` and in turn depending on host-only files.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adds a git commit lookup path which directly parses git files, bypassing the need to use `git` itself

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
