### PR TITLE
PR583 hot fix

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -560,7 +560,7 @@ class TestNorm:
 
         precise_comparison = True
 
-        if get_cudnn_version() < (9, 10, 0) and scaling_mode == ScalingMode.MXFP8_1D_SCALING:
+        if (get_cudnn_version() < (9, 10, 0) or is_hip_extension()) and scaling_mode == ScalingMode.MXFP8_1D_SCALING:
             # Reduce precision of test as we don't use fused norm below this version CuDNN for MXFP8 and instead
             # do an unfused norm and quantize with an intermediate cast into in_dtype which can reduce precision
             precise_comparison = False


### PR DESCRIPTION
# Description

[PR583](https://github.com/ROCm/TransformerEngine/pull/583) resulted in some jax test failures. 

The tuned HIP RMSNorm kernel can introduce small numerical jitter compared to the general kernel path. For MXFP8, these tiny differences can shift the selected scaling factor by one step, which in turn can double or halve the quantized data representation and cause bitwise comparisons to fail despite equivalent numerical behavior.

This hotfix disables precise/bitwise comparison for HIP MXFP8 test coverage while preserving the existing numerical correctness checks.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
