### PR TITLE
Add DeepSeek shapes to C++ benchmarks

### DIFF
--- a/benchmarks/cpp/cast/bench_casttranspose.cpp
+++ b/benchmarks/cpp/cast/bench_casttranspose.cpp
@@ -44,7 +44,7 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({496, 5760})              \
   ->Args({1792, 5760})
 
-// Tensor shapes from LLaMA (8B, 70B, 405B) and Qwen (7B, 72B)
+// Tensor shapes from LLaMA (8B, 70B, 405B), Qwen (7B, 72B), and DeepSeek-V3/V4
 #define COMMON_SHAPES              \
   ->Args({1024, 3584})             \
   ->Args({1024, 4096})             \
@@ -70,7 +70,22 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({16384, 16384})           \
   ->Args({16384, 28672})           \
   ->Args({32768, 8192})            \
-  ->Args({32768, 16384})
+  ->Args({32768, 16384})           \
+  ->Args({4096, 512})              \
+  ->Args({8192, 512})              \
+  ->Args({16384, 512})             \
+  ->Args({4096, 1536})             \
+  ->Args({8192, 1536})             \
+  ->Args({16384, 1536})            \
+  ->Args({4096, 3072})             \
+  ->Args({8192, 3072})             \
+  ->Args({16384, 3072})            \
+  ->Args({4096, 7168})             \
+  ->Args({8192, 7168})             \
+  ->Args({16384, 7168})            \
+  ->Args({4096, 65536})            \
+  ->Args({8192, 65536})            \
+  ->Args({16384, 65536})
 
 // Only used for specific benchmarks (older models, special cases, etc)
 #define EXTENDED_SHAPES            \

--- a/benchmarks/cpp/cast/bench_dequantize_mxfp8.cpp
+++ b/benchmarks/cpp/cast/bench_dequantize_mxfp8.cpp
@@ -19,7 +19,7 @@ using namespace te_bench;
 using namespace transformer_engine;
 using fp8_e4m3 = test::fp8e4m3;
 
-// Tensor shapes from LLaMA (8B, 70B, 405B) and Qwen (7B, 72B)
+// Tensor shapes from LLaMA (8B, 70B, 405B), Qwen (7B, 72B), and DeepSeek-V3/V4
 #define COMMON_SHAPES   \
   ->Args({1024, 3584})  \
   ->Args({1024, 4096})  \
@@ -39,7 +39,22 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({8192, 53248}) \
   ->Args({16384, 8192}) \
   ->Args({16384, 16384})\
