### PR TITLE
Fix GEMM build on gfx942

### DIFF
--- a/transformer_engine/common/gemm/kittens/CMakeLists.txt
+++ b/transformer_engine/common/gemm/kittens/CMakeLists.txt
@@ -3,54 +3,50 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-function(try_enable_hipkittens_gemm)
-    list(FIND CMAKE_HIP_ARCHITECTURES "gfx950" _gfx950_index)
-    if(_gfx950_index EQUAL -1)
-        message(STATUS "HipKittens GEMM disabled (gfx950 not in CMAKE_HIP_ARCHITECTURES)")
-        set(USE_HIPKITTENS_GEMM OFF PARENT_SCOPE)
-        return()
-    endif()
+list(FIND CMAKE_HIP_ARCHITECTURES "gfx950" _gfx950_index)
+if(_gfx950_index EQUAL -1)
+    message(STATUS "HipKittens GEMM disabled (gfx950 not in CMAKE_HIP_ARCHITECTURES)")
+    set(USE_HIPKITTENS_GEMM OFF CACHE BOOL "Use HipKittens MXFP8 GEMM kernels" FORCE)
+    return()
+endif()
 
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag("-std=c++20" HAS_CXX20)
-    if(NOT HAS_CXX20)
-        message(WARNING "HipKittens GEMMs require C++20")
-        set(USE_HIPKITTENS_GEMM OFF PARENT_SCOPE)
-        return()
-    endif()
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++20" HAS_CXX20)
+if(NOT HAS_CXX20)
+    message(WARNING "HipKittens GEMMs require C++20")
+    set(USE_HIPKITTENS_GEMM OFF CACHE BOOL "Use HipKittens MXFP8 GEMM kernels" FORCE)
+    return()
+endif()
 
