### PR TITLE
CK Tile Group GEMM gfx1250

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 [submodule "3rdparty/QoLA"]
 	path = 3rdparty/QoLA
 	url = https://github.com/Micky774/QoLA.git
+[submodule "rocm_libraries"]
+	path = 3rdparty/rocm_libraries
+	url = https://github.com/ROCm/rocm-libraries.git
+	branch = users/jia/ck/fix_grouped_gemm_quant_mxtype

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -354,7 +354,7 @@ set_property(
   PROPERTY
   COMPILE_OPTIONS "-g0;-dopt=on")
 else()
-  set(CK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/aiter/3rdparty/composable_kernel)
+  set(CK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/rocm_libraries/projects/composablekernel)
   target_include_directories(transformer_engine PRIVATE ${CK_ROOT}/include)
 endif() #USE_CUDA
 

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm.cpp
@@ -57,19 +57,19 @@ bool ck_tile_grouped_gemm(const NVTETensor* A,
   // FP8 special handling.
   //
   // A_use/B_use and transA_use/transB_use have already gone through the
-  // upstream-style grouped GEMM normalization above. This block only rewrites
-  // that normalized presentation into the CK FP8 preferred NT presentation by selecting
-  // `columnwise_data` when needed.
+  // upstream-style grouped GEMM normalization above. CK FP8 grouped GEMM is
+  // compiled only for the preferred NT presentation:
   //
-  // CK FP8 target presentation:
-  //   A_use: N
-  //   B_use: T
+  //   transA_use = false
+  //   transB_use = true
   //
-  // The outer condition checks whether this NT presentation is possible:
-  //   - A_use is already N, or can be made N using columnwise_data
-  //   - B_use is already T, or can be made T using columnwise_data
+  // This block rewrites the normalized presentation into that NT form by
+  // selecting columnwise_data when needed. If the required columnwise_data view
+  // is unavailable, this CK FP8 backend cannot represent the GEMM in its
+  // supported layout form, so we fall back instead of compiling/running an
+  // unsupported layout variant.
   //
-  // Then each operand is rewritten independently only if needed:
+  // Rewrite cases:
   //   NN -> rewrite B only
   //   TN -> rewrite A and B
   //   NT -> already in target form
@@ -81,16 +81,23 @@ bool ck_tile_grouped_gemm(const NVTETensor* A,
     const bool has_a_col = A0_te->has_columnwise_data();
     const bool has_b_col = B0_te->has_columnwise_data();
 
-    if ((!transA_use || has_a_col) && (transB_use || has_b_col)) {
-      if (transA_use) {
-        use_a_colwise_data = true;
-        transA_use = false;
-      }
+    const bool can_make_a_nt = !transA_use || has_a_col;
+    const bool can_make_b_nt = transB_use || has_b_col;
 
-      if (!transB_use) {
-        use_b_colwise_data = true;
-        transB_use = true;
-      }
+    if (!can_make_a_nt || !can_make_b_nt) {
+      NVTE_WARN("ck_tile_grouped_gemm: FP8 grouped GEMM requires NT presentation. "
+                "Missing required columnwise_data for layout rewrite; falling back.");
+      return false;
+    }
+
+    if (transA_use) {
+      use_a_colwise_data = true;
+      transA_use = false;
+    }
+
+    if (!transB_use) {
+      use_b_colwise_data = true;
+      transB_use = true;
     }
   }
 

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hip/hip_runtime.h>
+#include "common/util/cuda_runtime.h"
 
 #include <array>
 #include <type_traits>
@@ -68,6 +69,28 @@ static inline const transformer_engine::SimpleTensor& data_view(const transforme
 
 static inline const transformer_engine::SimpleTensor& scale_inv_view(const transformer_engine::Tensor& t) {
   return t.scale_inv;
+}
+
+enum class GPUArch {
+  GFX942,
+  GFX950,
+  GFX1250,
+  UNKNOWN
+};
+
+static inline GPUArch detect_gpu_arch() {
+  int arch = cuda::sm_arch(0);
+
+  if (arch == 94) {
+    return GPUArch::GFX942;
+  }
+  if (arch == 95) {
+    return GPUArch::GFX950;
+  }
+  if (arch == 125 || arch == 1250) {
+    return GPUArch::GFX1250;
+  }
+  return GPUArch::UNKNOWN;
 }
 
 struct GroupedGemmRunContext {

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
@@ -87,7 +87,7 @@ static inline GPUArch detect_gpu_arch() {
   if (arch == 95) {
     return GPUArch::GFX950;
   }
-  if (arch == 125 || arch == 1250) {
+  if (arch == 1250) {
     return GPUArch::GFX1250;
   }
   return GPUArch::UNKNOWN;

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp16.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp16.cpp
@@ -233,28 +233,10 @@ class GroupedGemmRunner : public RunnerInterface {
   })
 
 template <GPUArch Arch>
-struct FP16TileCfg;
-
-template <>
-struct FP16TileCfg<GPUArch::GFX942> {
-  using type = TileCfg_256x256x64_MFMA;
-};
-
-template <>
-struct FP16TileCfg<GPUArch::GFX950> {
-  using type = TileCfg_256x256x64_MFMA;
-};
-
-template <>
-struct FP16TileCfg<GPUArch::GFX1250> {
-  using type = TileCfg_256x256x64_WMMA;
-};
-
-template <GPUArch Arch>
 bool ck_tile_grouped_gemm_fp16_dispatch_arch(DType a_dtype,
-                                        DType b_dtype,
-                                        DType d_dtype,
-                                        const GroupedGemmRunContext& ctx) {
+                                             DType b_dtype,
+                                             DType d_dtype,
+                                             const GroupedGemmRunContext& ctx) {
   const ck_tile::stream_config s{ctx.stream};
   std::unique_ptr<RunnerInterface> runner = nullptr;
 
@@ -276,11 +258,11 @@ bool ck_tile_grouped_gemm_fp16_dispatch_arch(DType a_dtype,
             MAKE_RUNNER(TileCfg_256x256x64_WMMA);
           } else {
             if (ctx.N % 256 == 0) {
-                MAKE_RUNNER(TileCfg_256x256x64_MFMA);
+              MAKE_RUNNER(TileCfg_256x256x64_MFMA);
             } else if (ctx.N % 128 == 0) {
-                MAKE_RUNNER(TileCfg_256x128x64_MFMA);
+              MAKE_RUNNER(TileCfg_256x128x64_MFMA);
             } else {
-                MAKE_RUNNER(TileCfg_256x128x64_MFMA_padding);
+              MAKE_RUNNER(TileCfg_256x128x64_MFMA_padding);
             }
           }
         });
@@ -300,12 +282,19 @@ bool ck_tile_grouped_gemm_fp16_dispatch(DType a_dtype,
                                        DType d_dtype,
                                        const GroupedGemmRunContext& ctx) {
   switch (detect_gpu_arch()) {
+#if defined(__gfx942__)
     case GPUArch::GFX942:
       return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX942>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+#if defined(__gfx950__)
     case GPUArch::GFX950:
       return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX950>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+#if defined(__gfx1250__)
     case GPUArch::GFX1250:
       return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX1250>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+
     default:
       NVTE_ERROR("ck_tile_grouped_gemm: available architectures = {gfx942, gfx950, gfx1250}");
       return false;

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp16.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp16.cpp
@@ -14,7 +14,7 @@ namespace grouped_gemm {
 // Tile configs: FP16/BF16
 // -------------------------
 
-struct TileCfg_256x256x64 {
+struct TileCfg_256x256x64_MFMA {
   static constexpr ck_tile::index_t M_Tile = 256;
   static constexpr ck_tile::index_t N_Tile = 256;
   static constexpr ck_tile::index_t K_Tile = 64;
@@ -37,12 +37,35 @@ struct TileCfg_256x256x64 {
   static constexpr ck_tile::index_t TilePartitionerM01 = 4;
 };
 
-struct TileCfg_256x128x64 : TileCfg_256x256x64 {
+struct TileCfg_256x128x64_MFMA : TileCfg_256x256x64_MFMA {
   static constexpr ck_tile::index_t N_Tile = 128;
 };
 
-struct TileCfg_256x128x64_padding : TileCfg_256x128x64 {
+struct TileCfg_256x128x64_MFMA_padding : TileCfg_256x128x64_MFMA {
   static constexpr bool kPadN = true;
+};
+
+struct TileCfg_256x256x64_WMMA {
+  static constexpr ck_tile::index_t M_Tile = 256;
+  static constexpr ck_tile::index_t N_Tile = 256;
+  static constexpr ck_tile::index_t K_Tile = 64;
+
+  static constexpr ck_tile::index_t M_Warp = 2;
+  static constexpr ck_tile::index_t N_Warp = 2;
+  static constexpr ck_tile::index_t K_Warp = 1;
+
+  static constexpr ck_tile::index_t M_Warp_Tile = 16;
+  static constexpr ck_tile::index_t N_Warp_Tile = 16;
+  static constexpr ck_tile::index_t K_Warp_Tile = 32;
+
+  static constexpr bool kPadM = true;
+  static constexpr bool kPadN = true;
+  static constexpr bool kPadK = true;
+
+  static constexpr bool DoubleSmemBuffer = false;
+
+  static constexpr ck_tile::index_t TilePartitionerGroupNum = 8;
+  static constexpr ck_tile::index_t TilePartitionerM01 = 4;
 };
 
 template <typename AType,
@@ -209,7 +232,26 @@ class GroupedGemmRunner : public RunnerInterface {
     runner = std::make_unique<Runner>();                               \
   })
 
-bool ck_tile_grouped_gemm_fp16_dispatch(DType a_dtype,
+template <GPUArch Arch>
+struct FP16TileCfg;
+
+template <>
+struct FP16TileCfg<GPUArch::GFX942> {
+  using type = TileCfg_256x256x64_MFMA;
+};
+
+template <>
+struct FP16TileCfg<GPUArch::GFX950> {
+  using type = TileCfg_256x256x64_MFMA;
+};
+
+template <>
+struct FP16TileCfg<GPUArch::GFX1250> {
+  using type = TileCfg_256x256x64_WMMA;
+};
+
+template <GPUArch Arch>
+bool ck_tile_grouped_gemm_fp16_dispatch_arch(DType a_dtype,
                                         DType b_dtype,
                                         DType d_dtype,
                                         const GroupedGemmRunContext& ctx) {
@@ -229,13 +271,17 @@ bool ck_tile_grouped_gemm_fp16_dispatch(DType a_dtype,
 
         TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(d_dtype, d_te_type, {
           using CType = typename TETypeToCKType<d_te_type>::type;
-
-          if (ctx.N % 256 == 0) {
-            MAKE_RUNNER(TileCfg_256x256x64);
-          } else if (ctx.N % 128 == 0) {
-            MAKE_RUNNER(TileCfg_256x128x64);
+          
+          if constexpr (Arch == GPUArch::GFX1250) {
+            MAKE_RUNNER(TileCfg_256x256x64_WMMA);
           } else {
-            MAKE_RUNNER(TileCfg_256x128x64_padding);
+            if (ctx.N % 256 == 0) {
+                MAKE_RUNNER(TileCfg_256x256x64_MFMA);
+            } else if (ctx.N % 128 == 0) {
+                MAKE_RUNNER(TileCfg_256x128x64_MFMA);
+            } else {
+                MAKE_RUNNER(TileCfg_256x128x64_MFMA_padding);
+            }
           }
         });
       });
@@ -247,6 +293,23 @@ bool ck_tile_grouped_gemm_fp16_dispatch(DType a_dtype,
   }
 
   return runner->run(s, ctx);
+}
+
+bool ck_tile_grouped_gemm_fp16_dispatch(DType a_dtype,
+                                       DType b_dtype,
+                                       DType d_dtype,
+                                       const GroupedGemmRunContext& ctx) {
+  switch (detect_gpu_arch()) {
+    case GPUArch::GFX942:
+      return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX942>(a_dtype, b_dtype, d_dtype, ctx);
+    case GPUArch::GFX950:
+      return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX950>(a_dtype, b_dtype, d_dtype, ctx);
+    case GPUArch::GFX1250:
+      return ck_tile_grouped_gemm_fp16_dispatch_arch<GPUArch::GFX1250>(a_dtype, b_dtype, d_dtype, ctx);
+    default:
+      NVTE_ERROR("ck_tile_grouped_gemm: available architectures = {gfx942, gfx950, gfx1250}");
+      return false;
+  }
 }
 
 #undef MAKE_RUNNER

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
@@ -357,12 +357,19 @@ bool ck_tile_grouped_gemm_fp8_dispatch(DType a_dtype,
                                        DType d_dtype,
                                        const GroupedGemmRunContext& ctx) {
   switch (detect_gpu_arch()) {
+#if defined(__gfx942__)
     case GPUArch::GFX942:
       return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX942>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+#if defined(__gfx950__)
     case GPUArch::GFX950:
       return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX950>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+#if defined(__gfx1250__)
     case GPUArch::GFX1250:
       return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX1250>(a_dtype, b_dtype, d_dtype, ctx);
+#endif
+
     default:
       NVTE_ERROR("ck_tile_grouped_gemm: available architectures = {gfx942, gfx950, gfx1250}");
       return false;

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
@@ -6,7 +6,6 @@
 
 #include "ck_grouped_gemm_common.h"
 #include "ck_grouped_gemm_fp8.h"
-#include "common/util/cuda_runtime.h"
 
 #include "ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp"
 #include "ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp"
@@ -15,12 +14,6 @@
 
 namespace transformer_engine {
 namespace grouped_gemm {
-
-enum class GPUArch {
-  GFX942,
-  GFX950,
-  UNKNOWN
-};
 
 struct TileCfg_128x128x128_16x16x128_2x2x1 {
   static constexpr ck_tile::index_t M_Tile = 128;
@@ -55,7 +48,7 @@ struct TileCfg_128x128x128_16x16x128_2x2x1 {
 //
 // In all other compilation paths, the struct overrides the relevant fields to
 // provide the intended 32x32x16 configuration.
-#if defined(__gfx950__)
+#if defined(__gfx950__) || defined(__gfx125__)
 struct TileCfg_128x128x128_32x32x16_2x2x1
     : TileCfg_128x128x128_16x16x128_2x2x1 {};
 #else
@@ -115,8 +108,7 @@ class QuantGroupedGemmRunner : public RunnerInterface {
                                                     AccType,
                                                     GemmShape,
                                                     UniversalTraits,
-                                                    false,
-                                                    AccType>;
+                                                    false>;
 
   using Pipeline = ck_tile::GemmPipelineAgBgCrCompV3<Problem>;
 
@@ -265,18 +257,6 @@ class QuantGroupedGemmRunner : public RunnerInterface {
   }
 };
 
-static inline GPUArch detect_gpu_arch() {
-  int arch = cuda::sm_arch(0);
-
-  if (arch == 94) {
-    return GPUArch::GFX942;
-  }
-  if (arch == 95) {
-    return GPUArch::GFX950;
-  }
-  return GPUArch::UNKNOWN;
-}
-
 template <GPUArch Arch>
 struct FP8TileCfg;
 
@@ -287,6 +267,11 @@ struct FP8TileCfg<GPUArch::GFX942> {
 
 template <>
 struct FP8TileCfg<GPUArch::GFX950> {
+  using type = TileCfg_128x128x128_16x16x128_2x2x1;
+};
+
+template <>
+struct FP8TileCfg<GPUArch::GFX1250> {
   using type = TileCfg_128x128x128_16x16x128_2x2x1;
 };
 
@@ -346,8 +331,10 @@ bool ck_tile_grouped_gemm_fp8_dispatch(DType a_dtype,
       return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX942>(a_dtype, b_dtype, d_dtype, ctx);
     case GPUArch::GFX950:
       return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX950>(a_dtype, b_dtype, d_dtype, ctx);
+    case GPUArch::GFX1250:
+      return ck_tile_grouped_gemm_fp8_dispatch_arch<GPUArch::GFX1250>(a_dtype, b_dtype, d_dtype, ctx);
     default:
-      NVTE_ERROR("ck_tile_grouped_gemm: available architectures = {gfx942, gfx950}");
+      NVTE_ERROR("ck_tile_grouped_gemm: available architectures = {gfx942, gfx950, gfx1250}");
       return false;
   }
 }

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_fp8.cpp
@@ -38,6 +38,29 @@ struct TileCfg_128x128x128_16x16x128_2x2x1 {
   static constexpr ck_tile::index_t TilePartitionerM01 = 8;
 };
 
+struct TileCfg_128x128x128_16x16x64_2x2x1 {
+  static constexpr ck_tile::index_t M_Tile = 128;
+  static constexpr ck_tile::index_t N_Tile = 128;
+  static constexpr ck_tile::index_t K_Tile = 128;
+
+  static constexpr ck_tile::index_t M_Warp = 2;
+  static constexpr ck_tile::index_t N_Warp = 2;
+  static constexpr ck_tile::index_t K_Warp = 1;
+
+  static constexpr ck_tile::index_t M_Warp_Tile = 16;
+  static constexpr ck_tile::index_t N_Warp_Tile = 16;
+  static constexpr ck_tile::index_t K_Warp_Tile = 64;
+
+  static constexpr bool kPadM = false;
+  static constexpr bool kPadN = false;
+  static constexpr bool kPadK = false;
+
+  static constexpr bool DoubleSmemBuffer = false;
+
+  static constexpr ck_tile::index_t TilePartitionerGroupNum = 16;
+  static constexpr ck_tile::index_t TilePartitionerM01 = 8;
+};
+
 // gfx950 device compilation cannot instantiate the literal 32x32x16 FP8 tile
 // configuration due to an unsupported warp GEMM dispatcher configuration.
 // See: ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp for supported variants.
@@ -48,7 +71,7 @@ struct TileCfg_128x128x128_16x16x128_2x2x1 {
 //
 // In all other compilation paths, the struct overrides the relevant fields to
 // provide the intended 32x32x16 configuration.
-#if defined(__gfx950__) || defined(__gfx125__)
+#if defined(__gfx950__)
 struct TileCfg_128x128x128_32x32x16_2x2x1
     : TileCfg_128x128x128_16x16x128_2x2x1 {};
 #else
@@ -272,7 +295,7 @@ struct FP8TileCfg<GPUArch::GFX950> {
 
 template <>
 struct FP8TileCfg<GPUArch::GFX1250> {
-  using type = TileCfg_128x128x128_16x16x128_2x2x1;
+  using type = TileCfg_128x128x128_16x16x64_2x2x1;
 };
 
 template <GPUArch Arch>
@@ -286,31 +309,38 @@ static bool ck_tile_grouped_gemm_fp8_dispatch_arch(DType a_dtype,
   using CTypeLayout = RowMajor;
   using TileCfg = typename FP8TileCfg<Arch>::type;
 
-  TRANSFORMER_ENGINE_SWITCH_CONDITION(ctx.transA, kTransA, {
-    using ALayout = std::conditional_t<kTransA, ColMajor, RowMajor>;
+  // FP8 grouped GEMM is only compiled for CK's preferred NT presentation:
+  //   transA=false, transB=true
+  // which maps to:
+  //   ALayout=RowMajor, BLayout=ColMajor.
+  //
+  // The caller is responsible for rewriting other FP8 layouts into this form
+  // using columnwise_data when needed. Reject anything that did not normalize
+  // successfully so we do not instantiate unreachable/unsupported layout variants.
+  if (ctx.transA || !ctx.transB) {
+    return false;
+  }
 
-    TRANSFORMER_ENGINE_SWITCH_CONDITION(ctx.transB, kTransB, {
-      using BLayout = std::conditional_t<kTransB, ColMajor, RowMajor>;
+  using ALayout = RowMajor;
+  using BLayout = ColMajor;
 
-      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(a_dtype, a_te_type, {
-        using AType = typename TETypeToCKType<a_te_type>::type;
+  TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(a_dtype, a_te_type, {
+    using AType = typename TETypeToCKType<a_te_type>::type;
 
-        TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(b_dtype, b_te_type, {
-          using BType = typename TETypeToCKType<b_te_type>::type;
+    TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(b_dtype, b_te_type, {
+      using BType = typename TETypeToCKType<b_te_type>::type;
 
-          TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(d_dtype, d_te_type, {
-            using CType = typename TETypeToCKType<d_te_type>::type;
-            using Runner = QuantGroupedGemmRunner<AType,
-                                                  BType,
-                                                  CType,
-                                                  ALayout,
-                                                  BLayout,
-                                                  CTypeLayout,
-                                                  TileCfg,
-                                                  ck_tile::memory_operation_enum::set>;
-            runner = std::make_unique<Runner>();
-          });
-        });
+      TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(d_dtype, d_te_type, {
+        using CType = typename TETypeToCKType<d_te_type>::type;
+        using Runner = QuantGroupedGemmRunner<AType,
+                                              BType,
+                                              CType,
+                                              ALayout,
+                                              BLayout,
+                                              CTypeLayout,
+                                              TileCfg,
+                                              ck_tile::memory_operation_enum::set>;
+        runner = std::make_unique<Runner>();
       });
     });
   });

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -1122,7 +1122,8 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
   if (!use_cutlass || num_gemms == 1) {
 #else
   // Currently only support cutlass group gemm on Hopper Arch
-  if (!(is_hopper && use_cutlass)) {
+  //if (!(is_hopper && use_cutlass)) {
+  if (!use_cutlass) {
 #endif
     cublas_path();
     return;

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -1122,7 +1122,7 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
   if (!use_cutlass || num_gemms == 1) {
 #else
   // Currently only support cutlass group gemm on Hopper Arch
-  //if (!(is_hopper && use_cutlass)) {
+  if (!(is_hopper && use_cutlass)) {
   if (!use_cutlass) {
 #endif
     cublas_path();


### PR DESCRIPTION
# Description

Extend the present CK tile grouped GEMM (F16/F8) implementation for compatibility with gfx1250. Replaces 3rdparty/aiter with 3rdparty/rocm-libraries for the gfx1250 changes from CK.

Fixes #16490

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
