### PR TITLE
Update QoLA reducing [compile time, kernel count, lib size] by ~2x (Diet QoLA)

### DIFF
--- a/transformer_engine/common/ck_fused_attn/qola_manifest.toml
+++ b/transformer_engine/common/ck_fused_attn/qola_manifest.toml
@@ -9,9 +9,11 @@ architectures = ["gfx950", "gfx942"]
 [[modules]]
 name = "libmha_fwd"
 mode = "cpp_itfs"
+receipt = 700
 drop_srcs = ["mha_fwd_split.cu", "mha_fwd_batch_prefill.cu"]
 drop_directions = ["fwd_splitkv", "batch_prefill"]
 
 [[modules]]
 name = "libmha_bwd"
 mode = "cpp_itfs"
+receipt = 700


### PR DESCRIPTION
# Description

Updates QoLA to a new subcommit that relies on a custom patch to AITER's CK submodule, introducing a TE-specific receipt for CK's MHA code generating mechanism, shrinking FWD kernels by 10x and BWD by ~1.2x -- total shrinkage of ~2x across FWD/BWD cumulatively. This shrinkage includes the number of kernels, library size, and compile time.

This PR is primarily testing for https://github.com/Micky774/QoLA/pull/2

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adds custom CK receipt filter
- Adds receipt specification option to manifest

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
