### PR TITLE
Fix canonicalize MXFP8 GEMM to TN layout for other layouts.

### DIFF
--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -314,7 +314,7 @@ GemmParam CanonicalizeGemmInput(const transformer_engine::Tensor &A, const cubla
       NVTE_CHECK(A.has_columnwise_data(), "Input A is missing column-wise usage");
     }
     ret.A = is_A_transposed ? A.data.dptr : A.columnwise_data.dptr;
-    ret.transA = transA;
+    ret.transA = is_A_transposed ? transA : CUBLAS_OP_T;
     ret.Atype = is_A_transposed ? A.data.dtype : A.columnwise_data.dtype;
     ret.A_scale_inv = is_A_transposed ? A.scale_inv.dptr : A.columnwise_scale_inv.dptr;
     ret.lda = is_A_transposed ? k : m;
@@ -360,7 +360,7 @@ GemmParam CanonicalizeGemmInput(const transformer_engine::Tensor &A, const cubla
       NVTE_CHECK(B.has_data(), "Input B is missing row-wise usage");
     }
     ret.B = is_B_transposed ? B.columnwise_data.dptr : B.data.dptr;
-    ret.transB = transB;
+    ret.transB = is_B_transposed ? CUBLAS_OP_N : transB;
     ret.Btype = is_B_transposed ? B.columnwise_data.dtype : B.data.dtype;
     ret.B_scale_inv = is_B_transposed ? B.columnwise_scale_inv.dptr : B.scale_inv.dptr;
     ret.ldb = is_B_transposed ? n : k;


### PR DESCRIPTION
# Description
This PR fixes a bug and the below warning when using MXFP8 GEMM for wgrad computation (layout = NN).
```
shared/rocroller/lib/source/KernelGraph/Transformations/SwizzleScale.cpp:793: FatalError(m_params->transposeMemoryAccess[LayoutType::MATRIX_A] && !m_params->transposeMemoryAccess[LayoutType::MATRIX_B])
Non-TN is not supported by SwizzleScale
```

Issue:
ret.A = is_A_transposed ? A.data.dptr : A.columnwise_data.dptr;
ret.transA = transA;

ret.B = is_B_transposed ? B.columnwise_data.dptr : B.data.dptr;
ret.transB = transB;

For NN (transA=N, transB=N), the MXFP8 branch selects columnwise_data for A and data (rowwise) for B, but historically left transA and transB as N in the descriptor, which is incorrect.

If MXFP8 GEMM supports any layout, we should completely use rowwise data only or columnwise data only. But looking at the warning message above it only supports TN layout, which means the data selection is correct, but the flags aren't getting updated. This PR fixes it.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
