### PR TITLE
reuse warmup stream for graph capture

### DIFF
--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -451,7 +451,9 @@ def _make_graphed_callables(
     need_bwd_dw_graph = {}
 
     # Run warmup and do the above filtering.
-    with torch.cuda.stream(torch.cuda.Stream()):
+    # ROCm: reuse warmup stream for graph capture (ROCM-25129)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
         for func_idx, func in zip(warmup_func_idx, warmup_func):
             args = sample_args[func_idx]
             kwargs = sample_kwargs[func_idx]
@@ -587,7 +589,7 @@ def _make_graphed_callables(
                     args = sample_args[per_callable_fwd_idx]
                     kwargs = sample_kwargs[per_callable_fwd_idx]
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
-                    with _graph_context_wrapper(fwd_graph, pool=mempool):
+                    with _graph_context_wrapper(fwd_graph, stream=stream, pool=mempool):
                         outputs = func(*args, **kwargs)
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
@@ -650,7 +652,7 @@ def _make_graphed_callables(
                                 "No module needs wgrad computation but get float in order"
                             )
                         bwd_dw_graph = bwd_dw_graphs[per_callable_bwd_idx]
-                        with _graph_context_wrapper(bwd_dw_graph, pool=mempool):
+                        with _graph_context_wrapper(bwd_dw_graph, stream=stream, pool=mempool):
                             for module in visited_te_modules[per_callable_bwd_idx]:
                                 if (
                                     hasattr(module, "need_backward_dw")
@@ -687,7 +689,7 @@ def _make_graphed_callables(
                     if is_training:
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
                         with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
-                            bwd_graph, pool=mempool
+                            bwd_graph, stream=stream, pool=mempool
                         ):
                             torch.autograd.backward(
                                 tuple(
@@ -754,7 +756,7 @@ def _make_graphed_callables(
         per_callable_output_unflatten_spec = []
         graph_id = 0
         for func, args, kwargs, fwd_graph in zip(callables, sample_args, sample_kwargs, fwd_graphs):
-            with _graph_context_wrapper(fwd_graph, pool=mempool):
+            with _graph_context_wrapper(fwd_graph, stream=stream, pool=mempool):
                 outputs = func(*args, **kwargs)
             graph_callables[graph_id] = func
             graph_id += 1
@@ -781,7 +783,7 @@ def _make_graphed_callables(
             if is_training:
                 inputs = tuple(i for i in static_input_surface if i.requires_grad)
                 with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
-                    bwd_graph, pool=mempool
+                    bwd_graph, stream=stream, pool=mempool
                 ):
                     torch.autograd.backward(
                         tuple(o for o in static_outputs if o is not None and o.requires_grad),
@@ -791,7 +793,7 @@ def _make_graphed_callables(
                     grad_inputs = tuple(input.grad for input in inputs)
 
                 if need_bwd_dw_graph[bwd_idx]:
-                    with _graph_context_wrapper(bwd_dw_graph, pool=mempool):
+                    with _graph_context_wrapper(bwd_dw_graph, stream=stream, pool=mempool):
                         for module in visited_te_modules[bwd_idx]:
                             if hasattr(module, "need_backward_dw") and module.need_backward_dw():
                                 module.backward_dw()


### PR DESCRIPTION
# Description

This PR updates `_make_graphed_callables` so warmup and graph capture use the same stream, avoiding ROCm graph capture failures tied to hipBLASLt.

Fixes ROCM-25129

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

On ROCm, hipBLASLt handle caching is per (device, stream). If `stream=` is omitted, `torch.cuda.graph` uses its own default capture stream, which is not the stream used for warmup. The first real use on that capture stream will trigger a lazy hipblasLtCreate there. Handle creation runs capture‑unsafe internal allocation/setup, which fail with stream-capture errors (and sometimes hang) during capture.

Running warmup on the same stream passed into `torch.cuda.graph(..., stream=...)` creates and caches the hipBLASLt handle before capture.

Fixed test:
- pytorch/test_cuda_graphs.py::test_make_graphed_callables[Float8CurrentScaling-False-dtype0-transformer]

The test hung with pytorch 2.12+ with error `Hip error: 'operation not permitted when stream is capturing'(900)`

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
