### PR TITLE
ci: bump te-rocm-wheels artifact retention 1d -> 3d

### DIFF
--- a/.github/workflows/rocm-wheels-build.yml
+++ b/.github/workflows/rocm-wheels-build.yml
@@ -222,7 +222,7 @@ jobs:
           path: |
             ${{ runner.temp }}/wheelhouse/*.whl
             ${{ runner.temp }}/wheelhouse/*.tar.gz
-          retention-days: 1
+          retention-days: 5
           if-no-files-found: error
 
       - name: Upload build logs on failure

--- a/.github/workflows/rocm-wheels-build.yml
+++ b/.github/workflows/rocm-wheels-build.yml
@@ -222,7 +222,7 @@ jobs:
           path: |
             ${{ runner.temp }}/wheelhouse/*.whl
             ${{ runner.temp }}/wheelhouse/*.tar.gz
-          retention-days: 5
+          retention-days: 3
           if-no-files-found: error
 
       - name: Upload build logs on failure


### PR DESCRIPTION
## Summary

- Bump `retention-days` on the `te-rocm-wheels` artifact upload in `.github/workflows/rocm-wheels-build.yml` from `1` to `3`.

## Why

The `te-rocm-wheels` build artifact is downloaded by every downstream sGPU / mGPU test job. mi35x self-hosted runners have observed queue times of **24–36 hours** before a job actually starts, which races the previous 1-day retention window. Every mi35x job on recent PRs has failed at the download step with:

> `Unable to download artifact(s): Artifact not found for name: te-rocm-wheels`

Observed on PR #667 run [29390452937](https://github.com/ROCm/TransformerEngine/actions/runs/29390452937):

| Job | Started (offset from build finish) | Result |
|---|---|---|
| build (uploads artifact) | 0 | ✓ pass |
| mGPU Torch (mi30x) | +21h35m | ✓ pass |
| mGPU JAX (mi30x)   | +22h34m | ✓ pass (~1h26m before expiry) |
| sGPU (mi30x)       | +23h39m | ✗ artifact expired |
| sGPU (mi35x)       | +23h39m | ✗ artifact expired |
| mGPU Torch (mi35x) | +34h14m | ✗ artifact expired |
| mGPU JAX (mi35x)   | +35h31m | ✗ artifact expired |

Bumping to `3` days comfortably outlasts the observed mi35x queue tail (24–36h) while keeping the artifact-storage window trimmed close to what's actually needed.

## Test plan

- [ ] Confirm build job still uploads `te-rocm-wheels` successfully.
- [ ] Confirm downstream sGPU / mGPU jobs on both mi30x and mi35x can download the artifact even after long queueing delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)