### PR TITLE
[WIP] Load TE core with RTLD_LOCAL to stop rocroller symbol leak

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -115,6 +115,7 @@ def get_build_ext(
 
         def run(self) -> None:
             # Build CMake extensions
+            cmake_install_dirs: List[Path] = []
             for ext in self.extensions:
                 package_path = Path(self.get_ext_fullpath(ext.name))
                 install_dir = package_path.resolve().parent
@@ -135,12 +136,21 @@ def get_build_ext(
                         build_dir=build_dir,
                         install_dir=install_dir,
                     )
+                    cmake_install_dirs.append(install_dir)
 
             # Build non-CMake extensions as usual
             all_extensions = self.extensions
             self.extensions = [
                 ext for ext in self.extensions if not isinstance(ext, CMakeExtension)
             ]
+            # Make CMake-installed shared libraries (e.g. libtransformer_engine.so)
+            # discoverable when linking framework extensions that declare them as
+            # NEEDED dependencies.
+            for ext in self.extensions:
+                for cmake_install_dir in cmake_install_dirs:
+                    cmake_install_dir_str = str(cmake_install_dir)
+                    if cmake_install_dir_str not in ext.library_dirs:
+                        ext.library_dirs.append(cmake_install_dir_str)
             super().run()
             self.extensions = all_extensions
 

--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -145,7 +145,7 @@ def get_build_ext(
             ]
             # Make CMake-installed shared libraries (e.g. libtransformer_engine.so)
             # discoverable when linking framework extensions that declare them as
-            # NEEDED dependencies.
+            # NEEDED dependencies on a fresh full-tree build.
             for ext in self.extensions:
                 for cmake_install_dir in cmake_install_dirs:
                     cmake_install_dir_str = str(cmake_install_dir)

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -123,6 +123,29 @@ def setup_jax_extension(
     if rocm_build():
         cxx_flags.extend(["-D__HIP_PLATFORM_AMD__", "-DUSE_ROCM"])
 
+    # Link against the TE core library so the jax extension resolves core
+    # symbols via the ELF NEEDED graph rather than via RTLD_GLOBAL. This
+    # avoids transitively exposing librocroller.so symbols, which interpose
+    # with HIP's internal helpers and cause hipModuleLoad to abort with
+    # `free(): invalid size`.
+    #
+    # The CMake build of the core library runs before this extension is
+    # linked (see `_CMakeBuildExtension.run` in build_ext.py), and the
+    # CMake install directory is injected into `library_dirs` there so the
+    # linker can find `libtransformer_engine.so` even on a clean build. We
+    # additionally try to resolve a previously-built copy here so that
+    # incremental builds and tooling that links this extension in isolation
+    # still work.
+    libraries = ["nccl"] if not rocm_build() else []
+    libraries.append("transformer_engine")
+    library_dirs: List[str] = []
+    try:
+        from transformer_engine.common import _get_shared_object_file
+        core_lib_path = Path(_get_shared_object_file("core"))
+        library_dirs.append(str(core_lib_path.parent))
+    except (ImportError, FileNotFoundError):
+        pass
+
     # Define TE/JAX as a Pybind11Extension
     from pybind11.setup_helpers import Pybind11Extension
 
@@ -131,5 +154,6 @@ def setup_jax_extension(
         sources=[str(path) for path in sources],
         include_dirs=[str(path) for path in include_dirs],
         extra_compile_args=cxx_flags,
-        libraries=["nccl"] if not rocm_build() else [],
+        libraries=libraries,
+        library_dirs=library_dirs,
     )

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -12,6 +12,7 @@ import setuptools
 
 from .utils import rocm_build, rocm_path
 from .utils import all_files_in_dir, get_cuda_include_dirs, debug_build_enabled
+from .utils import installed_te_core_lib_dir
 from typing import List
 
 
@@ -128,23 +129,12 @@ def setup_jax_extension(
     # avoids transitively exposing librocroller.so symbols, which interpose
     # with HIP's internal helpers and cause hipModuleLoad to abort with
     # `free(): invalid size`.
-    #
-    # The CMake build of the core library runs before this extension is
-    # linked (see `_CMakeBuildExtension.run` in build_ext.py), and the
-    # CMake install directory is injected into `library_dirs` there so the
-    # linker can find `libtransformer_engine.so` even on a clean build. We
-    # additionally try to resolve a previously-built copy here so that
-    # incremental builds and tooling that links this extension in isolation
-    # still work.
     libraries = ["nccl"] if not rocm_build() else []
     libraries.append("transformer_engine")
     library_dirs: List[str] = []
-    try:
-        from transformer_engine.common import _get_shared_object_file
-        core_lib_path = Path(_get_shared_object_file("core"))
-        library_dirs.append(str(core_lib_path.parent))
-    except (ImportError, FileNotFoundError):
-        pass
+    core_lib_dir = installed_te_core_lib_dir()
+    if core_lib_dir is not None:
+        library_dirs.append(str(core_lib_dir))
 
     # Define TE/JAX as a Pybind11Extension
     from pybind11.setup_helpers import Pybind11Extension

--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -115,6 +115,27 @@ def setup_pytorch_extension(
         libraries.append("mpi")
         cxx_flags.extend(["-DNVTE_ENABLE_ROCSHMEM", "-DOMPI_SKIP_MPICXX"])
 
+    # Link against the TE core library so the torch extension resolves core
+    # symbols via the ELF NEEDED graph rather than via RTLD_GLOBAL. This
+    # avoids transitively exposing librocroller.so symbols, which interpose
+    # with HIP's internal helpers and cause hipModuleLoad to abort with
+    # `free(): invalid size`.
+    #
+    # The CMake build of the core library runs before this extension is
+    # linked (see `_CMakeBuildExtension.run` in build_ext.py), and the
+    # CMake install directory is injected into `library_dirs` there so the
+    # linker can find `libtransformer_engine.so` even on a clean build. We
+    # additionally try to resolve a previously-built copy here so that
+    # incremental builds and tooling that links this extension in isolation
+    # still work.
+    libraries.append("transformer_engine")
+    try:
+        from transformer_engine.common import _get_shared_object_file
+        core_lib_path = Path(_get_shared_object_file("core"))
+        library_dirs.append(str(core_lib_path.parent))
+    except (ImportError, FileNotFoundError):
+        pass
+
     # Construct PyTorch CUDA extension
     sources = [str(path) for path in sources]
     include_dirs = [str(path) for path in include_dirs]

--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -17,6 +17,7 @@ from .utils import (
     cuda_version,
     get_cuda_include_dirs,
     debug_build_enabled,
+    installed_te_core_lib_dir,
 )
 from typing import List
 
@@ -120,21 +121,10 @@ def setup_pytorch_extension(
     # avoids transitively exposing librocroller.so symbols, which interpose
     # with HIP's internal helpers and cause hipModuleLoad to abort with
     # `free(): invalid size`.
-    #
-    # The CMake build of the core library runs before this extension is
-    # linked (see `_CMakeBuildExtension.run` in build_ext.py), and the
-    # CMake install directory is injected into `library_dirs` there so the
-    # linker can find `libtransformer_engine.so` even on a clean build. We
-    # additionally try to resolve a previously-built copy here so that
-    # incremental builds and tooling that links this extension in isolation
-    # still work.
     libraries.append("transformer_engine")
-    try:
-        from transformer_engine.common import _get_shared_object_file
-        core_lib_path = Path(_get_shared_object_file("core"))
-        library_dirs.append(str(core_lib_path.parent))
-    except (ImportError, FileNotFoundError):
-        pass
+    core_lib_dir = installed_te_core_lib_dir()
+    if core_lib_dir is not None:
+        library_dirs.append(str(core_lib_dir))
 
     # Construct PyTorch CUDA extension
     sources = [str(path) for path in sources]

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -82,6 +82,33 @@ def remove_dups(_list: List):
     return list(set(_list))
 
 
+def installed_te_core_lib_dir() -> Optional[Path]:
+    """Locate an already-installed libtransformer_engine.so.
+
+    Searches Python's site-packages for the core library so that
+    framework extensions can declare an explicit DT_NEEDED link against
+    it. Used at build time when the core library is being installed
+    separately from the framework extension (e.g. when building the
+    ``transformer_engine_*_torch`` sdist against a pre-installed
+    ``transformer_engine_*`` core package).
+
+    Importing ``transformer_engine.common`` is intentionally avoided
+    here because that module eagerly loads framework extensions, which
+    may not exist yet during this very build.
+    """
+    import sysconfig
+
+    purelib = Path(sysconfig.get_paths()["purelib"])
+    candidate_dirs = (
+        purelib / "transformer_engine",
+        purelib / "transformer_engine" / "wheel_lib",
+    )
+    for candidate in candidate_dirs:
+        if candidate.is_dir() and any(candidate.glob("libtransformer_engine*.so*")):
+            return candidate
+    return None
+
+
 def found_cmake() -> bool:
     """ "Check if valid CMake is available
 

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -409,8 +409,16 @@ def is_fp8_fnuz():
 
 @functools.lru_cache(maxsize=None)
 def _load_core_library():
-    """Load shared library with Transformer Engine C extensions"""
-    return ctypes.CDLL(_get_shared_object_file("core"), mode=ctypes.RTLD_GLOBAL)
+    """Load shared library with Transformer Engine C extensions.
+
+    Loaded with RTLD_LOCAL so that transitive dependencies (notably
+    librocroller.so on ROCm) are not promoted into the global symbol
+    namespace, where they would interpose with HIP runtime helpers and
+    cause hipModuleLoad to abort with `free(): invalid size`. Framework
+    extensions therefore link against this library explicitly via ELF
+    NEEDED rather than relying on global symbol visibility.
+    """
+    return ctypes.CDLL(_get_shared_object_file("core"), mode=ctypes.RTLD_LOCAL)
 
 
 if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):


### PR DESCRIPTION
# Description

Switch libtransformer_engine.so from RTLD_GLOBAL to RTLD_LOCAL and link the torch/jax extensions against it explicitly via DT_NEEDED. This prevents librocroller.so symbols from interposing with HIP and fixes `free(): invalid size` in hipModuleLoad when TE is imported before MORI's shmem init on ROCm.

https://amd-hub.atlassian.net/browse/AIMORI-12

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
