### PR TITLE
rocm-ci: scope test container to pod-allocated GPUs

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -144,15 +144,28 @@ jobs:
 
       - name: Run Container
         run: |
+          # All GPUs are visible to the runner; per-suite visibility is set later
+          # via HIP_VISIBLE_DEVICES in the test step. Add render group for the
+          # container. Under kubernetes, GPU isolation comes from DEVICE_FLAG:
+          # the runner writes this pod's allocated render devices into
+          # /etc/podinfo/gha-render-devices; fall back to all GPUs on bare metal.
+          render_gid=$(cat /etc/group | grep render | cut -d: -f3)
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+          # --group-add daemon/bin cover the video-group GID -> subgid 1 mapping
+          # across Ubuntu 24.04 / AlmaLinux base images. /dev/kfd is the single
+          # system-wide compute node and is always required.
+          GPU_FLAG="--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
           docker run -dt \
             --rm \
             --name te-runner \
             --network=host \
-            --device=/dev/dri --device=/dev/kfd \
+            $GPU_FLAG \
             --shm-size=16G \
             --pid=host \
-            --group-add $(getent group render | cut -d: -f3) \
-            --group-add $(getent group video | cut -d: -f3) \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ${{ needs.select_image.outputs.image-tag }}
@@ -341,15 +354,28 @@ jobs:
 
       - name: Run Container
         run: |
+          # All GPUs are visible to the runner; per-suite visibility is set later
+          # via HIP_VISIBLE_DEVICES in the test step. Add render group for the
+          # container. Under kubernetes, GPU isolation comes from DEVICE_FLAG:
+          # the runner writes this pod's allocated render devices into
+          # /etc/podinfo/gha-render-devices; fall back to all GPUs on bare metal.
+          render_gid=$(cat /etc/group | grep render | cut -d: -f3)
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+          # --group-add daemon/bin cover the video-group GID -> subgid 1 mapping
+          # across Ubuntu 24.04 / AlmaLinux base images. /dev/kfd is the single
+          # system-wide compute node and is always required.
+          GPU_FLAG="--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
           docker run -dt \
             --rm \
             --name te-runner \
             --network=host \
-            --device=/dev/dri --device=/dev/kfd \
+            $GPU_FLAG \
             --shm-size=16G \
             --pid=host \
-            --group-add $(getent group render | cut -d: -f3) \
-            --group-add $(getent group video | cut -d: -f3) \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ${{ needs.select_image.outputs.image-tag }}

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -142,30 +142,20 @@ jobs:
         run: |
           docker pull ${{ needs.select_image.outputs.image-tag }}
 
-      - name: Run Container
+      - &run_container
+        name: Run Container
         run: |
-          # All GPUs are visible to the runner; per-suite visibility is set later
-          # via HIP_VISIBLE_DEVICES in the test step. Add render group for the
-          # container. Under kubernetes, GPU isolation comes from DEVICE_FLAG:
-          # the runner writes this pod's allocated render devices into
-          # /etc/podinfo/gha-render-devices; fall back to all GPUs on bare metal.
-          render_gid=$(cat /etc/group | grep render | cut -d: -f3)
-          if [ -f "/etc/podinfo/gha-render-devices" ]; then
-            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
-          else
-            DEVICE_FLAG="--device /dev/dri"
-          fi
-          # --group-add daemon/bin cover the video-group GID -> subgid 1 mapping
-          # across Ubuntu 24.04 / AlmaLinux base images. /dev/kfd is the single
-          # system-wide compute node and is always required.
-          GPU_FLAG="--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+          DEVICE_FLAG="$(cat /etc/podinfo/gha-render-devices 2>/dev/null || echo --device=/dev/dri)"
+          test -n "$DEVICE_FLAG"
           docker run -dt \
             --rm \
             --name te-runner \
             --network=host \
-            $GPU_FLAG \
+            --device=/dev/kfd $DEVICE_FLAG \
             --shm-size=16G \
             --pid=host \
+            --group-add $(getent group render | cut -d: -f3) \
+            --group-add $(getent group video | cut -d: -f3) \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ${{ needs.select_image.outputs.image-tag }}
@@ -352,33 +342,7 @@ jobs:
         run: |
           docker pull ${{ needs.select_image.outputs.image-tag }}
 
-      - name: Run Container
-        run: |
-          # All GPUs are visible to the runner; per-suite visibility is set later
-          # via HIP_VISIBLE_DEVICES in the test step. Add render group for the
-          # container. Under kubernetes, GPU isolation comes from DEVICE_FLAG:
-          # the runner writes this pod's allocated render devices into
-          # /etc/podinfo/gha-render-devices; fall back to all GPUs on bare metal.
-          render_gid=$(cat /etc/group | grep render | cut -d: -f3)
-          if [ -f "/etc/podinfo/gha-render-devices" ]; then
-            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
-          else
-            DEVICE_FLAG="--device /dev/dri"
-          fi
-          # --group-add daemon/bin cover the video-group GID -> subgid 1 mapping
-          # across Ubuntu 24.04 / AlmaLinux base images. /dev/kfd is the single
-          # system-wide compute node and is always required.
-          GPU_FLAG="--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
-          docker run -dt \
-            --rm \
-            --name te-runner \
-            --network=host \
-            $GPU_FLAG \
-            --shm-size=16G \
-            --pid=host \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            ${{ needs.select_image.outputs.image-tag }}
+      - *run_container
 
       - name: Install packages
         env:


### PR DESCRIPTION
The sGPU/mGPU jobs launched the test container with '--device=/dev/dri --device=/dev/kfd', exposing ALL host GPUs to the nested (privileged-dind) container. Combined with the hard-coded absolute HIP_VISIBLE_DEVICES=0..3, two jobs co-scheduled on the same node both pinned physical GPUs 0-3 and collided (OOM/hangs/test failures) while GPUs 4-7 sat idle. Jobs only passed when the node was otherwise idle -- arch-independent (seen on mi300x and mi35x).

Forward only the GPUs the AMD device plugin allocated to this pod: it restricts /dev/dri/renderD*+card* in the runner container to the pod's GPUs, so enumerate those and pass only them. /dev/kfd (single system-wide compute node) is always passed. Fail fast if zero GPUs are allocated.

The container now sees only its allocated GPUs as 0..N-1, so the existing per-suite HIP_VISIBLE_DEVICES=0/1/2/3 split is correct and collision-free across co-scheduled pods.