### PR TITLE
[ROCm] add the bias all row -inf support for jax unfused-attn

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1511,29 +1511,18 @@ class TestFusedAttn:
     not is_hip_extension(), reason="Bias all-neg-inf NaN fix is ROCm-specific (SWDEV-561757)"
 )
 @pytest.mark.parametrize(
-    "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout, bias_shape",
+    "s_kv, h_kv, bias_shape",
     [
-        pytest.param(
-            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            BiasShape._B1SS, id="B1SS-SELF",
-        ),
-        pytest.param(
-            2, 1024, 512, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            BiasShape._B1SS, id="B1SS-CROSS",
-        ),
-        pytest.param(
-            2, 1024, 1024, 12, 6, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            BiasShape._1HSS, id="1HSS-GQA",
-        ),
-        pytest.param(
-            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            BiasShape._BHSS, id="BHSS-SELF",
-        ),
-        pytest.param(
-            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            BiasShape._11SS, id="11SS-SELF",
-        ),
+        pytest.param(1024, 12, BiasShape._B1SS, id="B1SS-SELF"),
+        pytest.param(512,  12, BiasShape._B1SS, id="B1SS-CROSS"),
+        pytest.param(1024, 6,  BiasShape._1HSS, id="1HSS-GQA"),
+        pytest.param(1024, 12, BiasShape._BHSS, id="BHSS-SELF"),
+        pytest.param(1024, 12, BiasShape._11SS, id="11SS-SELF"),
     ],
+)
+@pytest.mark.parametrize(
+    "b, s_q, h_q, d_qk, d_v, dtype, qkv_layout",
+    [(2, 1024, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD)],
 )
 def test_backward_bias_all_neg_inf(
     b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout, bias_shape

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -97,6 +97,12 @@ def general_dot_product_attention(
         logits = logits.reshape((b, h_kv * num_groups, s_q, s_kv))
         # apply post-scale bias
         logits = logits + bias
+        # [ROCm] Detect query rows where ALL bias values are -inf (fully masked out).
+        # These rows would produce NaN in softmax; zero them so softmax yields 0 instead.
+        # Use equality check against -inf so real-valued bias (e.g. 1HSS) is unaffected.
+        if is_hip_extension():
+            bias_all_neg_mask = jnp.all(bias == -jnp.inf, axis=-1, keepdims=True)
+            logits = jnp.where(bias_all_neg_mask, 0, logits)
         # reshape logits back to original
         logits = logits.reshape((b, h_kv, num_groups, s_q, s_kv))
 
@@ -124,6 +130,14 @@ def general_dot_product_attention(
             softmax_out = softmax_with_extra[..., :-1].astype(dtype)
         case _:
             raise NotImplementedError(f"Unknown {softmax_type=}")
+
+    # [ROCm] Zero out softmax for fully-masked rows to prevent NaN propagation in backward
+    # Only triggers for -inf mask bias, not real-valued bias (e.g. 1HSS)
+    if bias is not None and is_hip_extension():
+        bias_all_neg_mask = jnp.all(bias == -jnp.inf, axis=-1, keepdims=True)
+        # Expand to match softmax_out 5D shape (b, h_kv, num_groups, s_q, s_kv)
+        bias_all_neg_mask = jnp.expand_dims(bias_all_neg_mask, axis=2)
+        softmax_out = jnp.where(bias_all_neg_mask, 0, softmax_out)
 
     if not deterministic and dropout_rate > 0.0:
         keep_prob = 1.0 - dropout_rate
@@ -1026,6 +1040,13 @@ class FusedAttnRunner:
         if self.dropout_prob > 0.0:
             return
 
+        # [ROCm] Verify no NaN or Inf in forward outputs
+        if is_hip_extension():
+            assert not jnp.any(jnp.isnan(primitive_out)), "Fused attention output contains NaN"
+            assert not jnp.any(jnp.isinf(primitive_out)), "Fused attention output contains Inf"
+            assert not jnp.any(jnp.isnan(reference_out)), "Reference attention output contains NaN"
+            assert not jnp.any(jnp.isinf(reference_out)), "Reference attention output contains Inf"
+
         print_debug_tensor_stats(f"primitive_out", primitive_out)
         print_debug_tensor_stats(f"reference_grad_valid", reference_out)
         print_debug_tensor_stats(f"diff_grad", jnp.abs(primitive_out - reference_out))
@@ -1052,6 +1073,18 @@ class FusedAttnRunner:
         primitive_dq = self.cp_inverse_reorder_fn(primitive_dq)
         primitive_dk = self.cp_inverse_reorder_fn(primitive_dk)
         primitive_dv = self.cp_inverse_reorder_fn(primitive_dv)
+
+        # [ROCm] Verify no NaN or Inf in gradients
+        if is_hip_extension():
+            for name, p_grad, r_grad in [
+                ("dq", primitive_dq, reference_dq),
+                ("dk", primitive_dk, reference_dk),
+                ("dv", primitive_dv, reference_dv),
+            ]:
+                assert not jnp.any(jnp.isnan(p_grad)), f"Fused attention {name} contains NaN"
+                assert not jnp.any(jnp.isinf(p_grad)), f"Fused attention {name} contains Inf"
+                assert not jnp.any(jnp.isnan(r_grad)), f"Reference attention {name} contains NaN"
+                assert not jnp.any(jnp.isinf(r_grad)), f"Reference attention {name} contains Inf"
 
         check_dqkv(primitive_dq, reference_dq, self.pad_q, 0)
         check_dqkv(primitive_dk, reference_dk, self.pad_kv, 1)
@@ -1473,6 +1506,74 @@ class TestFusedAttn:
             seq_desc_format,
         )
         runner.test_backward()
+
+@pytest.mark.skipif(
+    not is_hip_extension(), reason="Bias all-neg-inf NaN fix is ROCm-specific (SWDEV-561757)"
+)
+@pytest.mark.parametrize(
+    "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout",
+    [
+        pytest.param(
+            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
+            id="2-1024-1024-12-12-64-64-BF16-SELF-SEPARATE",
+        ),
+        pytest.param(
+            2, 1024, 512, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
+            id="2-1024-512-12-12-64-64-BF16-CROSS-SEPARATE",
+        ),
+    ],
+)
+def test_backward_bias_all_neg_inf(b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout):
+    """
+    Test backward with B1SS bias containing true -inf values.
+    Regression test for SWDEV-561757: when bias rows are ALL -inf (fully masked-out query
+    positions), softmax produces NaN which propagates into dq/dk/dv. The CK kernel fix and
+    the reference fix in general_dot_product_attention handle this by zeroing out fully-masked
+    rows before and after softmax.
+
+    The bias is a binary mask with only two values: 0 and -inf. Some rows are entirely -inf
+    (fully masked-out), while other rows have a mix of 0 and -inf (partially masked).
+    """
+    runner = FusedAttnRunner(
+        batch_size=b,
+        max_seqlen_q=s_q,
+        max_seqlen_kv=s_kv,
+        num_heads_q=h_q,
+        num_heads_kv=h_kv,
+        head_dim_qk=d_qk,
+        head_dim_v=d_v,
+        attn_bias_type=AttnBiasType.POST_SCALE_BIAS,
+        attn_mask_type=AttnMaskType.NO_MASK,
+        softmax_type=AttnSoftmaxType.VANILLA_SOFTMAX,
+        dropout_prob=0.0,
+        use_old_rng=True,
+        dtype=dtype,
+        is_training=True,
+        qkv_layout=qkv_layout,
+        bias_shape=BiasShape._B1SS,
+        window_size=None,
+        seq_desc_format=SeqDescFormat.Mask,
+    )
+    runner._setup_inputs()
+
+    # Build a B1SS binary bias with only two values: 0 and -inf.
+    # Use an explicit block-diagonal pattern with guaranteed gaps so that:
+    #   - Rows inside a block have a mix of 0 (within-block columns) and -inf (outside)
+    #   - Rows in the gaps between blocks are entirely -inf (fully masked-out)
+    bias_shape = (b, 1, s_q, s_kv)
+    bias = jnp.full(bias_shape, -jnp.inf, dtype=dtype)
+    block_size = min(s_q, s_kv) // 8
+    gap_size = block_size // 2
+    pos = 0
+    while pos + block_size <= min(s_q, s_kv):
+        bias = bias.at[:, :, pos : pos + block_size, pos : pos + block_size].set(0.0)
+        pos += block_size + gap_size  # leave a gap of all-neg-inf rows
+    runner.bias = bias
+
+    # Prevent test_backward from re-running _setup_inputs which would regenerate bias
+    runner._setup_inputs = lambda: None
+    runner.test_backward()
+
 
 # Single test with new-style RNG
 @pytest.mark.skipif(

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -98,7 +98,8 @@ def general_dot_product_attention(
         # apply post-scale bias
         logits = logits + bias
         # [ROCm] Detect query rows where ALL bias values are -inf (fully masked out).
-        # These rows would produce NaN in softmax; zero them so softmax yields 0 instead.
+        # These rows would produce NaN in softmax; zero logits to prevent NaN since
+        # the softmax output for these rows is zeroed out below anyway.
         # Use equality check against -inf so real-valued bias (e.g. 1HSS) is unaffected.
         if is_hip_extension():
             bias_all_neg_mask = jnp.all(bias == -jnp.inf, axis=-1, keepdims=True)
@@ -132,12 +133,13 @@ def general_dot_product_attention(
             raise NotImplementedError(f"Unknown {softmax_type=}")
 
     # [ROCm] Zero out softmax for fully-masked rows to prevent NaN propagation in backward
-    # Only triggers for -inf mask bias, not real-valued bias (e.g. 1HSS)
+    # Reuses bias_all_neg_mask from the pre-softmax block above to avoid drift.
     if bias is not None and is_hip_extension():
-        bias_all_neg_mask = jnp.all(bias == -jnp.inf, axis=-1, keepdims=True)
-        # Expand to match softmax_out 5D shape (b, h_kv, num_groups, s_q, s_kv)
-        bias_all_neg_mask = jnp.expand_dims(bias_all_neg_mask, axis=2)
-        softmax_out = jnp.where(bias_all_neg_mask, 0, softmax_out)
+        # Reshape 4D mask to 5D to match softmax_out (b, h_kv, num_groups, s_q, s_kv)
+        ms = bias_all_neg_mask.shape  # (batch_or_1, h_or_1, s_q, 1)
+        hkv = min(ms[1], h_kv)  # 1 for B1SS/11SS, h_kv for 1HSS
+        mask_5d = bias_all_neg_mask.reshape(ms[0], hkv, -1, ms[2], ms[3])
+        softmax_out = jnp.where(mask_5d, 0, softmax_out)
 
     if not deterministic and dropout_rate > 0.0:
         keep_prob = 1.0 - dropout_rate
@@ -1042,10 +1044,9 @@ class FusedAttnRunner:
 
         # [ROCm] Verify no NaN or Inf in forward outputs
         if is_hip_extension():
-            assert not jnp.any(jnp.isnan(primitive_out)), "Fused attention output contains NaN"
-            assert not jnp.any(jnp.isinf(primitive_out)), "Fused attention output contains Inf"
-            assert not jnp.any(jnp.isnan(reference_out)), "Reference attention output contains NaN"
-            assert not jnp.any(jnp.isinf(reference_out)), "Reference attention output contains Inf"
+            for name, out in [("Fused", primitive_out), ("Reference", reference_out)]:
+                assert not jnp.any(jnp.isnan(out)), f"{name} attention output contains NaN"
+                assert not jnp.any(jnp.isinf(out)), f"{name} attention output contains Inf"
 
         print_debug_tensor_stats(f"primitive_out", primitive_out)
         print_debug_tensor_stats(f"reference_grad_valid", reference_out)
@@ -1076,15 +1077,14 @@ class FusedAttnRunner:
 
         # [ROCm] Verify no NaN or Inf in gradients
         if is_hip_extension():
-            for name, p_grad, r_grad in [
+            for grad_name, p_grad, r_grad in [
                 ("dq", primitive_dq, reference_dq),
                 ("dk", primitive_dk, reference_dk),
                 ("dv", primitive_dv, reference_dv),
             ]:
-                assert not jnp.any(jnp.isnan(p_grad)), f"Fused attention {name} contains NaN"
-                assert not jnp.any(jnp.isinf(p_grad)), f"Fused attention {name} contains Inf"
-                assert not jnp.any(jnp.isnan(r_grad)), f"Reference attention {name} contains NaN"
-                assert not jnp.any(jnp.isinf(r_grad)), f"Reference attention {name} contains Inf"
+                for src_name, grad in [("Fused", p_grad), ("Reference", r_grad)]:
+                    assert not jnp.any(jnp.isnan(grad)), f"{src_name} {grad_name} contains NaN"
+                    assert not jnp.any(jnp.isinf(grad)), f"{src_name} {grad_name} contains Inf"
 
         check_dqkv(primitive_dq, reference_dq, self.pad_q, 0)
         check_dqkv(primitive_dk, reference_dk, self.pad_kv, 1)
@@ -1511,21 +1511,35 @@ class TestFusedAttn:
     not is_hip_extension(), reason="Bias all-neg-inf NaN fix is ROCm-specific (SWDEV-561757)"
 )
 @pytest.mark.parametrize(
-    "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout",
+    "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout, bias_shape",
     [
         pytest.param(
             2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            id="2-1024-1024-12-12-64-64-BF16-SELF-SEPARATE",
+            BiasShape._B1SS, id="B1SS-SELF",
         ),
         pytest.param(
             2, 1024, 512, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
-            id="2-1024-512-12-12-64-64-BF16-CROSS-SEPARATE",
+            BiasShape._B1SS, id="B1SS-CROSS",
+        ),
+        pytest.param(
+            2, 1024, 1024, 12, 6, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
+            BiasShape._1HSS, id="1HSS-GQA",
+        ),
+        pytest.param(
+            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
+            BiasShape._BHSS, id="BHSS-SELF",
+        ),
+        pytest.param(
+            2, 1024, 1024, 12, 12, 64, 64, jnp.bfloat16, QKVLayout.BSHD_BSHD_BSHD,
+            BiasShape._11SS, id="11SS-SELF",
         ),
     ],
 )
-def test_backward_bias_all_neg_inf(b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout):
+def test_backward_bias_all_neg_inf(
+    b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout, bias_shape
+):
     """
-    Test backward with B1SS bias containing true -inf values.
+    Test backward with bias containing true -inf values for all supported bias shapes.
     Regression test for SWDEV-561757: when bias rows are ALL -inf (fully masked-out query
     positions), softmax produces NaN which propagates into dq/dk/dv. The CK kernel fix and
     the reference fix in general_dot_product_attention handle this by zeroing out fully-masked
@@ -1550,18 +1564,25 @@ def test_backward_bias_all_neg_inf(b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qk
         dtype=dtype,
         is_training=True,
         qkv_layout=qkv_layout,
-        bias_shape=BiasShape._B1SS,
+        bias_shape=bias_shape,
         window_size=None,
         seq_desc_format=SeqDescFormat.Mask,
     )
     runner._setup_inputs()
 
-    # Build a B1SS binary bias with only two values: 0 and -inf.
+    # Build a binary bias with only two values: 0 and -inf.
+    # Shape depends on bias_shape: B1SS=(b,1,s_q,s_kv), 1HSS=(1,h_q,s_q,s_kv), etc.
+    shape_map = {
+        BiasShape._B1SS: (b, 1, s_q, s_kv),
+        BiasShape._1HSS: (1, h_q, s_q, s_kv),
+        BiasShape._BHSS: (b, h_q, s_q, s_kv),
+        BiasShape._11SS: (1, 1, s_q, s_kv),
+    }
+    concrete_shape = shape_map[bias_shape]
+    bias = jnp.full(concrete_shape, -jnp.inf, dtype=dtype)
     # Use an explicit block-diagonal pattern with guaranteed gaps so that:
     #   - Rows inside a block have a mix of 0 (within-block columns) and -inf (outside)
     #   - Rows in the gaps between blocks are entirely -inf (fully masked-out)
-    bias_shape = (b, 1, s_q, s_kv)
-    bias = jnp.full(bias_shape, -jnp.inf, dtype=dtype)
     block_size = min(s_q, s_kv) // 8
     gap_size = block_size // 2
     pos = 0

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1570,6 +1570,9 @@ def test_backward_bias_all_neg_inf(
     )
     runner._setup_inputs()
 
+    if runner.backend != NVTE_Fused_Attn_Backend.NVTE_CK:
+        pytest.skip("All-neg-inf bias NaN fix is CK-specific")
+
     # Build a binary bias with only two values: 0 and -inf.
     # Shape depends on bias_shape: B1SS=(b,1,s_q,s_kv), 1HSS=(1,h_q,s_q,s_kv), etc.
     shape_map = {


### PR DESCRIPTION
# Description

CK fixed the corner case with all row -inf in bias in https://github.com/ROCm/composable_kernel/pull/3326. This also aligns with NV upstream. We added the corresponding jax pytest by modifying the jax unfused-attn.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
This concludes the https://github.com/ROCm/frameworks-internal/issues/14668 and https://ontrack-internal.amd.com/browse/SWDEV-561757

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