-  ->Args({32768, 8192})
+  ->Args({32768, 8192}) \
+  ->Args({4096, 512})   \
+  ->Args({8192, 512})   \
+  ->Args({16384, 512})  \
+  ->Args({4096, 1536})  \
+  ->Args({8192, 1536})  \
+  ->Args({16384, 1536}) \
+  ->Args({4096, 3072})  \
+  ->Args({8192, 3072})  \
+  ->Args({16384, 3072}) \
+  ->Args({4096, 7168})  \
+  ->Args({8192, 7168})  \
+  ->Args({16384, 7168}) \
+  ->Args({4096, 65536}) \
+  ->Args({8192, 65536}) \
+  ->Args({16384, 65536})
 
 template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X>
 static void BM_DequantizeMXFP8(benchmark::State &state) {

--- a/benchmarks/cpp/cast/bench_gated_mxfp8.cpp
+++ b/benchmarks/cpp/cast/bench_gated_mxfp8.cpp
@@ -20,7 +20,7 @@ using namespace te_bench;
 using namespace transformer_engine;
 using fp8_e4m3 = test::fp8e4m3;
 
-// SwiGLU shapes from LLaMA (8B, 70B, 405B) and Qwen (7B, 72B)
+// SwiGLU shapes from LLaMA (8B, 70B, 405B), Qwen (7B, 72B), and DeepSeek-V3/V4 MoE experts
 #define COMMON_SHAPES    \
   ->Args({1024, 14336})  \
   ->Args({1024, 18944})  \
@@ -38,7 +38,13 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({16384, 28672}) \
   ->Args({16384, 53248}) \
   ->Args({32768, 28672}) \
-  ->Args({32768, 53248})
+  ->Args({32768, 53248}) \
+  ->Args({1024, 2048})   \
+  ->Args({4096, 2048})   \
+  ->Args({8192, 2048})   \
+  ->Args({1024, 3072})   \
+  ->Args({4096, 3072})   \
+  ->Args({8192, 3072})
 
 template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X>
 static void BM_GatedMXFP8_Forward(benchmark::State &state) {

--- a/benchmarks/cpp/cast/bench_group_quantize_mxfp8.cpp
+++ b/benchmarks/cpp/cast/bench_group_quantize_mxfp8.cpp
@@ -56,11 +56,11 @@ static std::vector<int> generate_routed_tokens(int total_tokens, int num_experts
   return tokens;
 }
 
-template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X>
+template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X, int EP = 1>
 static void BM_GroupQuantizeMXFP8(benchmark::State &state) {
-  const int num_experts  = state.range(0);
+  const int num_experts  = state.range(0) / EP;
   const int cols         = state.range(1);
-  const int total_tokens = state.range(2);
+  const int total_tokens = state.range(2) / EP;
   const int skewed       = state.range(3);
 
   constexpr bool USE_ROWWISE = SCALE_DIM_X > 1;
@@ -210,11 +210,11 @@ static void BM_GroupQuantizeMXFP8(benchmark::State &state) {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X>
+template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X, int EP = 1>
 static void BM_MultiQuantizeMXFP8(benchmark::State &state) {
-  const int num_experts  = state.range(0);
+  const int num_experts  = state.range(0) / EP;
   const int cols         = state.range(1);
-  const int total_tokens = state.range(2);
+  const int total_tokens = state.range(2) / EP;
   const int skewed       = state.range(3);
 
   constexpr bool USE_ROWWISE = SCALE_DIM_X > 1;
@@ -346,14 +346,18 @@ static void BM_MultiQuantizeMXFP8(benchmark::State &state) {
 #define MOE_BALANCED                                              \
   ->Args({128,  4096, 65536,  0}) /* Qwen3 H=4096  */             \
   ->Args({128,  1536, 65536,  0}) /* Qwen3 I=1536  */             \
-  ->Args({256,  7168, 131072, 0}) /* DeepSeek H=7168 */           \
-  ->Args({256,  2048, 131072, 0}) /* DeepSeek I=2048 */
+  ->Args({256,  7168, 131072, 0}) /* DSv3 H=7168   */             \
+  ->Args({256,  2048, 131072, 0}) /* DSv3 I=2048   */             \
+  ->Args({384,  7168, 131072, 0}) /* DSv4 H=7168   */             \
+  ->Args({384,  3072, 131072, 0}) /* DSv4 I=3072   */
 
 #define MOE_SKEWED                                                \
   ->Args({128,  4096, 65536,  1}) /* Qwen3 H=4096  */             \
   ->Args({128,  1536, 65536,  1}) /* Qwen3 I=1536  */             \
-  ->Args({256,  7168, 131072, 1}) /* DeepSeek H=7168 */           \
-  ->Args({256,  2048, 131072, 1}) /* DeepSeek I=2048 */
+  ->Args({256,  7168, 131072, 1}) /* DSv3 H=7168   */             \
+  ->Args({256,  2048, 131072, 1}) /* DSv3 I=2048   */             \
+  ->Args({384,  7168, 131072, 1}) /* DSv4 H=7168   */             \
+  ->Args({384,  3072, 131072, 1}) /* DSv4 I=3072   */
 
 #define REGISTER_GROUP_QUANTIZE(ITYPE, OTYPE, INAME, ONAME)                                \
   BENCHMARK_TEMPLATE(BM_GroupQuantizeMXFP8, ITYPE, OTYPE, 1, 32)                           \
@@ -386,5 +390,38 @@ REGISTER_GROUP_QUANTIZE(hip_bfloat16, fp8_e4m3, "BF16", "E4M3")
     ->Unit(benchmark::kMicrosecond) ->UseManualTime();
 
 REGISTER_MULTI_QUANTIZE(hip_bfloat16, fp8_e4m3, "BF16", "E4M3")
+
+#ifdef NVTE_ROCM_EP8_BENCHMARKS
+#define REGISTER_GROUP_QUANTIZE_EP8(ITYPE, OTYPE, INAME, ONAME)                            \
+  BENCHMARK_TEMPLATE(BM_GroupQuantizeMXFP8, ITYPE, OTYPE, 1, 32, 8)                        \
+    ->Name("BM_GroupQuantizeMXFP8/rowwise_ep8/" INAME "_" ONAME)                           \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();                                     \
+  BENCHMARK_TEMPLATE(BM_GroupQuantizeMXFP8, ITYPE, OTYPE, 32, 1, 8)                        \
+    ->Name("BM_GroupQuantizeMXFP8/colwise_ep8/" INAME "_" ONAME)                           \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();                                     \
+  BENCHMARK_TEMPLATE(BM_GroupQuantizeMXFP8, ITYPE, OTYPE, 32, 32, 8)                       \
+    ->Name("BM_GroupQuantizeMXFP8/both_ep8/" INAME "_" ONAME)                              \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();
+
+#define REGISTER_MULTI_QUANTIZE_EP8(ITYPE, OTYPE, INAME, ONAME)                            \
+  BENCHMARK_TEMPLATE(BM_MultiQuantizeMXFP8, ITYPE, OTYPE, 1, 32, 8)                        \
+    ->Name("BM_MultiQuantizeMXFP8/rowwise_ep8/" INAME "_" ONAME)                           \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();                                     \
+  BENCHMARK_TEMPLATE(BM_MultiQuantizeMXFP8, ITYPE, OTYPE, 32, 1, 8)                        \
+    ->Name("BM_MultiQuantizeMXFP8/colwise_ep8/" INAME "_" ONAME)                           \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();                                     \
+  BENCHMARK_TEMPLATE(BM_MultiQuantizeMXFP8, ITYPE, OTYPE, 32, 32, 8)                       \
+    ->Name("BM_MultiQuantizeMXFP8/both_ep8/" INAME "_" ONAME)                              \
+    MOE_BALANCED MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond) ->UseManualTime();
+
+REGISTER_GROUP_QUANTIZE_EP8(hip_bfloat16, fp8_e4m3, "BF16", "E4M3")
+REGISTER_MULTI_QUANTIZE_EP8(hip_bfloat16, fp8_e4m3, "BF16", "E4M3")
+#endif
 
 BENCHMARK_MAIN();

--- a/benchmarks/cpp/cast/bench_multi_cast_transpose.cpp
+++ b/benchmarks/cpp/cast/bench_multi_cast_transpose.cpp
@@ -26,7 +26,7 @@ using namespace te_bench;
 using namespace transformer_engine;
 using fp8_e4m3 = test::fp8e4m3;
 
-// MoE shapes from Qwen3-235B and DeepSeek-V3
+// MoE shapes from Qwen3-235B, DeepSeek-V3, and DeepSeek-V4
 // Args: {total_tokens, cols, num_experts, top_k, routing_mode}
 #define MOE_BALANCED                     \
   ->Args({4096,  4096, 128, 8, 0})       \
@@ -46,7 +46,13 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({16384, 2048, 256, 8, 0})       \
   ->Args({4096,  4096, 256, 8, 0})       \
   ->Args({8192,  4096, 256, 8, 0})       \
-  ->Args({16384, 4096, 256, 8, 0})
+  ->Args({16384, 4096, 256, 8, 0})       \
+  ->Args({4096,  7168, 384, 6, 0})       \
+  ->Args({8192,  7168, 384, 6, 0})       \
+  ->Args({16384, 7168, 384, 6, 0})       \
+  ->Args({4096,  3072, 384, 6, 0})       \
+  ->Args({8192,  3072, 384, 6, 0})       \
+  ->Args({16384, 3072, 384, 6, 0})
 
 #define MOE_SKEWED                       \
   ->Args({4096,  4096, 128, 8, 1})       \
@@ -66,7 +72,13 @@ using fp8_e4m3 = test::fp8e4m3;
   ->Args({16384, 2048, 256, 8, 1})       \
   ->Args({4096,  4096, 256, 8, 1})       \
   ->Args({8192,  4096, 256, 8, 1})       \
-  ->Args({16384, 4096, 256, 8, 1})
+  ->Args({16384, 4096, 256, 8, 1})       \
+  ->Args({4096,  7168, 384, 6, 1})       \
+  ->Args({8192,  7168, 384, 6, 1})       \
+  ->Args({16384, 7168, 384, 6, 1})       \
+  ->Args({4096,  3072, 384, 6, 1})       \
+  ->Args({8192,  3072, 384, 6, 1})       \
+  ->Args({16384, 3072, 384, 6, 1})
 
 namespace {
 
@@ -137,11 +149,11 @@ static std::vector<size_t> simulate_topk_skewed(
   return counts;
 }
 
-template <typename IType>
+template <typename IType, int EP = 1>
 static void BM_MultiCastTranspose(benchmark::State &state) {
-  const size_t total_tokens = state.range(0);
+  const size_t total_tokens = state.range(0) / EP;
   const size_t cols         = state.range(1);
-  const size_t num_experts  = state.range(2);
+  const size_t num_experts  = state.range(2) / EP;
   const size_t top_k        = state.range(3);
   const size_t routing_mode = state.range(4);
 
@@ -227,11 +239,11 @@ static void BM_MultiCastTranspose(benchmark::State &state) {
 }
 
 // Unfused baseline: separate padding kernel + cast_transpose
-template <typename IType>
+template <typename IType, int EP = 1>
 static void BM_PaddingThenMCT(benchmark::State &state) {
-  const size_t total_tokens = state.range(0);
+  const size_t total_tokens = state.range(0) / EP;
   const size_t cols         = state.range(1);
-  const size_t num_experts  = state.range(2);
+  const size_t num_experts  = state.range(2) / EP;
   const size_t top_k        = state.range(3);
   const size_t routing_mode = state.range(4);
 
@@ -320,11 +332,11 @@ static void BM_PaddingThenMCT(benchmark::State &state) {
 }
 
 // Fused: single cast_transpose kernel with built-in padding
-template <typename IType>
+template <typename IType, int EP = 1>
 static void BM_FusedPaddingMCT(benchmark::State &state) {
-  const size_t total_tokens = state.range(0);
+  const size_t total_tokens = state.range(0) / EP;
   const size_t cols         = state.range(1);
-  const size_t num_experts  = state.range(2);
+  const size_t num_experts  = state.range(2) / EP;
   const size_t top_k        = state.range(3);
   const size_t routing_mode = state.range(4);
 
@@ -440,5 +452,44 @@ static void BM_FusedPaddingMCT(benchmark::State &state) {
 
 REGISTER_MCT(hip_bfloat16, "BF16")
 REGISTER_PAD_MCT(hip_bfloat16, "BF16")
+
+#ifdef NVTE_ROCM_EP8_BENCHMARKS
+#define REGISTER_MCT_EP8(ITYPE, INAME)                                        \
+  BENCHMARK_TEMPLATE(BM_MultiCastTranspose, ITYPE, 8)                         \
+    ->Name("BM_MultiCastTranspose/" INAME "_E4M3/moe_ep8")                    \
+    MOE_BALANCED                                                              \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();                                                        \
+  BENCHMARK_TEMPLATE(BM_MultiCastTranspose, ITYPE, 8)                         \
+    ->Name("BM_MultiCastTranspose/" INAME "_E4M3/moe_ep8_skewed")             \
+    MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();
+
+#define REGISTER_PAD_MCT_EP8(ITYPE, INAME)                                    \
+  BENCHMARK_TEMPLATE(BM_PaddingThenMCT, ITYPE, 8)                             \
+    ->Name("BM_PaddingThenMCT/" INAME "_E4M3/moe_ep8")                        \
+    MOE_BALANCED                                                              \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();                                                        \
+  BENCHMARK_TEMPLATE(BM_PaddingThenMCT, ITYPE, 8)                             \
+    ->Name("BM_PaddingThenMCT/" INAME "_E4M3/moe_ep8_skewed")                 \
+    MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();                                                        \
+  BENCHMARK_TEMPLATE(BM_FusedPaddingMCT, ITYPE, 8)                            \
+    ->Name("BM_FusedPaddingMCT/" INAME "_E4M3/moe_ep8")                       \
+    MOE_BALANCED                                                              \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();                                                        \
+  BENCHMARK_TEMPLATE(BM_FusedPaddingMCT, ITYPE, 8)                            \
+    ->Name("BM_FusedPaddingMCT/" INAME "_E4M3/moe_ep8_skewed")                \
+    MOE_SKEWED                                                                \
+    ->Unit(benchmark::kMicrosecond)                                           \
+    ->UseManualTime();
+
+REGISTER_MCT_EP8(hip_bfloat16, "BF16")
+REGISTER_PAD_MCT_EP8(hip_bfloat16, "BF16")
+#endif
 
 BENCHMARK_MAIN();

--- a/benchmarks/cpp/cast/bench_quantize_mxfp8_fused.cpp
+++ b/benchmarks/cpp/cast/bench_quantize_mxfp8_fused.cpp
@@ -28,7 +28,7 @@ enum ProcessingMethod {
     CAST_ACT
 };
 
-// Tensor shapes from LLaMA (8B, 70B, 405B) and Qwen (7B, 72B)
+// Tensor shapes from LLaMA (8B, 70B, 405B), Qwen (7B, 72B), and DeepSeek-V3/V4
 #define COMMON_SHAPES   \
   ->Args({1024, 3584})  \
   ->Args({1024, 4096})  \
@@ -54,7 +54,22 @@ enum ProcessingMethod {
   ->Args({16384, 16384})\
   ->Args({16384, 28672})\
   ->Args({32768, 8192}) \
-  ->Args({32768, 16384})
+  ->Args({32768, 16384})\
+  ->Args({4096, 512})   \
+  ->Args({8192, 512})   \
+  ->Args({16384, 512})  \
+  ->Args({4096, 1536})  \
+  ->Args({8192, 1536})  \
+  ->Args({16384, 1536}) \
+  ->Args({4096, 3072})  \
+  ->Args({8192, 3072})  \
+  ->Args({16384, 3072}) \
+  ->Args({4096, 7168})  \
+  ->Args({8192, 7168})  \
+  ->Args({16384, 7168}) \
+  ->Args({4096, 65536}) \
+  ->Args({8192, 65536}) \
+  ->Args({16384, 65536})
 
 template <typename IType, typename OType, int SCALE_DIM_Y, int SCALE_DIM_X,
           ProcessingMethod PROC_METHOD>

--- a/benchmarks/cpp/normalization/bench_normalization.cpp
+++ b/benchmarks/cpp/normalization/bench_normalization.cpp
@@ -17,10 +17,22 @@
 using namespace te_bench;
 using namespace transformer_engine;
 
-#define NORM_SHAPES    \
-  ->Args({8192, 128})  \
-  ->Args({8192, 1536}) \
-  ->Args({8192, 7168})
+#define NORM_SHAPES     \
+  ->Args({4096, 128})   \
+  ->Args({4096, 1024})  \
+  ->Args({4096, 1536})  \
+  ->Args({4096, 4096})  \
+  ->Args({4096, 7168})  \
+  ->Args({8192, 128})   \
+  ->Args({8192, 1024})  \
+  ->Args({8192, 1536})  \
+  ->Args({8192, 4096})  \
+  ->Args({8192, 7168})  \
+  ->Args({16384, 128})  \
+  ->Args({16384, 1024}) \
+  ->Args({16384, 1536}) \
+  ->Args({16384, 4096}) \
+  ->Args({16384, 7168})
 
 constexpr float kNormEpsilon = 1e-5f;
 


### PR DESCRIPTION
Adds DeepSeek V3, V4 shapes to benchmark scripts

Adds a EP=8 option to benchmarks to crudely simulate mGPU workloads