### PR TITLE
fix spurious recompilation on incremental editable builds

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -113,6 +113,19 @@ def get_build_ext(
     class _CMakeBuildExtension(extension_cls):
         """Setuptools command with support for CMake extension modules"""
 
+        def finalize_options(self) -> None:
+            super().finalize_options()
+            # Persist the intermediate object directory (build_temp) across builds.
+            # Framework extensions (e.g. transformer_engine_torch) are compiled by
+            # setuptools/pip into build_temp, but pip normally points it at an
+            # ephemeral temp dir, so every `pip install` recompiles all objects from
+            # scratch. Rooting it at a stable location lets the underlying ninja skip
+            # unchanged objects. Mirrors the persistent CMake build dir above.
+            root_dir = Path(__file__).resolve().parent.parent
+            build_temp = root_dir / "build" / "torch_temp"
+            build_temp.mkdir(parents=True, exist_ok=True)
+            self.build_temp = str(build_temp)
+
         def run(self) -> None:
             # Build CMake extensions
             for ext in self.extensions:

--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -122,7 +122,7 @@ def get_build_ext(
             # scratch. Rooting it at a stable location lets the underlying ninja skip
             # unchanged objects. Mirrors the persistent CMake build dir above.
             root_dir = Path(__file__).resolve().parent.parent
-            build_temp = root_dir / "build" / "torch_temp"
+            build_temp = root_dir / "build" / "ext_temp"
             build_temp.mkdir(parents=True, exist_ok=True)
             self.build_temp = str(build_temp)
 

--- a/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
+++ b/transformer_engine/common/gemm/ck_grouped_gemm/ck_grouped_gemm_common.h
@@ -18,7 +18,7 @@
 
 #include "common/util/cuda_runtime.h"
 #include "../../common.h"
-#include "../../common/util/system.h"
+#include "../../util/system.h"
 
 #include "ck_tile/core.hpp"
 #include "ck_tile/host/kernel_launch.hpp"


### PR DESCRIPTION
# Description

Two unrelated causes made `pip install -e .` recompile from scratch even
with no source changes:

- PyTorch extension: setuptools' editable_wheel points build_ext.build_temp
  at an ephemeral /tmp/*.build-temp dir, so all csrc objects recompiled every
  build. Override finalize_options() to pin build_temp to build/torch_temp,
  giving ninja a persistent object cache.

- CK grouped gemm: ck_grouped_gemm_common.h had a malformed relative include
  ("../../common/util/system.h", which resolves to a nonexistent path). This
  forced hipify's output-dir-dependent fallback resolution, so the pytorch and
  common hipify passes emitted different include paths and the generated
  _hip.h flip-flopped every build, retriggering all 8 CK objects. Correct the
  include to "../../util/system.h" so both passes agree.

Companion to #666 and https://github.com/Micky774/QoLA/pull/9. 
With all three PRs, total rebuild time without source code changes is reduced from ~8 minutes to ~6 seconds, with zero recompilations.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
