### PR TITLE
[ROCm] fix the bug in hipfied optimized cast tranpose flow that two kernels got run

### DIFF
--- a/ci/pytorch.sh
+++ b/ci/pytorch.sh
@@ -65,6 +65,7 @@ run_test_config(){
     run_default_fa 1 test_recipe.py
     run 1 test_sanity.py
     run_default_fa 1 test_sanity_import.py
+    run_default_fa 3 test_sanity_hipified_cast_transpose.py
     run_default_fa 1 attention/test_attention.py # Backend selection is controlled by the test
     run_default_fa 1 attention/test_cp_utils.py
     run_default_fa 1 attention/test_kv_cache.py

--- a/tests/pytorch/test_sanity_hipified_cast_transpose.py
+++ b/tests/pytorch/test_sanity_hipified_cast_transpose.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022-2026, Advanced Micro Devices, Inc. All rights reserved.
+# License for AMD contributions = MIT. See LICENSE for more information
+
+"""
+Non-regression tests for the hipified cast_transpose kernel dispatch.
+
+Verifies that tex.quantize (which routes through cast_transpose on AMD)
+dispatches exactly one GPU kernel per call.  A previous bug (commit 542b8c7b)
+caused the NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE path to launch both
+cast_transpose_optimized_kernel AND cast_transpose_general_kernel per call,
+doubling the GPU work.
+"""
+
+import os
+import pytest
+import torch
+from torch.profiler import profile, ProfilerActivity
+
+from transformer_engine.pytorch import cpp_extensions as tex
+from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+
+
+def _fill_uniform(shape, dtype):
+    """Create a deterministic random tensor on GPU."""
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(12345)
+    return torch.empty(shape, dtype=dtype, device="cuda").uniform_(-2.0, 2.0, generator=gen)
+
+
+@pytest.mark.parametrize("shape", [
+    (128, 128),
+    (2048, 12288),
+    (256, 256),
+])
+@pytest.mark.parametrize("in_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("out_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2])
+@pytest.mark.parametrize("use_hipified_env", [False, True])
+def test_single_kernel_dispatch(shape, in_dtype, out_dtype, use_hipified_env):
+    """
+    Verify that tex.quantize dispatches exactly one cast_transpose GPU kernel.
+    Tests both the default cost-model RTC path and the PR #89 hipified path
+    (NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE=1).
+    """
+    input_tensor = _fill_uniform(shape, dtype=in_dtype)
+    scale = torch.rand(1, dtype=torch.float32, device="cuda") * 3.0 - 2.0
+    amax = torch.zeros(1, dtype=torch.float32, device="cuda")
+
+    env_key = "NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE"
+    old_val = os.environ.get(env_key)
+
+    try:
+        if use_hipified_env:
+            os.environ[env_key] = "1"
+        else:
+            os.environ.pop(env_key, None)
+
+        # Warmup (also triggers hipRTC compilation)
+        q = Float8Quantizer(scale=scale.clone(), amax=amax.clone(), fp8_dtype=out_dtype)
+        tex.quantize(input_tensor, q)
+        torch.cuda.synchronize()
+
+        # Profiled run
+        q = Float8Quantizer(scale=scale.clone(), amax=amax.clone(), fp8_dtype=out_dtype)
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+            tex.quantize(input_tensor, q)
+            torch.cuda.synchronize()
+
+        ct_kernels = [
+            evt.name for evt in prof.events()
+            if evt.device_type == torch.autograd.DeviceType.CUDA
+            and "cast_transpose" in evt.name
+        ]
+
+        assert len(ct_kernels) == 1, (
+            f"Expected exactly 1 cast_transpose kernel, got {len(ct_kernels)}: {ct_kernels}"
+        )
+    finally:
+        if old_val is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = old_val

--- a/transformer_engine/common/transpose/cast_transpose.cu
+++ b/transformer_engine/common/transpose/cast_transpose.cu
@@ -262,13 +262,10 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
             // Choose between runtime-compiled or statically-compiled kernel
             const bool aligned =
                 (row_length % THREADS_PER_WARP == 0 && num_rows % THREADS_PER_WARP == 0);
