### PR TITLE
Consolidating blockwise FP32 scale flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -291,10 +291,10 @@ The backend shares the existing USE_HIPKITTENS_GEMM build option with MXFP8:
 * OFF - disable the HipKittens blockwise FP8 and MXFP8 GEMM backend;
 * ON - enable the HipKittens GEMM backend (default).
 
-On gfx950 there are two blockwise FP8 GEMM kernels, selected at runtime by the NVTE_BLOCKWISE_FP8_POWER_OF_2_SCALE environment variable:
+On gfx950 there are two blockwise FP8 GEMM kernels, selected at runtime by the NVTE_FP8_BLOCK_SCALING_FP32_SCALES environment variable, which also controls the scale produced by the Float8BlockScaling recipe:
 
-* 0 - compute the GEMM with the FP32 scales directly;
-* 1 - cast the incoming FP32 scales to E8M0 (power-of-2) and compute the GEMM with those scales (default).
+* 0 - cast the incoming FP32 scales to E8M0 (power-of-2) and compute the GEMM with those scales (default);
+* 1 - compute the GEMM with the FP32 scales directly.
 
 Two-stage amax Kernel
 ^^^^^^^^^^^^^^^^^^^^^

--- a/transformer_engine/common/gemm/kittens/cdna4/blockwise_fp8_gemm.cpp
+++ b/transformer_engine/common/gemm/kittens/cdna4/blockwise_fp8_gemm.cpp
@@ -1110,8 +1110,8 @@ class BlockwiseGemmCdna4 final : public BlockwiseGemmBackend {
         float *sb = reinterpret_cast<float *>(const_cast<void *>(ksb));
 
         static const bool use_pow2 = []() {
-            const char *e = std::getenv("NVTE_BLOCKWISE_FP8_POWER_OF_2_SCALE");
-            return e == nullptr || std::strcmp(e, "0") != 0;
+            const char *e = std::getenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES");
+            return e == nullptr || std::strcmp(e, "1") != 0;
         }();
 
         const int k_iters = K / BLOCK_K;


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

The upstream already had a flag NVTE_FP8_BLOCK_SCALING_FP32_SCALES (default 0) which is used to limit and store the blockwise quantization scales in the power-of-2 in fp32 precision. This PR is removing the unnecessary additional flag and using the original flag and on gfx950, if this flag is set to 1, then the host blockwise gemm dispatcher selects the kernel with fp32 scale computation.



Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
