### PR TITLE
ci: add workflow to build and publish CI deps Docker image

### DIFF
--- a/.github/workflows/ci-deps-docker-publish.yml
+++ b/.github/workflows/ci-deps-docker-publish.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: te_builder
+    runs-on: build-only-te
     timeout-minutes: 720
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-deps-docker-publish.yml
+++ b/.github/workflows/ci-deps-docker-publish.yml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#
+# Build .github/scripts/Dockerfile.ci.deps and push to Artifactory.
+#
+# Required repository secrets:
+#   ARTIFACTORY_DOCKER_USERNAME / ARTIFACTORY_DOCKER_PASSWORD — registry basic auth
+#
+# Required repository variables:
+#   ARTIFACTORY_DOCKER_REGISTRY
+#   ARTIFACTORY_CI_DEPS_REPOSITORY — path under that registry
+
+name: Publish CI deps Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag pushed to Artifactory (required)"
+        required: true
+        type: string
+
+jobs:
+  build-and-push:
+    runs-on: linux-te-mi325-8
+    timeout-minutes: 720
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate configuration
+        env:
+          REGISTRY: ${{ vars.ARTIFACTORY_DOCKER_REGISTRY }}
+          REPOSITORY: ${{ vars.ARTIFACTORY_CI_DEPS_REPOSITORY }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${REGISTRY}" ] || [ -z "${REPOSITORY}" ]; then
+            echo "Set repository variables ARTIFACTORY_DOCKER_REGISTRY and ARTIFACTORY_CI_DEPS_REPOSITORY." >&2
+            exit 1
+          fi
+          if [ -z "${IMAGE_TAG}" ]; then
+            echo "image_tag must be non-empty." >&2
+            exit 1
+          fi
+
+      - name: Log in to Artifactory Docker registry
+        env:
+          REGISTRY: ${{ vars.ARTIFACTORY_DOCKER_REGISTRY }}
+          ARTIFACTORY_DOCKER_USERNAME: ${{ secrets.ARTIFACTORY_DOCKER_USERNAME }}
+          ARTIFACTORY_DOCKER_PASSWORD: ${{ secrets.ARTIFACTORY_DOCKER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          echo "${ARTIFACTORY_DOCKER_PASSWORD}" | docker login "${REGISTRY}" \
+            -u "${ARTIFACTORY_DOCKER_USERNAME}" \
+            --password-stdin
+
+      - name: Build and push image
+        env:
+          REGISTRY: ${{ vars.ARTIFACTORY_DOCKER_REGISTRY }}
+          REPOSITORY: ${{ vars.ARTIFACTORY_CI_DEPS_REPOSITORY }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euxo pipefail
+          FULL_IMAGE="${REGISTRY}/${REPOSITORY}"
+          docker build \
+            -f .github/scripts/Dockerfile.ci.deps \
+            -t "${FULL_IMAGE}:${IMAGE_TAG}" \
+            .
+          docker push "${FULL_IMAGE}:${IMAGE_TAG}"
+          echo "Pushed ${FULL_IMAGE}:${IMAGE_TAG}"

--- a/.github/workflows/ci-deps-docker-publish.yml
+++ b/.github/workflows/ci-deps-docker-publish.yml
@@ -45,16 +45,12 @@ jobs:
             exit 1
           fi
 
-      - name: Log in to Artifactory Docker registry
-        env:
-          REGISTRY: ${{ vars.ARTIFACTORY_DOCKER_REGISTRY }}
-          ARTIFACTORY_DOCKER_USERNAME: ${{ secrets.ARTIFACTORY_DOCKER_USERNAME }}
-          ARTIFACTORY_DOCKER_PASSWORD: ${{ secrets.ARTIFACTORY_DOCKER_PASSWORD }}
-        run: |
-          set -euo pipefail
-          echo "${ARTIFACTORY_DOCKER_PASSWORD}" | docker login "${REGISTRY}" \
-            -u "${ARTIFACTORY_DOCKER_USERNAME}" \
-            --password-stdin
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.ARTIFACTORY_DOCKER_REGISTRY }}
+          username: ${{ secrets.ARTIFACTORY_DOCKER_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_DOCKER_PASSWORD }}
 
       - name: Build and push image
         env:
@@ -62,7 +58,7 @@ jobs:
           REPOSITORY: ${{ vars.ARTIFACTORY_CI_DEPS_REPOSITORY }}
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           FULL_IMAGE="${REGISTRY}/${REPOSITORY}"
           docker build \
             -f .github/scripts/Dockerfile.ci.deps \

--- a/.github/workflows/ci-deps-docker-publish.yml
+++ b/.github/workflows/ci-deps-docker-publish.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/scripts
 
       - name: Validate configuration
         env:

--- a/.github/workflows/ci-deps-docker-publish.yml
+++ b/.github/workflows/ci-deps-docker-publish.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: linux-te-mi325-8
+    runs-on: te_builder
     timeout-minutes: 720
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description

Adds a manual GitHub Actions workflow (Publish CI deps Docker image) that builds [.github/scripts/Dockerfile.ci.deps] on the linux-te-mi325-8 runner, logs into the configured container registry, and pushes the image with a caller-supplied tag. This automates publishing the TE CI dependency image to Harbor (or any Docker registry using the same login/push flow) instead of building and pushing only by hand.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:



# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