-#ifdef __HIP_PLATFORM_AMD__
-            // Whether to fall back to the cost-model-based RTC kernel selection
-            bool fallback_to_cost_model_rtc = false;
-#endif
             if (aligned && rtc::is_enabled()) {  // Runtime-compiled tuned kernel
 #ifdef __HIP_PLATFORM_AMD__
-              fallback_to_cost_model_rtc = true;
+              // Whether to fall back to the cost-model-based RTC kernel selection
+              bool fallback_to_cost_model_rtc = true;
               // even if we enforce to use OPTIMIZED_HIPIFIED_CAST_TRANSPOSE, may fall back to general kernel configs from NVTE cost model
               bool nvte_use_optimized_hipified_cast_transpose = false;
               if (const char* env_p = std::getenv("NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE") ) {
@@ -352,8 +349,7 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
                                     num_rows);
                 }
               }
-            }
-            if(fallback_to_cost_model_rtc){
+              if(fallback_to_cost_model_rtc){
 #endif
               // Pick kernel config
               std::vector<KernelConfig> kernel_configs;
@@ -413,11 +409,9 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
                                  static_cast<CType *>(output.amax.dptr),
                                  static_cast<CType *>(output.scale_inv.dptr), row_length, num_rows);
 #ifdef __HIP_PLATFORM_AMD__
-            }
-            if (!aligned || !rtc::is_enabled()) {  // Statically-compiled general kernel
-#else
-            } else {  // Statically-compiled general kernel
+              }
 #endif
+            } else {  // Statically-compiled general kernel
               constexpr size_t load_size = 4;
               constexpr size_t store_size = 4;
               constexpr size_t row_tile_size = load_size / itype_size * THREADS_PER_WARP;

--- a/transformer_engine/common/transpose/cast_transpose.cu
+++ b/transformer_engine/common/transpose/cast_transpose.cu
@@ -263,12 +263,12 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
             const bool aligned =
                 (row_length % THREADS_PER_WARP == 0 && num_rows % THREADS_PER_WARP == 0);
 #ifdef __HIP_PLATFORM_AMD__
-            // do_general_config means using the cost model like NVTE to generate kernel configs
-            bool do_general_config = false;
+            // Whether to fall back to the cost-model-based RTC kernel selection
+            bool fallback_to_cost_model_rtc = false;
 #endif
             if (aligned && rtc::is_enabled()) {  // Runtime-compiled tuned kernel
 #ifdef __HIP_PLATFORM_AMD__
-              do_general_config = true;
+              fallback_to_cost_model_rtc = true;
               // even if we enforce to use OPTIMIZED_HIPIFIED_CAST_TRANSPOSE, may fall back to general kernel configs from NVTE cost model
               bool nvte_use_optimized_hipified_cast_transpose = false;
               if (const char* env_p = std::getenv("NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE") ) {
@@ -318,9 +318,9 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
                 size_t num_blocks = (row_length / row_tile_elements) * (num_rows / col_tile_elements);
                 size_t rtc_block_size = THREADS_PER_WARP * wpt_size;
 
-                do_general_config =!(row_length % row_tile_elements == 0 && num_rows % col_tile_elements == 0);
+                fallback_to_cost_model_rtc =!(row_length % row_tile_elements == 0 && num_rows % col_tile_elements == 0);
 
-                if(!do_general_config){
+                if(!fallback_to_cost_model_rtc){
                   // Compile NVRTC kernel if needed and launch
                   auto &rtc_manager = rtc::KernelManager::instance();
                   const std::string kernel_label = concat_strings(
@@ -353,7 +353,7 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
                 }
               }
             }
-            if(do_general_config){
+            if(fallback_to_cost_model_rtc){
 #endif
               // Pick kernel config
               std::vector<KernelConfig> kernel_configs;
@@ -412,7 +412,12 @@ void cast_transpose(const Tensor &input, const Tensor &noop, Tensor *output_, cu
                                  static_cast<const CType *>(output.scale.dptr),
                                  static_cast<CType *>(output.amax.dptr),
                                  static_cast<CType *>(output.scale_inv.dptr), row_length, num_rows);
+#ifdef __HIP_PLATFORM_AMD__
+            }
+            if (!aligned || !rtc::is_enabled()) {  // Statically-compiled general kernel
+#else
             } else {  // Statically-compiled general kernel
+#endif
               constexpr size_t load_size = 4;
               constexpr size_t store_size = 4;
               constexpr size_t row_tile_size = load_size / itype_size * THREADS_PER_WARP;


### PR DESCRIPTION
# Description

In ROCm TE when NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE is set, no matter the optimized kernel run or not, it will still run another kernel, either fallback to the cost model rtc one, or the general one. This PR fixes this issue

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
1). fix the bug in hipfied optimized cast tranpose flow that two kernels got run
2). rename the do_general_config to make it easier to understand
3). added a new unit test

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