-    set(HIPKITTENS_INCLUDE_DIR
-        "${CMAKE_CURRENT_SOURCE_DIR}/../../../../3rdparty/hipkittens/include")
-    if(NOT EXISTS "${HIPKITTENS_INCLUDE_DIR}/kittens.cuh")
-        message(FATAL_ERROR
-            "Could not find HipKittens headers at ${HIPKITTENS_INCLUDE_DIR}. "
-            "Try running 'git submodule update --init --recursive' "
-            "within the Transformer Engine source.")
-    endif()
+set(HIPKITTENS_INCLUDE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../3rdparty/hipkittens/include")
+if(NOT EXISTS "${HIPKITTENS_INCLUDE_DIR}/kittens.cuh")
+    message(FATAL_ERROR
+        "Could not find HipKittens headers at ${HIPKITTENS_INCLUDE_DIR}. "
+        "Try running 'git submodule update --init --recursive' "
+        "within the Transformer Engine source.")
+endif()
 
-    set(CMAKE_CXX_STANDARD 20)
-    project(kittens_gemm LANGUAGES HIP CXX)
+set(CMAKE_CXX_STANDARD 20)
+project(kittens_gemm LANGUAGES HIP CXX)
 
-    set(kittens_gemm_SOURCES
-        mxfp8_gemm.cpp)
+set(kittens_gemm_SOURCES
+    mxfp8_gemm.cpp)
 
-    add_library(kittens_gemm SHARED ${kittens_gemm_SOURCES})
-    set_source_files_properties(${kittens_gemm_SOURCES} PROPERTIES LANGUAGE HIP)
-    set_target_properties(kittens_gemm PROPERTIES HIP_ARCHITECTURES "gfx950")
+add_library(kittens_gemm SHARED ${kittens_gemm_SOURCES})
+set_source_files_properties(${kittens_gemm_SOURCES} PROPERTIES LANGUAGE HIP)
+set_target_properties(kittens_gemm PROPERTIES HIP_ARCHITECTURES "gfx950")
 
-    set(KITTENS_GEMM_COMPILE_OPTIONS
-        -DKITTENS_CDNA4
-        -fno-gpu-rdc
-        -O3)
+set(KITTENS_GEMM_COMPILE_OPTIONS
+    -DKITTENS_CDNA4
+    -fno-gpu-rdc
+    -O3)
 
-    find_package(hip)
-    target_include_directories(kittens_gemm PRIVATE ${HIPKITTENS_INCLUDE_DIR})
-    target_include_directories(kittens_gemm PRIVATE ${HIP_INCLUDE_DIRS})
-    target_link_libraries(kittens_gemm PUBLIC hip::host hip::device)
-    target_compile_options(kittens_gemm PRIVATE ${KITTENS_GEMM_COMPILE_OPTIONS})
+find_package(hip)
+target_include_directories(kittens_gemm PRIVATE ${HIPKITTENS_INCLUDE_DIR})
+target_include_directories(kittens_gemm PRIVATE ${HIP_INCLUDE_DIRS})
+target_link_libraries(kittens_gemm PUBLIC hip::host hip::device)
+target_compile_options(kittens_gemm PRIVATE ${KITTENS_GEMM_COMPILE_OPTIONS})
 
-    install(TARGETS kittens_gemm
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/transformer_engine/lib)
-endfunction()
-
-try_enable_hipkittens_gemm()
+install(TARGETS kittens_gemm
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/transformer_engine/lib)

--- a/transformer_engine/common/gemm/rocm_gemm.cu
+++ b/transformer_engine/common/gemm/rocm_gemm.cu
@@ -1823,7 +1823,7 @@ void release_service_stream(hipStream_t stream, struct ServiceStreamCtl &ctl)
 {
     NVTE_CHECK_CUDA(hipEventRecord(ctl.end_event, ctl.stream));
     NVTE_CHECK_CUDA(hipStreamWaitEvent(stream, ctl.end_event, 0));
-    //TODO: when event are really destroyed (documentation says on devide synchronize) and how much overhead is to create them
+    //TODO: when event are really destroyed (documentation says on device synchronize) and how much overhead is to create them
     //May need to store event in eventPool and reuse them after thy are recorded
     NVTE_CHECK_CUDA(hipEventDestroy(ctl.start_event));
 }
@@ -1996,8 +1996,6 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                   && m % 256 == 0 && n % 256 == 0 && k % 128 == 0 && k >= 256;
   }
 
-  hipStream_t s = use_service_stream ? ss_ctl.stream : stream;
-
   if (use_hipkittens) {
     auto param = CanonicalizeGemmInput(*inputA, transa, *inputB, transb, m, n, k);
 
@@ -2011,7 +2009,7 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                        outputPreGelu->data.dptr,
                        static_cast<int>(outputD->data.dtype),
                        static_cast<int>(outputPreGelu->data.dtype),
-                       workspace, workspaceSize, s);
+                       workspace, workspaceSize, gemm_stream);
   } else {
 #endif
     // FIXME(https://amd-hub.atlassian.net/browse/ROCM-26110): Remove this workaround once hipBLASLt supports NN/NT
@@ -2020,11 +2018,11 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
                                                     outputPreGelu, transa, transb, grad,
                                                     workspace, workspaceSize, alpha, beta,
                                                     use_split_accumulator, math_sm_count,
-                                                    s, handle, m, n, k);
+                                                    gemm_stream, handle, m, n, k);
     if (!handled) {
       hipblaslt_gemm(inputA, inputB, outputD, inputBias, outputPreGelu, m, n, k, lda, ldb, ldd, transa,
                      transb, grad, workspace, workspaceSize, alpha, beta, use_split_accumulator,
-                     math_sm_count, s, handle);
+                     math_sm_count, gemm_stream, handle);
     }
 #ifdef USE_HIPKITTENS_GEMM
   }


### PR DESCRIPTION
# Description

Fix TE building if no gfx950 arch is specified and HipKittents build is automatically disabled

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove single global function in TE/kittents CMake
- Cache HipKittenst enablement flag in TE  build
- Remove GEMM stream declaration under HIP_KITTENS ifdef if favor of the one made unconditionally

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
