### PR TITLE
[ROCm] Fix biased wgrad with fp32 gradient accumulation

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1410,10 +1410,6 @@ def test_linear_accuracy_delay_wgrad_compute(dtype, bs, model, bias, fuse_wgrad_
 
     config = model_configs[model]
 
-    if IS_HIP_EXTENSION:
-        if dtype not in (torch.float32,) and fuse_wgrad_accumulation and bias:
-            pytest.skip(f"ROCm does not support fused wgrad accumulation for {dtype}.")
-
     te_linear_ref = Linear(
         config.hidden_size,
         4 * config.hidden_size,

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1704,9 +1704,6 @@ def test_layernorm_linear_accuracy(
 def test_layernorm_linear_accuracy_delay_wgrad_compute(
     dtype, bs, model, normalization, zero_centered_gamma, bias, fuse_wgrad_accumulation
 ):
-    if IS_HIP_EXTENSION:
-        if dtype not in (torch.float32,) and fuse_wgrad_accumulation and bias:
-            pytest.skip(f"ROCm does not support fused wgrad accumulation for {dtype}.")
     if NVTE_TEST_NVINSPECT_ENABLED:
         pytest.skip("Delayed wgrad compute is not supported in debug mode.")
 
@@ -1927,10 +1924,6 @@ def test_layernorm_mlp_accuracy_delay_wgrad_compute(
         pytest.skip("Delayed wgrad compute is not supported in debug mode.")
 
     config = model_configs[model]
-
-    if IS_HIP_EXTENSION:
-        if dtype not in (torch.float32,) and fuse_wgrad_accumulation and bias:
-            pytest.skip(f"ROCm does not support fused wgrad accumulation for {dtype}.")
 
     ln_mlp = LayerNormMLP(
         hidden_size=config.hidden_size,

--- a/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -431,6 +431,27 @@ def general_gemm(
         )
         out_dtype = torch.bfloat16 if use_bf16_tn_output_workaround else out_dtype
 
+    # ROCm: hipBLASLt has no algorithm for a bf16 -> fp32-accumulate wgrad GEMM
+    # that also fuses the bias-gradient (BGRADB) epilogue; the heuristic returns
+    # no algorithms and the GEMM raises "Unable to find any suitable algorithms".
+    # Run the GEMM with the default epilogue (no fused bias grad) and reduce the
+    # bias gradient separately afterwards. Every wgrad path (Linear,
+    # LayerNormLinear, LayerNormMLP, and the delayed-wgrad store) reads the bias
+    # gradient from this function's return value, so handling it here covers them
+    # all. Gated on ROCm + bias-grad (grad + bias) + fp32 main_grad accumulate +
+    # non-quantized, so CUDA, the forward bias-add path (grad=False) and fp8/fp4
+    # are untouched.
+    rocm_split_dbias = (
+        IS_HIP_EXTENSION
+        and grad
+        and bias is not None
+        and accumulate
+        and out is not None
+        and out.dtype == torch.float32
+        and quantization_params is None
+    )
+    gemm_bias = None if rocm_split_dbias else bias
+
     args = (
         A,
         transa,  # transa
@@ -439,7 +460,7 @@ def general_gemm(
         out,
         quantization_params,
         TE_DType[out_dtype] if out_dtype is not None else None,
-        bias,
+        gemm_bias,
         bias_dtype,
         gelu,
         gelu_in,
@@ -459,6 +480,12 @@ def general_gemm(
     }
 
     out, bias_grad, gelu_input, extra_output = tex.generic_gemm(*args, **kwargs)
+
+    if rocm_split_dbias:
+        # dbias = column-sum of grad_output (operand B) over tokens, accumulated
+        # in fp32 and cast to the bias dtype to match the fused BGRADB epilogue
+        # this replaces.
+        bias_grad = B.reshape(-1, B.shape[-1]).sum(dim=0, dtype=torch.float32).to(bias.dtype)
 
     if IS_HIP_EXTENSION and use_bf16_tn_output_workaround:
         out = cast_if_needed(out, torch.float32)

--- a/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -431,14 +431,12 @@ def general_gemm(
         )
         out_dtype = torch.bfloat16 if use_bf16_tn_output_workaround else out_dtype
 
-    # hipBLASLt has no algorithm for the fused bias-grad (BGRADB) epilogue on a
-    # bf16 -> fp32-accumulate wgrad GEMM, so split it: run the GEMM without the
-    # fused dbias and reduce the bias gradient separately below.
+    # hipBLASLt has no fused bias-grad (BGRADB) algorithm for an fp32-output wgrad GEMM, so skip the fused dbias and reduce grad_output below.
     rocm_split_dbias = (
         IS_HIP_EXTENSION
         and grad
         and bias is not None
-        and accumulate
+        and not gelu
         and out is not None
         and out.dtype == torch.float32
         and quantization_params is None
@@ -475,7 +473,6 @@ def general_gemm(
     out, bias_grad, gelu_input, extra_output = tex.generic_gemm(*args, **kwargs)
 
     if rocm_split_dbias:
-        # dbias = column-sum of grad_output over tokens, in fp32, cast to bias dtype.
         bias_grad = B.reshape(-1, B.shape[-1]).sum(dim=0, dtype=torch.float32).to(bias.dtype)
 
     if IS_HIP_EXTENSION and use_bf16_tn_output_workaround:

--- a/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -431,16 +431,9 @@ def general_gemm(
         )
         out_dtype = torch.bfloat16 if use_bf16_tn_output_workaround else out_dtype
 
-    # ROCm: hipBLASLt has no algorithm for a bf16 -> fp32-accumulate wgrad GEMM
-    # that also fuses the bias-gradient (BGRADB) epilogue; the heuristic returns
-    # no algorithms and the GEMM raises "Unable to find any suitable algorithms".
-    # Run the GEMM with the default epilogue (no fused bias grad) and reduce the
-    # bias gradient separately afterwards. Every wgrad path (Linear,
-    # LayerNormLinear, LayerNormMLP, and the delayed-wgrad store) reads the bias
-    # gradient from this function's return value, so handling it here covers them
-    # all. Gated on ROCm + bias-grad (grad + bias) + fp32 main_grad accumulate +
-    # non-quantized, so CUDA, the forward bias-add path (grad=False) and fp8/fp4
-    # are untouched.
+    # hipBLASLt has no algorithm for the fused bias-grad (BGRADB) epilogue on a
+    # bf16 -> fp32-accumulate wgrad GEMM, so split it: run the GEMM without the
+    # fused dbias and reduce the bias gradient separately below.
     rocm_split_dbias = (
         IS_HIP_EXTENSION
         and grad
@@ -482,9 +475,7 @@ def general_gemm(
     out, bias_grad, gelu_input, extra_output = tex.generic_gemm(*args, **kwargs)
 
     if rocm_split_dbias:
-        # dbias = column-sum of grad_output (operand B) over tokens, accumulated
-        # in fp32 and cast to the bias dtype to match the fused BGRADB epilogue
-        # this replaces.
+        # dbias = column-sum of grad_output over tokens, in fp32, cast to bias dtype.
         bias_grad = B.reshape(-1, B.shape[-1]).sum(dim=0, dtype=torch.float32).to(bias.dtype)
 
     if IS_HIP_EXTENSION and use_bf16_tn_output_workaround:

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -892,6 +892,19 @@ class _LayerNormLinear(torch.autograd.Function):
                         dgrad_shape, dtype=ctx.activation_dtype, device=grad_outputs[0].device
                     )
 
+                # ROCm hipBLASLt has no algorithm for a bf16 -> fp32-accumulate wgrad
+                # GEMM that also fuses the bias-gradient (BGRADB) epilogue, so the
+                # heuristic returns no algorithms and the GEMM raises. When wgrad is
+                # accumulated into an fp32 main_grad on ROCm, skip the fusion and
+                # reduce grad_bias separately below.
+                rocm_unfuse_dbias = (
+                    IS_HIP_EXTENSION
+                    and accumulate_wgrad_into_param_main_grad
+                    and grad_bias is None
+                    and not ctx.fp8
+                    and bias is not None
+                )
+
                 # Arguments to include in wgrad GEMM closure
                 wgrad_gemm_kwargs = {
                     "out_dtype": (
@@ -905,7 +918,11 @@ class _LayerNormLinear(torch.autograd.Function):
                     ),
                     "layout": "NT",
                     "out": main_grad if ctx.fuse_wgrad_accumulation else None,
-                    "bias": (bias if (grad_bias is None and not ctx.fp8) else None),
+                    "bias": (
+                        bias
+                        if (grad_bias is None and not ctx.fp8 and not rocm_unfuse_dbias)
+                        else None
+                    ),
                     "use_split_accumulator": use_split_accumulator,
                     "grad": True,
                     "ub": ub_obj_wgrad,
@@ -951,7 +968,16 @@ class _LayerNormLinear(torch.autograd.Function):
 
                     # Update grad bias if needed
                     if grad_bias is None:
-                        grad_bias = grad_bias_
+                        if rocm_unfuse_dbias:
+                            # Fused dbias was suppressed for the ROCm fp32-accumulate
+                            # path; reduce it here (fp32 accumulate, cast to bias dtype).
+                            grad_bias = (
+                                grad_output.reshape(-1, grad_output.shape[-1])
+                                .sum(dim=0, dtype=torch.float32)
+                                .to(bias.dtype)
+                            )
+                        else:
+                            grad_bias = grad_bias_
                     del grad_bias_
 
                     # Deallocate input tensors if permitted

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -892,19 +892,6 @@ class _LayerNormLinear(torch.autograd.Function):
                         dgrad_shape, dtype=ctx.activation_dtype, device=grad_outputs[0].device
                     )
 
-                # ROCm hipBLASLt has no algorithm for a bf16 -> fp32-accumulate wgrad
-                # GEMM that also fuses the bias-gradient (BGRADB) epilogue, so the
-                # heuristic returns no algorithms and the GEMM raises. When wgrad is
-                # accumulated into an fp32 main_grad on ROCm, skip the fusion and
-                # reduce grad_bias separately below.
-                rocm_unfuse_dbias = (
-                    IS_HIP_EXTENSION
-                    and accumulate_wgrad_into_param_main_grad
-                    and grad_bias is None
-                    and not ctx.fp8
-                    and bias is not None
-                )
-
                 # Arguments to include in wgrad GEMM closure
                 wgrad_gemm_kwargs = {
                     "out_dtype": (
@@ -918,11 +905,7 @@ class _LayerNormLinear(torch.autograd.Function):
                     ),
                     "layout": "NT",
                     "out": main_grad if ctx.fuse_wgrad_accumulation else None,
-                    "bias": (
-                        bias
-                        if (grad_bias is None and not ctx.fp8 and not rocm_unfuse_dbias)
-                        else None
-                    ),
+                    "bias": (bias if (grad_bias is None and not ctx.fp8) else None),
                     "use_split_accumulator": use_split_accumulator,
                     "grad": True,
                     "ub": ub_obj_wgrad,
@@ -968,16 +951,7 @@ class _LayerNormLinear(torch.autograd.Function):
 
                     # Update grad bias if needed
                     if grad_bias is None:
-                        if rocm_unfuse_dbias:
-                            # Fused dbias was suppressed for the ROCm fp32-accumulate
-                            # path; reduce it here (fp32 accumulate, cast to bias dtype).
-                            grad_bias = (
-                                grad_output.reshape(-1, grad_output.shape[-1])
-                                .sum(dim=0, dtype=torch.float32)
-                                .to(bias.dtype)
-                            )
-                        else:
-                            grad_bias = grad_bias_
+                        grad_bias = grad_bias_
                     del grad_bias_
 
                     # Deallocate input tensors if permitted


### PR DESCRIPTION
## Problem

On ROCm, hipBLASLt cannot find a suitable algorithm for an fp32 weight gradient GEMM with fused bias gradient computation.

This causes training with --add-qkv-bias and --accumulate-allreduce-grads-in-fp32 to fail with:

```text
RuntimeError: Unable to find any suitable algorithms
```

## Fix

Run the weight gradient GEMM without the fused bias gradient and compute the bias gradient separately by summing grad_output.

The fix is implemented in general_gemm, covering delayed weight gradient execution and other callers using the same path. CUDA behavior is unchanged.

## Testing

Verified on MI350X:

- The isolated reproduction passes.
- Qwen2.5-0.5B GSM8K training passes the previously failing backward step.
- Re-enabled the ROCm wgrad numerics tests previously skipped by grouped GEMM change 434:
  - test_linear_accuracy_delay_wgrad_compute
  - test_layernorm_linear_accuracy_delay_wgrad_compute
  - test_layernorm_mlp_accuracy_delay_wgrad_compute

  All three use general_gemm.

Result:

```text
132 passed, 0 skipped, 0 failed
```
