### PR TITLE
[tests/cpp] register source files as dependencies to rebuild on change

### DIFF
--- a/build_tools/hipify/hipify.cmake
+++ b/build_tools/hipify/hipify.cmake
@@ -6,14 +6,6 @@ set(_HIPIFY_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 
 function(TE_Hipify SRC_DIR)
-    # Register original source files as configure dependencies so that
-    # editing them triggers re-configuration and re-hipification.
-    file(GLOB_RECURSE _hipify_source_deps
-        "${SRC_DIR}/*.cu"
-        "${SRC_DIR}/*.cuh"
-    )
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${_hipify_source_deps})
-
     # Create result file
     set(hipify_result "${CMAKE_BINARY_DIR}/hipify_result.json")
     

--- a/build_tools/hipify/hipify.cmake
+++ b/build_tools/hipify/hipify.cmake
@@ -6,6 +6,14 @@ set(_HIPIFY_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 
 function(TE_Hipify SRC_DIR)
+    # Register original source files as configure dependencies so that
+    # editing them triggers re-configuration and re-hipification.
+    file(GLOB_RECURSE _hipify_source_deps
+        "${SRC_DIR}/*.cu"
+        "${SRC_DIR}/*.cuh"
+    )
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${_hipify_source_deps})
+
     # Create result file
     set(hipify_result "${CMAKE_BINARY_DIR}/hipify_result.json")
     

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -95,6 +95,25 @@ endif()
 if(USE_ROCM)
   include("${CMAKE_CURRENT_SOURCE_DIR}/../../build_tools/hipify/hipify.cmake")
   TE_Hipify(${CMAKE_CURRENT_SOURCE_DIR})
+
+  # Register original source files as configure dependencies so that
+  # editing them triggers re-configuration and re-hipification.
+  # SOURCES covers explicitly listed .cu/.cpp files; headers (.h, .cuh,
+  # .hpp) are globbed from BASE_DIR since they are not enumerated in SOURCES.
+  function(TE_AddHipifyDeps SOURCES BASE_DIR)
+      set(_deps)
+      foreach(_src ${SOURCES})
+          get_filename_component(_abs "${BASE_DIR}/${_src}" ABSOLUTE)
+          list(APPEND _deps "${_abs}")
+      endforeach()
+      file(GLOB _hdrs
+          "${BASE_DIR}/*.h"
+          "${BASE_DIR}/*.cuh"
+          "${BASE_DIR}/*.hpp"
+      )
+      list(APPEND _deps ${_hdrs})
+      set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${_deps})
+  endfunction()
 endif()
 
 add_subdirectory(operator)

--- a/tests/cpp/operator/CMakeLists.txt
+++ b/tests/cpp/operator/CMakeLists.txt
@@ -46,6 +46,7 @@ if(USE_CUDA)
   add_executable(test_operator ${test_cuda_sources})
 else()
   TE_GetHipifiedSources("${test_cuda_sources}" ${CMAKE_CURRENT_SOURCE_DIR} test_hip_sources)
+  TE_AddHipifyDeps("${test_cuda_sources}" ${CMAKE_CURRENT_SOURCE_DIR})
   message("${message_line}")
   message(STATUS "test_operator hipified sources: ${test_hip_sources}")
 

--- a/tests/cpp/util/CMakeLists.txt
+++ b/tests/cpp/util/CMakeLists.txt
@@ -12,6 +12,7 @@ if(USE_CUDA)
     add_executable(test_util ${test_cuda_sources})
 else()  
     TE_GetHipifiedSources("${test_cuda_sources}" ${CMAKE_CURRENT_SOURCE_DIR} test_hip_sources)
+    TE_AddHipifyDeps("${test_cuda_sources}" ${CMAKE_CURRENT_SOURCE_DIR})
     message("${message_line}")
     message(STATUS "test_util hipified sources: ${test_hip_sources}")
 


### PR DESCRIPTION
# Description

