### PR TITLE
[TE] Fix RMSNorm autotune HIP-graph related error

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/norms_common.py
+++ b/transformer_engine/pytorch/triton_kernels/norms_common.py
@@ -15,7 +15,7 @@ from transformer_engine.pytorch.triton_kernels.common import (
     te_dtype_to_triton_dtype,
 )
 from ..quantized_tensor import Quantizer
-from .utils import num_programs, block_size, use_blocked, make_ln_out, get_num_sms
+from .utils import num_programs, block_size, use_blocked, make_ln_out, get_num_sms, use_cuda_graph_autotune
 from .common import get_fp8_max
 from .rmsnorm import (
     _rmsnorm_fwd_triton,
@@ -86,7 +86,7 @@ def _get_fp8_transpose_configs():
 _fp8_transpose_2d_triton = triton.autotune(
     configs=_get_fp8_transpose_configs(),
     key=['n_rows', 'n_cols'],
-    use_cuda_graph=True,
+    use_cuda_graph=use_cuda_graph_autotune(),
 )(_fp8_transpose_2d_impl)
 
 _fp8_transpose_kernels = {

--- a/transformer_engine/pytorch/triton_kernels/rmsnorm.py
+++ b/transformer_engine/pytorch/triton_kernels/rmsnorm.py
@@ -4,6 +4,8 @@
 import torch
 import triton
 import triton.language as tl
+from .utils import use_cuda_graph_autotune
+
 
 def get_autotune_config():
     return [triton.Config({'waves_per_eu': 0}, num_warps=nw) for nw in (1, 4, 8, 16)]
@@ -208,7 +210,7 @@ autotune_dec = triton.autotune(
     configs=get_autotune_config(),
     key=['n_rows', 'n_cols'],
     prune_configs_by={'early_config_prune': _prune_rms_configs},
-    use_cuda_graph=True,
+    use_cuda_graph=use_cuda_graph_autotune(),
 )
 _rmsnorm_fwd_triton = autotune_dec(_rmsnorm_fwd_triton_impl)
 
@@ -383,7 +385,7 @@ _rmsnorm_bwd_triton = triton.autotune(
     configs=get_autotune_config(),
     key=['n_rows', 'n_cols'],
     prune_configs_by={'early_config_prune': _prune_rms_configs},
-    use_cuda_graph=True,
+    use_cuda_graph=use_cuda_graph_autotune(),
 )(_rmsnorm_bwd_triton_impl)
 
 
@@ -423,5 +425,5 @@ def _get_dg_reduce_configs():
 _rmsnorm_bwd_dg_reduce_triton = triton.autotune(
     configs=_get_dg_reduce_configs(),
     key=['n_rows', 'n_cols'],
-    use_cuda_graph=True,
+    use_cuda_graph=use_cuda_graph_autotune(),
 )(_rmsnorm_bwd_dg_reduce_triton_impl)

--- a/transformer_engine/pytorch/triton_kernels/utils.py
+++ b/transformer_engine/pytorch/triton_kernels/utils.py
@@ -12,23 +12,17 @@ from .common import te_dtype_to_torch_dtype
 
 
 def use_cuda_graph_autotune():
-    """Whether Triton autotuning should benchmark configs via CUDA/HIP graphs.
+    """Return whether Triton autotuning should benchmark configs with CUDA/HIP graphs.
 
-    Triton's ``do_bench_cudagraph`` path (``use_cuda_graph=True``) captures each
-    candidate launch into a graph. On ROCm/HIP this is fragile: if any single
-    candidate errors mid-capture it poisons the whole capture and every later op
-    fails with "HIP error: operation failed due to a previous error during
-    capture" (Code 901), aborting the first training step. The plain ``do_bench``
-    path (``use_cuda_graph=False``) times each config independently, so a bad
-    config is simply pruned. Default to graphs on CUDA only; allow an explicit
-    override via ``NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH`` (set to 1 or 0).
+    Graph-based benchmarking is enabled by default on CUDA and disabled on ROCm/HIP.
+    Set ``NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH`` to ``1`` or ``0`` to override the default.
     """
     override = os.getenv("NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH")
     if override is not None:
         return override == "1"
     return torch.version.hip is None
 
-    
+
 def get_ln_sm_margin(sm_margin_type):
     assert sm_margin_type in {"FWD", "BWD", "INF"}
     try:

--- a/transformer_engine/pytorch/triton_kernels/utils.py
+++ b/transformer_engine/pytorch/triton_kernels/utils.py
@@ -10,6 +10,25 @@ from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch.utils import get_sm_count
 from .common import te_dtype_to_torch_dtype
 
+
+def use_cuda_graph_autotune():
+    """Whether Triton autotuning should benchmark configs via CUDA/HIP graphs.
+
+    Triton's ``do_bench_cudagraph`` path (``use_cuda_graph=True``) captures each
+    candidate launch into a graph. On ROCm/HIP this is fragile: if any single
+    candidate errors mid-capture it poisons the whole capture and every later op
+    fails with "HIP error: operation failed due to a previous error during
+    capture" (Code 901), aborting the first training step. The plain ``do_bench``
+    path (``use_cuda_graph=False``) times each config independently, so a bad
+    config is simply pruned. Default to graphs on CUDA only; allow an explicit
+    override via ``NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH`` (set to 1 or 0).
+    """
+    override = os.getenv("NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH")
+    if override is not None:
+        return override == "1"
+    return torch.version.hip is None
+
+    
 def get_ln_sm_margin(sm_margin_type):
     assert sm_margin_type in {"FWD", "BWD", "INF"}
     try:

--- a/transformer_engine/pytorch/triton_kernels/utils.py
+++ b/transformer_engine/pytorch/triton_kernels/utils.py
@@ -2,6 +2,7 @@
 # License for AMD contributions = MIT. See LICENSE for more information
 
 import os
+from functools import cache
 import torch
 import triton
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor, Float8CurrentScalingQuantizer
@@ -10,7 +11,7 @@ from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch.utils import get_sm_count
 from .common import te_dtype_to_torch_dtype
 
-
+@cache
 def use_cuda_graph_autotune():
     """Return whether Triton autotuning should benchmark configs with CUDA/HIP graphs.
 


### PR DESCRIPTION
# Description

On ROCm/HIP, Triton's HIP-graph autotune crashed MXFP8 RMSNorm at the first training step (HIP Code 901). 

This fix routes the norm autotuners through a shared helper that disables the graph-based timing path in `triton.autotune` on HIP, preserving CUDA behavior. Real CUDA/HIP graph capture elsewhere is unaffected.

This is a mitigation, as the real problem can be candidate configs for autotuning that can fail mid-capture for a given shape.

Fixes https://github.com/ROCm/frameworks-internal/issues/17026

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `use_cuda_graph_autotune()` in `utils.py` controlling only `triton.autotune` `use_cuda_graph` timing path which is on for CUDA, off for ROCm/HIP, overridable via `NVTE_TRITON_AUTOTUNE_WITH_CUDA_GRAPH`
- Route the RMSNorm (fwd/bwd/dg-reduce) and FP8-transpose autotuners in `rmsnorm.py` / `norms_common.py` through the helper.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
