### PR TITLE
Refactor TE's CK backend padding add/remove kernels

### DIFF
--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -354,13 +354,15 @@ void pad_remap(
     });
 }
 
-// cuda kernel to copy softmax lse between padded and unpadded layouts.
+// Cuda kernel to copy softmax lse between padded and unpadded layouts.
+// Also performs a format conversion between CK[h, total_tokens_q] and
+// NVTE[total_tokens_q, h] formats. 
 // padded layout (selected by is_ragged):
 //   is_ragged=false: [b, h, s_q]
 //   is_ragged=true : [max_tokens_q with padding, h]
 // unpadded layout: [h, max_tokens_q]
-// one wavefront in charge of one token index (h*sizeof(float) bytes)
-// one workitem (thread) in one wavefront is charge of one element in THREADS_PER_WAVE_FRONT(64) segment trunk of h
+// One wavefront in charge of one token index (h*sizeof(float) bytes)
+// One workitem (thread) in one wavefront is charge of one element in THREADS_PER_WAVE_FRONT(64) segment trunk of h
 template<bool is_ragged, PadDirection dir>
 __global__ void pad_remap_lse_kernel(
   uint64_t b, uint64_t h, uint64_t s_q,

--- a/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
+++ b/transformer_engine/common/fused_attn_rocm/fused_attn_ck.cpp
@@ -267,17 +267,22 @@ __forceinline__ __device__ int binary_search(int32_t target, const int32_t *arra
 }
 
 constexpr int THREADS_PER_WAVEFRONT = 64;
-// kernel to remove padding for q, k, v, o (dq, dk, dv, do)
+// Direction for pad_remap / pad_remap_lse:
+//   Remove: padded -> unpadded
+//   Add   : unpadded -> padded
+enum class PadDirection { Remove, Add };
+
+// kernel to copy q, k, v, o (dq, dk, dv, do) between padded and unpadded layouts.
 // each wavefront is in charge of one token index (h*d*sizeof(DataType) bytes copy)
 // one workitem (thread) in one wavefront is charge of one element in 32 segment trunk of h*d
-template<typename DataType, bool is_ragged>
-__global__ void remove_padding_kernel(
+template<typename DataType, bool is_ragged, PadDirection dir>
+__global__ void pad_remap_kernel(
   // b guaranteed to be correct, extracted from input_cu_seqlens->data.shape[0] - 1
   uint64_t b, uint64_t h, uint64_t s, uint64_t d,
   uint64_t stride_b, uint64_t stride_h, uint64_t stride_s, //stride_d is 1
-  const DataType* data_ptr,
+  DataType* padded_ptr,
   const int32_t* cu_seqlen_ptr, const int32_t* cu_seqlen_padded_ptr,
-  DataType* data_without_padding_ptr){
+  DataType* unpadded_ptr){
 
   int wavefront_idx = (blockIdx.x * blockDim.x + threadIdx.x) / THREADS_PER_WAVEFRONT;
   int workitem_idx = threadIdx.x % THREADS_PER_WAVEFRONT;
@@ -288,35 +293,40 @@ __global__ void remove_padding_kernel(
   for(int token_id = wavefront_idx; token_id<num_total_tokens; token_id += num_wavefronts){
     int b_idx = binary_search(token_id, cu_seqlen_ptr, b+1);
     int s_idx = token_id - cu_seqlen_ptr[b_idx];
-    DataType* cur_without_padding = nullptr;
-    const DataType* cur = nullptr;
+    DataType* unpadded_cur = nullptr;
+    DataType* padded_cur = nullptr;
     if constexpr(is_ragged){
-      cur_without_padding = data_without_padding_ptr + stride_s* token_id;
-      cur = data_ptr + (cu_seqlen_padded_ptr[b_idx] + s_idx)*stride_s;
+      unpadded_cur = unpadded_ptr + stride_s* token_id;
+      padded_cur = padded_ptr + (cu_seqlen_padded_ptr[b_idx] + s_idx)*stride_s;
     }else{
-      cur_without_padding = data_without_padding_ptr + stride_total_seqlen* token_id;
-      cur = data_ptr + (b_idx * stride_b + s_idx*stride_s);
+      unpadded_cur = unpadded_ptr + stride_total_seqlen* token_id;
+      padded_cur = padded_ptr + (b_idx * stride_b + s_idx*stride_s);
     }
     for(int hd_idx = workitem_idx; hd_idx < h*d; hd_idx+=THREADS_PER_WAVEFRONT){
       int h_idx = hd_idx/d;
       int d_idx = hd_idx%d;
-      cur_without_padding[h_idx*stride_h + d_idx] = cur[h_idx*stride_h + d_idx];
+      if constexpr(dir == PadDirection::Add){
+        padded_cur[h_idx*stride_h + d_idx] = unpadded_cur[h_idx*stride_h + d_idx];
+      }else{
+        unpadded_cur[h_idx*stride_h + d_idx] = padded_cur[h_idx*stride_h + d_idx];
+      }
     }
   }
 }
 
-// kernel launcher for remove padding in q, k, v, o (dq, dk, dv, do)
-void remove_padding(
+// kernel launcher for q, k, v, o (dq, dk, dv, do) padded<->unpadded copy
+template<PadDirection dir>
+void pad_remap(
   DType dtype,
   uint64_t b, uint64_t h, uint64_t s, uint64_t d,
-  uint64_t max_tokens, 
+  uint64_t max_tokens,
   bool is_ragged,
   uint64_t stride_b, uint64_t stride_h, uint64_t stride_s, //stride_d is 1
-  const void* data_ptr,
+  void* padded_ptr,
   const void* cu_seqlen_ptr, const void* cu_seqlen_padded_ptr,
-  void* data_without_padding_ptr,
+  void* unpadded_ptr,
   hipStream_t stream){
-  
+
   // cu_seqlen_padded_ptr can be nullptr
   assert(cu_seqlen_ptr!=nullptr);
   constexpr int THREADS_PER_BLOCK = 256;
@@ -326,177 +336,38 @@ void remove_padding(
 
   TRANSFORMER_ENGINE_TYPE_SWITCH_16BIT(dtype, DataType,
     if(is_ragged){
-      remove_padding_kernel<DataType, true><<<grid, block, 0, stream>>>(
+      pad_remap_kernel<DataType, true, dir><<<grid, block, 0, stream>>>(
         b, h, s, d,
         stride_b, stride_h, stride_s,
-        static_cast<const DataType*>(data_ptr),
+        static_cast<DataType*>(padded_ptr),
         static_cast<const int32_t*>(cu_seqlen_ptr),
         static_cast<const int32_t*>(cu_seqlen_padded_ptr),
-        static_cast<DataType*>(data_without_padding_ptr));
+        static_cast<DataType*>(unpadded_ptr));
     }else{
-      remove_padding_kernel<DataType, false><<<grid, block, 0, stream>>>(
+      pad_remap_kernel<DataType, false, dir><<<grid, block, 0, stream>>>(
         b, h, s, d,
         stride_b, stride_h, stride_s,
-        static_cast<const DataType*>(data_ptr),
+        static_cast<DataType*>(padded_ptr),
         static_cast<const int32_t*>(cu_seqlen_ptr),
         static_cast<const int32_t*>(cu_seqlen_padded_ptr),
-        static_cast<DataType*>(data_without_padding_ptr));
+        static_cast<DataType*>(unpadded_ptr));
     });
 }
 
-// kernel to add padding for q, k, v, o (dq, dk, dv, do)
-// reverse of remove_padding
-template<typename DataType, bool is_ragged>
-__global__ void add_padding_kernel(
-  // b guaranteed to be correct, extracted from input_cu_seqlens->data.shape[0] - 1
-  uint64_t b, uint64_t h, uint64_t s, uint64_t d,
-  uint64_t stride_b, uint64_t stride_h, uint64_t stride_s, //stride_d is 1
-  const DataType* data_without_padding_ptr,
-  const int32_t* cu_seqlen_ptr, const int32_t* cu_seqlen_padded_ptr,
-  DataType* data_ptr){
-
-  int wavefront_idx = (blockIdx.x * blockDim.x + threadIdx.x) / THREADS_PER_WAVEFRONT;
-  int workitem_idx = threadIdx.x % THREADS_PER_WAVEFRONT;
-  int num_wavefronts = (blockDim.x * gridDim.x) / THREADS_PER_WAVEFRONT;
-  int num_total_tokens = cu_seqlen_ptr[b];
-
-  //BSHD SBHD --> THD (BSHD)
-  uint64_t stride_total_seqlen = std::min(stride_b, stride_s);
-  for(int token_id = wavefront_idx; token_id<num_total_tokens; token_id += num_wavefronts){
-    int b_idx = binary_search(token_id, cu_seqlen_ptr, b+1);
-    int s_idx = token_id - cu_seqlen_ptr[b_idx];
-    const DataType* cur_without_padding = nullptr;
-    DataType* cur = nullptr;
-    if constexpr(is_ragged){
-      cur_without_padding = data_without_padding_ptr + stride_s* token_id;
-      cur = data_ptr + (cu_seqlen_padded_ptr[b_idx] + s_idx)*stride_s;
-    }else{
-      cur_without_padding = data_without_padding_ptr + stride_total_seqlen* token_id;
-      cur = data_ptr + (b_idx * stride_b + s_idx*stride_s);
-    }
-    for(int hd_idx = workitem_idx; hd_idx < h*d; hd_idx+=THREADS_PER_WAVEFRONT){
-      int h_idx = hd_idx/d;
-      int d_idx = hd_idx%d;
-      cur[h_idx*stride_h + d_idx] = cur_without_padding[h_idx*stride_h + d_idx];
-    }
-  }
-}
-
-// kernel launcher for adding padding in q, k, v, o (dq, dk, dv, do)
-void add_padding(
-  DType dtype,
-  uint64_t b, uint64_t h, uint64_t s, uint64_t d,
-  uint64_t max_tokens, 
-  bool is_ragged,
-  uint64_t stride_b, uint64_t stride_h, uint64_t stride_s, //stride_d is 1
-  const void* data_without_padding_ptr,
-  const void* cu_seqlen_ptr, const void* cu_seqlen_padded_ptr,
-  void* data_ptr,
-  hipStream_t stream){
-  
-  // cu_seqlen_padded_ptr can be nullptr
-  assert(cu_seqlen_ptr!=nullptr);
-  constexpr int THREADS_PER_BLOCK = 256;
-  // parallel over h*d dimension
-  dim3 block(THREADS_PER_BLOCK);
-  dim3 grid(ceil(1.0 * max_tokens * THREADS_PER_WAVEFRONT/THREADS_PER_BLOCK));
-
-  TRANSFORMER_ENGINE_TYPE_SWITCH_16BIT(dtype, DataType,
-    if(is_ragged){
-      add_padding_kernel<DataType, true><<<grid, block, 0, stream>>>(
-        b, h, s, d,
-        stride_b, stride_h, stride_s,
-        static_cast<const DataType*>(data_without_padding_ptr),
-        static_cast<const int32_t*>(cu_seqlen_ptr),
-        static_cast<const int32_t*>(cu_seqlen_padded_ptr),
-        static_cast<DataType*>(data_ptr));
-    }else{
-      add_padding_kernel<DataType, false><<<grid, block, 0, stream>>>(
-        b, h, s, d,
-        stride_b, stride_h, stride_s,
-        static_cast<const DataType*>(data_without_padding_ptr),
-        static_cast<const int32_t*>(cu_seqlen_ptr),
-        static_cast<const int32_t*>(cu_seqlen_padded_ptr),
-        static_cast<DataType*>(data_ptr));
-    });
-}
-
-// cuda kernel to convert softmax lse from var seqlen, no padding format, can be of 2 scenarios:
-// 1).[h, max_tokens_q] to [b, h, s_q] 
-// 2).[h, max_tokens_q] to [max_tokens_q with padding, h]
+// cuda kernel to copy softmax lse between padded and unpadded layouts.
+// padded layout (selected by is_ragged):
+//   is_ragged=false: [b, h, s_q]
+//   is_ragged=true : [max_tokens_q with padding, h]
+// unpadded layout: [h, max_tokens_q]
 // one wavefront in charge of one token index (h*sizeof(float) bytes)
 // one workitem (thread) in one wavefront is charge of one element in THREADS_PER_WAVE_FRONT(64) segment trunk of h
-template<bool is_ragged>
-__global__ void add_padding_softmax_lse_kernel(
+template<bool is_ragged, PadDirection dir>
+__global__ void pad_remap_lse_kernel(
   uint64_t b, uint64_t h, uint64_t s_q,
   uint64_t max_tokens_q,
-  const float* lse_without_padding_ptr,
+  float* padded_lse_ptr,
   const int32_t* cu_seqlen_q_ptr, const int32_t* cu_seqlen_q_padded_ptr,
-  float* lse_ptr){
-
-  int wavefront_idx = (blockIdx.x * blockDim.x + threadIdx.x) / THREADS_PER_WAVEFRONT;
-  int workitem_idx = threadIdx.x % THREADS_PER_WAVEFRONT;
-  int num_wavefronts = (blockDim.x * gridDim.x) / THREADS_PER_WAVEFRONT;
-  int num_total_tokens = cu_seqlen_q_ptr[b];
-
-  for(int token_id = wavefront_idx; token_id < num_total_tokens; token_id += num_wavefronts){
-    int b_idx = binary_search(token_id, cu_seqlen_q_ptr, b+1);
-    int s_idx = token_id - cu_seqlen_q_ptr[b_idx];
-    
-    if constexpr(is_ragged){
-      // [h, max_tokens_q without padding] to [max_tokens_q with padding, h]
-      for(int h_idx = workitem_idx; h_idx < h; h_idx += THREADS_PER_WAVEFRONT){
-        lse_ptr[(cu_seqlen_q_padded_ptr[b_idx]+s_idx)*h + h_idx] = lse_without_padding_ptr[h_idx * max_tokens_q + token_id];
-      }
-    }else{
-      // [h, max_tokens_q without padding] to [b, h, s_q]
-      for(int h_idx = workitem_idx; h_idx < h; h_idx += THREADS_PER_WAVEFRONT){
-        lse_ptr[b_idx*h*s_q + h_idx*s_q + s_idx] = lse_without_padding_ptr[h_idx * max_tokens_q + token_id];
-      }
-    }
-  }
-}
-
-// kernel launcher to add padding in softmax_lse, [h, max_tokens_q] to [b, h, max_seqlen_q] or [max_tokens_q with padding, h]
-void add_padding_softmax_lse(
-  uint64_t b, uint64_t h, uint64_t s_q,
-  uint64_t max_tokens_q, 
-  bool is_ragged,
-  const void* lse_without_padding_ptr,
-  const void* cu_seqlen_q_ptr, const void* cu_seqlen_q_padded_ptr, 
-  void* lse_ptr, 
-  hipStream_t stream){
-  
-  constexpr int THREADS_PER_BLOCK = 256;
-  dim3 block(THREADS_PER_BLOCK);
-  dim3 grid(ceil(1.0 * max_tokens_q * THREADS_PER_WAVEFRONT/THREADS_PER_BLOCK));
-  if(is_ragged){
-    add_padding_softmax_lse_kernel<true><<<grid, block, 0, stream>>>(
-      b, h, s_q, max_tokens_q, 
-      static_cast<const float*>(lse_without_padding_ptr),
-      static_cast<const int32_t*>(cu_seqlen_q_ptr), 
-      static_cast<const int32_t*>(cu_seqlen_q_padded_ptr),
-      static_cast<float*>(lse_ptr));
-  }else{
-    add_padding_softmax_lse_kernel<false><<<grid, block, 0, stream>>>(
-      b, h, s_q, max_tokens_q, 
-      static_cast<const float*>(lse_without_padding_ptr),
-      static_cast<const int32_t*>(cu_seqlen_q_ptr), 
-      static_cast<const int32_t*>(cu_seqlen_q_padded_ptr),
-      static_cast<float*>(lse_ptr));
-  }
-}
-
-// remove the padding in softmax lse, can be of two scenarios:
-// 1). [b, h, s_q] into shape [h, max_tokens without padding]
-// 2). [max_tokens with padding, h] to [h, max_tokens without padding]
-template<bool is_ragged>
-__global__ void remove_padding_softmax_lse_kernel(
-  uint64_t b, uint64_t h, uint64_t s_q,
-  uint64_t max_tokens_q,
-  const float* lse_ptr,
-  const int32_t* cu_seqlen_q_ptr, const int32_t* cu_seqlen_q_padded_ptr,
-  float* lse_without_padding_ptr){
+  float* unpadded_lse_ptr){
 
   int wavefront_idx = (blockIdx.x * blockDim.x + threadIdx.x) / THREADS_PER_WAVEFRONT;
   int workitem_idx = threadIdx.x % THREADS_PER_WAVEFRONT;
@@ -507,47 +378,51 @@ __global__ void remove_padding_softmax_lse_kernel(
     int b_idx = binary_search(token_id, cu_seqlen_q_ptr, b+1);
     int s_idx = token_id - cu_seqlen_q_ptr[b_idx];
 
-    if constexpr(is_ragged){
-      // [h, max_tokens_q with padding] to [h, max_tokens_q without padding]
-      for(int h_idx = workitem_idx; h_idx < h; h_idx += THREADS_PER_WAVEFRONT){
-        lse_without_padding_ptr[h_idx * max_tokens_q + token_id] = lse_ptr[(cu_seqlen_q_padded_ptr[b_idx]+s_idx)*h + h_idx];
+    for(int h_idx = workitem_idx; h_idx < h; h_idx += THREADS_PER_WAVEFRONT){
+      uint64_t padded_idx;
+      if constexpr(is_ragged){
+        padded_idx = (cu_seqlen_q_padded_ptr[b_idx]+s_idx)*h + h_idx;
+      }else{
+        padded_idx = b_idx*h*s_q + h_idx*s_q + s_idx;
       }
-    }else{
-      // [b, h, s_q] to [h, max_tokens_q without padding]
-      for(int h_idx = workitem_idx; h_idx < h; h_idx += THREADS_PER_WAVEFRONT){
-        lse_without_padding_ptr[h_idx * max_tokens_q + token_id] = lse_ptr[b_idx*h*s_q + h_idx*s_q + s_idx];
+      uint64_t unpadded_idx = h_idx * max_tokens_q + token_id;
+      if constexpr(dir == PadDirection::Add){
+        padded_lse_ptr[padded_idx] = unpadded_lse_ptr[unpadded_idx];
+      }else{
+        unpadded_lse_ptr[unpadded_idx] = padded_lse_ptr[padded_idx];
       }
     }
   }
 }
 
-// kernel launcher to remove padding for softmax_lse
-void remove_padding_softmax_lse(
+// kernel launcher for softmax_lse padded<->unpadded copy
+template<PadDirection dir>
+void pad_remap_lse(
   uint64_t b, uint64_t h, uint64_t s_q,
-  uint64_t max_tokens_q, 
+  uint64_t max_tokens_q,
   bool is_ragged,
-  const void* lse_ptr,
-  const void* cu_seqlen_q_ptr, const void* cu_seqlen_q_padded_ptr, 
-  void* lse_without_padding_ptr, 
+  void* padded_lse_ptr,
+  const void* cu_seqlen_q_ptr, const void* cu_seqlen_q_padded_ptr,
+  void* unpadded_lse_ptr,
   hipStream_t stream){
 
   constexpr int THREADS_PER_BLOCK = 256;
   dim3 block(THREADS_PER_BLOCK);
   dim3 grid(ceil(1.0 * max_tokens_q * THREADS_PER_WAVEFRONT/THREADS_PER_BLOCK));
   if(is_ragged){
-    remove_padding_softmax_lse_kernel<true><<<grid, block, 0, stream>>>(
-      b, h, s_q, max_tokens_q, 
-      static_cast<const float*>(lse_ptr),
-      static_cast<const int32_t*>(cu_seqlen_q_ptr), 
+    pad_remap_lse_kernel<true, dir><<<grid, block, 0, stream>>>(
+      b, h, s_q, max_tokens_q,
+      static_cast<float*>(padded_lse_ptr),
+      static_cast<const int32_t*>(cu_seqlen_q_ptr),
       static_cast<const int32_t*>(cu_seqlen_q_padded_ptr),
-      static_cast<float*>(lse_without_padding_ptr));
+      static_cast<float*>(unpadded_lse_ptr));
   }else{
-    remove_padding_softmax_lse_kernel<false><<<grid, block, 0, stream>>>(
-      b, h, s_q, max_tokens_q, 
-      static_cast<const float*>(lse_ptr),
-      static_cast<const int32_t*>(cu_seqlen_q_ptr), 
+    pad_remap_lse_kernel<false, dir><<<grid, block, 0, stream>>>(
+      b, h, s_q, max_tokens_q,
+      static_cast<float*>(padded_lse_ptr),
+      static_cast<const int32_t*>(cu_seqlen_q_ptr),
       static_cast<const int32_t*>(cu_seqlen_q_padded_ptr),
-      static_cast<float*>(lse_without_padding_ptr));
+      static_cast<float*>(unpadded_lse_ptr));
   }
 }
 
@@ -741,9 +616,9 @@ void fused_attn_ck_fwd_impl(
   }
   if(is_SBHD && is_padding){
     // remove padding for q, k, v
-    remove_padding(dtype, b, h, s_q, d_qk, max_tokens_q, false, q_stride[0], q_stride[1], q_stride[2], devPtrQ, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrQWithoutPadding, stream);
-    remove_padding(dtype, b, hg, s_kv, d_qk, max_tokens_kv, false, k_stride[0], k_stride[1], k_stride[2], devPtrK, devPtrCuSeqlensKV, devPtrCuSeqlenPaddedKV, devPtrKWithoutPadding, stream);
-    remove_padding(dtype, b, hg, s_kv, d_v, max_tokens_kv, false, v_stride[0], v_stride[1], v_stride[2], devPtrV, devPtrCuSeqlensKV, devPtrCuSeqlenPaddedKV, devPtrVWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, h, s_q, d_qk, max_tokens_q, false, q_stride[0], q_stride[1], q_stride[2], devPtrQ, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrQWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, hg, s_kv, d_qk, max_tokens_kv, false, k_stride[0], k_stride[1], k_stride[2], devPtrK, devPtrCuSeqlensKV, devPtrCuSeqlenPaddedKV, devPtrKWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, hg, s_kv, d_v, max_tokens_kv, false, v_stride[0], v_stride[1], v_stride[2], devPtrV, devPtrCuSeqlensKV, devPtrCuSeqlenPaddedKV, devPtrVWithoutPadding, stream);
     // call varlen api using without_padding ptrs
     // for BSHD/SBHD, after padding removal, THD require stride_s update
     using ck_fused_attn::ck_attn_varlen_fwd;
@@ -771,8 +646,8 @@ void fused_attn_ck_fwd_impl(
         nvte_ck_how_v3_bf16_cvt,
         stream));
     // add padding for o and softmax_lse
-    add_padding(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrOWithoutPadding, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrO, stream);
-    add_padding_softmax_lse(b, h, s_q, max_tokens_q, false, devPtrSoftmaxLSEWithoutPadding, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxAux, stream);
+    pad_remap<PadDirection::Add>(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrO, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrOWithoutPadding, stream);
+    pad_remap_lse<PadDirection::Add>(b, h, s_q, max_tokens_q, false, devPtrSoftmaxAux, devPtrCuSeqlensQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxLSEWithoutPadding, stream);
   }else if(bshd_to_thd || is_ragged){
     using ck_fused_attn::ck_attn_varlen_fwd;
     NVTE_CHECK_CUDA(
@@ -799,7 +674,7 @@ void fused_attn_ck_fwd_impl(
         nvte_ck_how_v3_bf16_cvt,
         stream));
     // aiter asm output softmax_lse with padding
-    add_padding_softmax_lse(b, h, s_q, max_tokens_q, is_ragged, devPtrSoftmaxLSEWithoutPadding, devPtrCuSeqlenPaddedQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxAux, stream);
+    pad_remap_lse<PadDirection::Add>(b, h, s_q, max_tokens_q, is_ragged, devPtrSoftmaxAux, devPtrCuSeqlenPaddedQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxLSEWithoutPadding, stream);
   }else{
     using ck_fused_attn::ck_attn_fwd;
     NVTE_CHECK_CUDA(
@@ -1156,14 +1031,14 @@ void fused_attn_ck_bwd_impl(
   }
   if(is_SBHD && is_padding){
     // remove padding for q, k, v, o, do
-    remove_padding(dtype, b, h, s_q, d_qk, max_tokens_q, false, q_stride[0], q_stride[1], q_stride[2], devPtrQ, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrQWithoutPadding, stream);
-    remove_padding(dtype, b, hg, s_kv, d_qk, max_tokens_kv, false, k_stride[0], k_stride[1], k_stride[2], devPtrK, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrKWithoutPadding, stream);
-    remove_padding(dtype, b, hg, s_kv, d_v, max_tokens_kv, false, v_stride[0], v_stride[1], v_stride[2], devPtrV, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrVWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, h, s_q, d_qk, max_tokens_q, false, q_stride[0], q_stride[1], q_stride[2], devPtrQ, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrQWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, hg, s_kv, d_qk, max_tokens_kv, false, k_stride[0], k_stride[1], k_stride[2], devPtrK, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrKWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, hg, s_kv, d_v, max_tokens_kv, false, v_stride[0], v_stride[1], v_stride[2], devPtrV, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrVWithoutPadding, stream);
     // o and do should be of same shape as q
-    remove_padding(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrO, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrOWithoutPadding, stream);
-    remove_padding(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrdO, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrdOWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrO, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrOWithoutPadding, stream);
+    pad_remap<PadDirection::Remove>(dtype, b, h, s_q, d_v, max_tokens_q, false, o_stride[0], o_stride[1], o_stride[2], devPtrdO, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrdOWithoutPadding, stream);
     // also remove the padding for softmax lse
-    remove_padding_softmax_lse(b, h, s_q, max_tokens_q, false, devPtrSoftmaxAux, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrSoftmaxLSEWithoutPadding, stream);
+    pad_remap_lse<PadDirection::Remove>(b, h, s_q, max_tokens_q, false, devPtrSoftmaxAux, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrSoftmaxLSEWithoutPadding, stream);
     using ck_fused_attn::ck_attn_varlen_bwd;
     NVTE_CHECK_CUDA(
       ck_attn_varlen_bwd(
@@ -1206,11 +1081,11 @@ void fused_attn_ck_bwd_impl(
         stream));
     // add padding for dq, dk, dv
     // dq, dk, dv of same shape as q, k, v
-    add_padding(dtype, b, h, s_q, d_qk, max_tokens_q, is_ragged, q_stride[0], q_stride[1], q_stride[2], devPtrdQWithoutPadding, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrdQ, stream);
-    add_padding(dtype, b, hg, s_kv, d_qk, max_tokens_kv, is_ragged, k_stride[0], k_stride[1], k_stride[2], devPtrdKWithoutPadding, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrdK, stream);
-    add_padding(dtype, b, hg, s_kv, d_v, max_tokens_kv, is_ragged, v_stride[0], v_stride[1], v_stride[2], devPtrdVWithoutPadding, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrdV, stream);
+    pad_remap<PadDirection::Add>(dtype, b, h, s_q, d_qk, max_tokens_q, is_ragged, q_stride[0], q_stride[1], q_stride[2], devPtrdQ, devPtrCuSeqlensQ, devPtrSeqOffsetsQ, devPtrdQWithoutPadding, stream);
+    pad_remap<PadDirection::Add>(dtype, b, hg, s_kv, d_qk, max_tokens_kv, is_ragged, k_stride[0], k_stride[1], k_stride[2], devPtrdK, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrdKWithoutPadding, stream);
+    pad_remap<PadDirection::Add>(dtype, b, hg, s_kv, d_v, max_tokens_kv, is_ragged, v_stride[0], v_stride[1], v_stride[2], devPtrdV, devPtrCuSeqlensKV, devPtrSeqOffsetsKV, devPtrdVWithoutPadding, stream);
   }else if(bshd_to_thd || is_ragged){
-    remove_padding_softmax_lse(b, h, s_q, max_tokens_q, is_ragged, devPtrSoftmaxAux, devPtrCuSeqlenPaddedQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxLSEWithoutPadding, stream);
+    pad_remap_lse<PadDirection::Remove>(b, h, s_q, max_tokens_q, is_ragged, devPtrSoftmaxAux, devPtrCuSeqlenPaddedQ, devPtrCuSeqlenPaddedQ, devPtrSoftmaxLSEWithoutPadding, stream);
     using ck_fused_attn::ck_attn_varlen_bwd;
     NVTE_CHECK_CUDA(
       ck_attn_varlen_bwd(


### PR DESCRIPTION
# Description

Collapsed four near-identical templated kernels (`remove_padding_kernel`, `add_padding_kernel`, `add_padding_softmax_lse_kernel`, `remove_padding_softmax_lse_kernel`) into two direction-templated kernels. Their four launcher wrappers were thin enough that the call sites read better calling the templated launcher directly with a tagged enum.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added `enum class PadDirection { Remove, Add }`
- Replaced QKV/output kernels with `pad_remap_kernel<DataType, is_ragged, PadDirection dir>`
- Replaced LSE kernels with `pad_remap_lse_kernel<is_ragged, PadDirection dir>`
- Added templated launchers `pad_remap<dir>` and `pad_remap_lse<dir>`
- Deleted the four wrapper functions (`remove_padding`, `add_padding`, `remove_padding_softmax_lse`, `add_padding_softmax_lse`)

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
