### PR TITLE
Added sidecar mechanism for hard-fault-/thread-kill-tolerant CI test logging

### DIFF
--- a/ci/_utils.sh
+++ b/ci/_utils.sh
@@ -228,6 +228,35 @@ get_pytest_junitxml() {
     fi
 }
 
+# Pytest can exit *before* it writes its --junitxml report: a usage error
+# (exit 4), a conftest import failure, a hard per-test timeout that os._exit()s
+# the process, or a segfault/OOM-kill during collection. The file then silently
+# never appears, junit_report.py only sees the other (passing) files' XML, and
+# the job summary shows green even though pytest_run already recorded the failure
+# via test_run_error. Synthesize a minimal JUnit XML for the missing file so the
+# report surfaces it as an error instead of dropping it (keeps the summary
+# consistent with the suite exit-code gate).
+# args: test_name_tag exit_code
+write_missing_junitxml() {
+    test -n "$JUNITXML_PREFIX$JUNITXML_SUFFIX" || return 0   # XML not requested (local run)
+    _missing_xml="$JUNITXML_PREFIX$1$JUNITXML_SUFFIX"
+    test -s "$_missing_xml" && return 0   # pytest already wrote a (non-empty) report
+    # A non-empty sidecar means te_ci_result_sink captured per-test progress;
+    # junit_report.py reconstructs the run from it, so don't shadow that richer
+    # record with a coarse whole-file stub.
+    test -s "$_missing_xml.partial" && return 0
+    mkdir -p "$(dirname "$_missing_xml")" 2>/dev/null
+    # Keep the words 'timeout'/'timed out' out of this message: junit_report.py's
+    # is_timeout() substring-matches the message and would mislabel the entry.
+    _missing_msg="pytest exited $2 without writing JUnit XML (crash, usage/conftest error, or process hard-exit before reporting); see the suite .log artifact"
+    cat > "$_missing_xml" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1">
+<testcase classname="$1" name="(no JUnit XML written)"><error message="$_missing_msg"></error></testcase>
+</testsuite></testsuites>
+EOF
+}
+
 get_ctest_junitxml() {
     if [ -n "$JUNITXML_PREFIX$JUNITXML_SUFFIX" ]; then
         echo "--output-junit ${JUNITXML_PREFIX}$1${JUNITXML_SUFFIX}"
@@ -294,10 +323,31 @@ pytest_run() {
     # A per-test timeout is applied to every item. Callers may still append their
     # own --timeout/--timeout-method (e.g. distributed tests); since argparse
     # takes the last value, a caller-supplied override wins over these defaults.
-    python3 -m pytest -v -rfEs \
+    #
+    # te_ci_result_sink streams per-test progress to a <junitxml>.partial sidecar
+    # so a hard --timeout-method=thread exit (or segfault/OOM) that skips pytest's
+    # end-of-session JUnit XML write stays reconstructable by junit_report.py
+    # instead of vanishing from the summary. Enabled only when JUnit XML is
+    # requested (CI); a plain local run is unaffected.
+    _junitxml_arg=`get_pytest_junitxml $_test_name_tag`
+    _sink_plugin=""
+    _result_sink=""
+    _pytest_pythonpath="$PYTHONPATH"
+    if [ -n "$_junitxml_arg" ]; then
+        _result_sink="${JUNITXML_PREFIX}${_test_name_tag}${JUNITXML_SUFFIX}.partial"
+        rm -f "$_result_sink" 2>/dev/null
+        _sink_plugin="-p te_ci_result_sink"
+        _pytest_pythonpath="${TE_PATH}ci${PYTHONPATH:+:$PYTHONPATH}"
+    fi
+    TE_RESULT_SINK="$_result_sink" PYTHONPATH="$_pytest_pythonpath" \
+        python3 -m pytest -v -rfEs \
         --timeout=$PYTEST_TIMEOUT --timeout-method=$PYTEST_TIMEOUT_METHOD \
-        `get_pytest_junitxml $_test_name_tag` $TEST_PYTEST_ARGS "$TEST_DIR/$@"
-    test $? -eq 0 || test_run_error "[$_test_variant_tag] $1"
+        $_sink_plugin $_junitxml_arg $TEST_PYTEST_ARGS "$TEST_DIR/$@"
+    _pytest_rc=$?
+    if [ $_pytest_rc -ne 0 ]; then
+        test_run_error "[$_test_variant_tag] $1"
+        write_missing_junitxml "$_test_name_tag" "$_pytest_rc"
+    fi
     echo "Done [$_test_variant_tag] $1 in `time_elapsed $_start_ts`"
 }
 

--- a/ci/junit_report.py
+++ b/ci/junit_report.py
@@ -23,6 +23,7 @@ Design notes:
 """
 
 import glob
+import json
 import os
 import sys
 import xml.etree.ElementTree as ET
@@ -86,6 +87,76 @@ def is_timeout(testcase, message):
     return "timeout" in blob or "timed out" in blob
 
 
+_HARDEXIT_MSG = (
+    "did not finish: process hard-exited while running this test "
+    "(per-test timeout, segfault, or OOM); see the suite .log"
+)
+
+
+def reconstruct_from_partial(path):
+    """Rebuild per-test results from a te_ci_result_sink ``.partial`` sidecar.
+
+    Used when a pytest process hard-exited (thread-method timeout, segfault,
+    OOM) before writing its JUnit XML: the NDJSON sidecar still holds every
+    completed outcome plus the test that was in flight when the process died.
+
+    Returns ``(counts, failures)`` where ``counts`` is a status->int mapping and
+    ``failures`` is a list of ``(testid, label, message)``. The single still-
+    running test (started but with no terminal phase) is surfaced as a timeout.
+    Returns ``(None, None)`` if the sidecar can't be read at all.
+    """
+    starts = []
+    phases = defaultdict(dict)   # nodeid -> {when: outcome}
+    msgs = {}                    # nodeid -> first-line failure message
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue     # tolerate a half-written final line
+                if rec.get("e") == "start":
+                    starts.append(rec.get("nodeid", ""))
+                elif rec.get("e") == "report":
+                    nid = rec.get("nodeid", "")
+                    phases[nid][rec.get("when", "")] = rec.get("outcome", "")
+                    if rec.get("msg"):
+                        msgs[nid] = rec["msg"]
+    except OSError:
+        return None, None
+
+    counts = defaultdict(int)
+    failures = []
+    completed = set()
+    for nid, when_outcome in phases.items():
+        if "call" in when_outcome:
+            status = {"passed": "passed", "failed": "failed",
+                      "skipped": "skipped"}.get(when_outcome["call"], "failed")
+        elif when_outcome.get("setup") == "failed" or when_outcome.get("teardown") == "failed":
+            status = "error"
+        elif when_outcome.get("setup") == "skipped":
+            status = "skipped"
+        else:
+            continue   # started but no terminal phase -> handled as in-flight below
+        completed.add(nid)
+        counts[status] += 1
+        if status in ("failed", "error"):
+            failures.append((nid, status, msgs.get(nid, "")))
+
+    # Any test that started but never reached a terminal phase was running when
+    # the process died -- the hung/crashing test.
+    for nid in starts:
+        if nid and nid not in completed:
+            completed.add(nid)
+            counts["error"] += 1
+            failures.append((nid, "timeout", _HARDEXIT_MSG))
+
+    return counts, failures
+
+
 def emit(lines):
     """Append the report to the step summary if available, else stdout."""
     text = "\n".join(lines) + "\n"
@@ -107,11 +178,14 @@ def main():
         title = sys.argv[sys.argv.index("--title") + 1]
 
     xml_files = sorted(glob.glob(os.path.join(results_dir, "*.xml")))
+    # Sidecars left behind by te_ci_result_sink when a run hard-exited before
+    # writing its JUnit XML (glob.glob("*.xml") does not match "*.xml.partial").
+    partial_files = sorted(glob.glob(os.path.join(results_dir, "*.xml.partial")))
 
     lines = []
     lines.append(f"## {title}\n")
 
-    if not xml_files:
+    if not xml_files and not partial_files:
         lines.append(
             "> :warning: **No JUnit XML files were produced.** No test file "
             "completed far enough to write results -- the run likely crashed or "
@@ -124,9 +198,11 @@ def main():
     totals = defaultdict(float)  # passed/failed/error/skipped/timeout/incomplete/time
     per_file = []                # (name, counts, time)
     failures = []                # (file, testid, label, message)
+    seen_tags = set()            # tags already produced by a JUnit XML
 
     for xf in xml_files:
         name = os.path.basename(xf)[: -len(".xml")]
+        seen_tags.add(name)
         counts = defaultdict(int)
         suite_time = 0.0
 
@@ -165,6 +241,36 @@ def main():
         totals["time"] += suite_time
         per_file.append((name, counts, suite_time))
 
+    # Reconstruct any file that hard-exited before writing JUnit XML from its
+    # sidecar. A leftover .partial only exists when the session never finished
+    # cleanly (te_ci_result_sink deletes it on a clean end), so it always wins
+    # over the coarse stub the shell would otherwise emit -- but a tag already
+    # covered by real XML (pathological race) is left to the XML above.
+    for pf in partial_files:
+        name = os.path.basename(pf)[: -len(".xml.partial")]
+        if name in seen_tags:
+            continue
+        seen_tags.add(name)
+        if os.path.getsize(pf) == 0:
+            continue   # empty sidecar -> the shell's whole-file stub covers it
+        counts, local_failures = reconstruct_from_partial(pf)
+        if counts is None:
+            counts = defaultdict(int)
+            counts["incomplete"] = 1
+            totals["incomplete"] += 1
+            failures.append((name, "(whole file)", "incomplete",
+                             "unreadable result sidecar"))
+            per_file.append((name, counts, 0.0))
+            continue
+        for status, n in counts.items():
+            totals[status] += n
+        for testid, label, msg in local_failures:
+            if label == "timeout":
+                totals["timeout"] += 1
+            failures.append((name, testid, label,
+                             msg.splitlines()[0] if msg else ""))
+        per_file.append((name, counts, 0.0))
+
     n_pass = int(totals["passed"])
     n_fail = int(totals["failed"])
     n_err = int(totals["error"])
@@ -183,7 +289,7 @@ def main():
         summary_line += f" ({n_to} timed out)"
     if n_incomplete:
         summary_line += f"; **{n_incomplete} file(s) incomplete**"
-    summary_line += f" -- {totals['time']:.0f}s across {len(xml_files)} files\n"
+    summary_line += f" -- {totals['time']:.0f}s across {len(per_file)} files\n"
     lines.append(summary_line)
 
     # Per-file breakdown (collapsed to keep the summary scannable).

--- a/ci/te_ci_result_sink.py
+++ b/ci/te_ci_result_sink.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Incremental pytest result sink for crash/hang-resilient CI reporting.
+
+pytest writes its ``--junitxml`` report only once, at session end. A per-test
+``--timeout-method=thread`` firing, a segfault, or an OOM-kill calls
+``os._exit`` (or is SIGKILLed) and skips that finalization, so the JUnit XML for
+the whole file is lost -- including tests that already passed. junit_report.py
+then sees no XML for the file and the job summary shows green despite the crash.
+
+This plugin streams each test's progress to a sidecar NDJSON file (one JSON
+object per line, flushed immediately) named ``<junitxml>.partial``. If the
+process dies mid-file the sidecar survives, and junit_report.py reconstructs the
+results from it: every completed outcome is preserved and the test that was in
+flight when the process died is surfaced as a timeout/crash.
+
+On a clean session end the sidecar is deleted (the real JUnit XML is
+authoritative), so a leftover ``.partial`` is itself the signal that the run did
+not finish.
+
+Activated only when ``TE_RESULT_SINK`` is set (done by ci/_utils.sh::pytest_run
+whenever JUnit XML output is requested); a no-op otherwise.
+"""
+
+import json
+import os
+
+# Captured at import time; ci/_utils.sh sets it inline for the pytest process.
+_SINK_PATH = os.environ.get("TE_RESULT_SINK") or None
+
+
+def _append(record):
+    """Append one NDJSON record and flush so it survives a hard process exit."""
+    if not _SINK_PATH:
+        return
+    try:
+        with open(_SINK_PATH, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+            fh.flush()  # push to the OS so os._exit()/SIGKILL still leaves it on disk
+    except OSError:
+        pass  # bookkeeping must never break the test run
+
+
+def pytest_runtest_logstart(nodeid, location):
+    _append({"e": "start", "nodeid": nodeid})
+
+
+def pytest_runtest_logreport(report):
+    record = {
+        "e": "report",
+        "nodeid": report.nodeid,
+        "when": report.when,
+        "outcome": report.outcome,
+    }
+    if report.outcome == "failed" and report.longrepr is not None:
+        # First line of the failure repr -- enough to identify it in the digest.
+        first = str(report.longrepr).strip().splitlines()
+        if first:
+            record["msg"] = first[0][:500]
+    _append(record)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Clean session end: the real JUnit XML is authoritative, drop the sidecar.
+    if _SINK_PATH and os.path.exists(_SINK_PATH):
+        try:
+            os.remove(_SINK_PATH)
+        except OSError:
+            pass


### PR DESCRIPTION
# Description

The CI test summary (`junit_report.py`) is a pure aggregator of JUnit XML files, but pytest writes its `--junitxml` only at session end so a `--timeout-method=thread` firing, segfault, or OOM-kill that `os._exit()`s the process produces **no** XML for that file, and the summary silently drops it and shows green even though the suite exit-code gate correctly fails.

This change closes that gap on two levels: 

(1) a new `te_ci_result_sink` pytest plugin streams each test's progress to a `<junitxml>.partial` sidecar (flushed per line, deleted on clean exit), which `junit_report.py` reconstructs when a run hard-exits, preserving pre-crash passes and surfacing the in-flight test as a `[timeout]`

(2) as a floor, `pytest_run` now synthesizes a minimal error report when pytest exits non-zero without writing any XML at all (e.g. usage/conftest-import errors before the plugin loads), so the summary always stays consistent with the pass/fail gate. Verified end-to-end against real thread-method timeouts, conftest errors, normal failures, and clean passes.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