Register original sources as CMAKE_CONFIGURE_DEPENDS so that editing them triggers automatic re-configuration and re-hipification during incremental builds.

Avoids having to run e.g. `cmake -GNinja -Bbuild` or `touch CMakeLists.txt` on every change before `cmake --build build`, which is easy to forget and not necessary in upstream.

Same issue with `Ninja` and `Unix Makefiles` generators.

Before:

```bash
$ touch tests/cpp/operator/test_cublaslt_gemm.cu

# No re-hipification/rebuild of test_cublaslt_gemm.cu:
$ cmake --build build  # same issue when using ninja to build
[  4%] Built target gtest
[  9%] Built target gmock
[ 13%] Built target gmock_main
[ 18%] Built target gtest_main
[ 90%] Built target test_operator
[100%] Built target test_util
$
```

After:

```bash
$ touch tests/cpp/operator/test_cublaslt_gemm.cu

# Re-hipification/rebuild of test_cublaslt_gemm.cu:
$ cmake --build build
Using AMD Platform
-------------------------------------------------------------
-- USE_CUDA OFF
-- USE_ROCM ON
-- Found transformer_engine library: /dockerx/TransformerEngine/libtransformer_engine.so
Successfully preprocessed all matching files.
Hipifying sources in /dockerx/TransformerEngine/tests/cpp with TE root /dockerx/TransformerEngine, saving results to /dockerx/TransformerEngine/tests/cpp/build/hipify_result.json
Run hipify on /dockerx/TransformerEngine/tests/cpp
Getting hipified sources from /dockerx/TransformerEngine/tests/cpp/build/hipify_result.json and updating /dockerx/TransformerEngine/tests/cpp/build/source_list_RnZmOrnS.txt with base path /dockerx/TransformerEngine/tests/cpp/operator
-------------------------------------------------------------
-- test_operator hipified sources: test_cast_mxfp8_gated_swiglu.hip;test_multi_unpadding.hip;test_transpose.hip;test_cast_current_scaling.hip;test_cublaslt_gemm.hip;test_cast_dbias_dgelu.hip;test_cast_nvfp4_transpose.hip;test_dequantize_nvfp4.hip;test_gemm_prodgemm.hip;test_multi_padding.hip;test_cast.hip;test_cast_dbias.hip;test_normalization.hip;test_normalization_mxfp8.hip;test_swap_first_dims.hip;test_cast_transpose_dbias_dgelu.hip;test_cast_transpose_dbias.hip;test_cast_transpose_dgeglu.hip;test_cast_mxfp8.hip;test_memset.hip;test_cast_transpose.hip;test_multi_cast_transpose.hip;test_qdq.hip;test_causal_softmax.hip;test_cast_gated_swiglu.hip;test_cast_mxfp4_transpose.hip;test_act.hip;test_cast_transpose_current_scaling.hip;../test_common.hip;test_dequantize_mxfp8.hip;
Getting hipified sources from /dockerx/TransformerEngine/tests/cpp/build/hipify_result.json and updating /dockerx/TransformerEngine/tests/cpp/build/source_list_xkUCeclP.txt with base path /dockerx/TransformerEngine/tests/cpp/util
-------------------------------------------------------------
-- test_util hipified sources: test_nvrtc_hip.cpp;test_string.cpp;../test_common.hip;
-- Configuring done (3.4s)
-- Generating done (0.0s)
-- Build files have been written to: /dockerx/TransformerEngine/tests/cpp/build
[  4%] Built target gtest
[  9%] Built target gmock
[ 13%] Built target gmock_main
[ 18%] Built target gtest_main
[ 20%] Building HIP object operator/CMakeFiles/test_operator.dir/test_cublaslt_gemm.hip.o
[ 23%] Linking HIP executable test_operator
[ 90%] Built target test_operator
[ 93%] Linking HIP executable test_util
[100%] Built target test_util
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
