### PR TITLE
gfx1250: fix MXFP8 scale_inv shape mismatch in C++ tests

### DIFF
--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -1337,7 +1337,8 @@ std::array<size_t, 4> get_scale_tensor_dims(const size_t rows,
       alignment_Y = alignment_X =
           (getDeviceComputeCapability() == 125) ? mxfp8_gfx1250_scale_tensor_alignment : 1;
     } else {
-      alignment_Y = alignment_X = 1;
+      alignment_Y = 1;
+      alignment_X = 1;
     }
 #else
     const size_t alignment_Y = is_rowwise

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -167,7 +167,8 @@ std::pair<scale_inv_meta, scale_inv_meta> get_scales(const NVTEShape& shape,
 #ifdef __HIP_PLATFORM_AMD__
     // gfx1250 MX pre-swizzle requires MXFP8 scales padded to a multiple of 4 in both dims
     if (getDeviceComputeCapability() == 125) {
-      align_Y_rowwise = align_X_rowwise = align_Y_colwise = align_X_colwise = 4;
+      align_Y_rowwise = align_X_rowwise = align_Y_colwise = align_X_colwise =
+          mxfp8_gfx1250_scale_tensor_alignment;
     }
 #endif
 
@@ -1334,13 +1335,8 @@ std::array<size_t, 4> get_scale_tensor_dims(const size_t rows,
                                : nvfp4_scale_tensor_alignment_X_colwise;
     } else {
       // MXFP8: gfx1250 MX pre-swizzle requires scales padded to a multiple of 4 in both dims
-      if (getDeviceComputeCapability() == 125) {
-        alignment_Y = 4;
-        alignment_X = 4;
-      } else {
-        alignment_Y = 1;
-        alignment_X = 1;
-      }
+      alignment_Y = alignment_X =
+          (getDeviceComputeCapability() == 125) ? mxfp8_gfx1250_scale_tensor_alignment : 1;
     }
 #else
     const size_t alignment_Y = is_rowwise

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -160,14 +160,25 @@ std::pair<scale_inv_meta, scale_inv_meta> get_scales(const NVTEShape& shape,
 
     scale_inv_meta ret_rowwise, ret_colwise;
 
+    size_t align_Y_rowwise = scale_tensor_alignment_Y_rowwise;
+    size_t align_X_rowwise = scale_tensor_alignment_X_rowwise;
+    size_t align_Y_colwise = scale_tensor_alignment_Y_colwise;
+    size_t align_X_colwise = scale_tensor_alignment_X_colwise;
+#ifdef __HIP_PLATFORM_AMD__
+    // gfx1250 MX pre-swizzle requires MXFP8 scales padded to a multiple of 4 in both dims
+    if (getDeviceComputeCapability() == 125) {
+      align_Y_rowwise = align_X_rowwise = align_Y_colwise = align_X_colwise = 4;
+    }
+#endif
+
     const size_t block_size_X_rowwise = 32;
-    size_t scale_dim_Y_rowwise = DIVUP_TO_MULTIPLE(first_dim, scale_tensor_alignment_Y_rowwise);
-    size_t scale_dim_X_rowwise = DIVUP_TO_MULTIPLE(DIVUP(last_dim, block_size_X_rowwise), scale_tensor_alignment_X_rowwise);
+    size_t scale_dim_Y_rowwise = DIVUP_TO_MULTIPLE(first_dim, align_Y_rowwise);
+    size_t scale_dim_X_rowwise = DIVUP_TO_MULTIPLE(DIVUP(last_dim, block_size_X_rowwise), align_X_rowwise);
     ret_rowwise.shape = {scale_dim_Y_rowwise, scale_dim_X_rowwise};
 
     const size_t block_size_Y_colwise = 32;
-    size_t scale_dim_Y_colwise = DIVUP_TO_MULTIPLE(DIVUP(first_dim, block_size_Y_colwise), scale_tensor_alignment_Y_colwise);
-    size_t scale_dim_X_colwise = DIVUP_TO_MULTIPLE(last_dim, scale_tensor_alignment_X_colwise);
+    size_t scale_dim_Y_colwise = DIVUP_TO_MULTIPLE(DIVUP(first_dim, block_size_Y_colwise), align_Y_colwise);
+    size_t scale_dim_X_colwise = DIVUP_TO_MULTIPLE(last_dim, align_X_colwise);
     ret_colwise.shape = {scale_dim_Y_colwise, scale_dim_X_colwise};
 
     ret_rowwise.type = DType::kFloat8E8M0;
@@ -1322,8 +1333,14 @@ std::array<size_t, 4> get_scale_tensor_dims(const size_t rows,
       alignment_X = is_rowwise ? nvfp4_scale_tensor_alignment_X_rowwise
                                : nvfp4_scale_tensor_alignment_X_colwise;
     } else {
-      alignment_Y = 1;
-      alignment_X = 1;
+      // MXFP8: gfx1250 MX pre-swizzle requires scales padded to a multiple of 4 in both dims
+      if (getDeviceComputeCapability() == 125) {
+        alignment_Y = 4;
+        alignment_X = 4;
+      } else {
+        alignment_Y = 1;
+        alignment_X = 1;
+      }
     }
 #else
     const size_t alignment_Y = is_rowwise

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -160,27 +160,26 @@ std::pair<scale_inv_meta, scale_inv_meta> get_scales(const NVTEShape& shape,
 
     scale_inv_meta ret_rowwise, ret_colwise;
 
-    size_t align_Y_rowwise = scale_tensor_alignment_Y_rowwise;
-    size_t align_X_rowwise = scale_tensor_alignment_X_rowwise;
-    size_t align_Y_colwise = scale_tensor_alignment_Y_colwise;
-    size_t align_X_colwise = scale_tensor_alignment_X_colwise;
-#ifdef __HIP_PLATFORM_AMD__
-    // gfx1250 MX pre-swizzle requires MXFP8 scales padded to a multiple of 4 in both dims
-    if (getDeviceComputeCapability() == 125) {
-      align_Y_rowwise = align_X_rowwise = align_Y_colwise = align_X_colwise =
-          mxfp8_gfx1250_scale_tensor_alignment;
-    }
-#endif
-
     const size_t block_size_X_rowwise = 32;
-    size_t scale_dim_Y_rowwise = DIVUP_TO_MULTIPLE(first_dim, align_Y_rowwise);
-    size_t scale_dim_X_rowwise = DIVUP_TO_MULTIPLE(DIVUP(last_dim, block_size_X_rowwise), align_X_rowwise);
+    size_t scale_dim_Y_rowwise = DIVUP_TO_MULTIPLE(first_dim, scale_tensor_alignment_Y_rowwise);
+    size_t scale_dim_X_rowwise = DIVUP_TO_MULTIPLE(DIVUP(last_dim, block_size_X_rowwise), scale_tensor_alignment_X_rowwise);
     ret_rowwise.shape = {scale_dim_Y_rowwise, scale_dim_X_rowwise};
 
     const size_t block_size_Y_colwise = 32;
-    size_t scale_dim_Y_colwise = DIVUP_TO_MULTIPLE(DIVUP(first_dim, block_size_Y_colwise), align_Y_colwise);
-    size_t scale_dim_X_colwise = DIVUP_TO_MULTIPLE(last_dim, align_X_colwise);
+    size_t scale_dim_Y_colwise = DIVUP_TO_MULTIPLE(DIVUP(first_dim, block_size_Y_colwise), scale_tensor_alignment_Y_colwise);
+    size_t scale_dim_X_colwise = DIVUP_TO_MULTIPLE(last_dim, scale_tensor_alignment_X_colwise);
     ret_colwise.shape = {scale_dim_Y_colwise, scale_dim_X_colwise};
+
+#ifdef __HIP_PLATFORM_AMD__
+    // gfx1250 MX pre-swizzle pads MXFP8 scales to a multiple of 4 in both dims
+    if (getDeviceComputeCapability() == 125) {
+      const size_t align = mxfp8_gfx1250_scale_tensor_alignment;
+      ret_rowwise.shape = {DIVUP_TO_MULTIPLE(ret_rowwise.shape[0], align),
+                           DIVUP_TO_MULTIPLE(ret_rowwise.shape[1], align)};
+      ret_colwise.shape = {DIVUP_TO_MULTIPLE(ret_colwise.shape[0], align),
+                           DIVUP_TO_MULTIPLE(ret_colwise.shape[1], align)};
+    }
+#endif
 
     ret_rowwise.type = DType::kFloat8E8M0;
     ret_rowwise.type_size_bits = typeToNumBits(DType::kFloat8E8M0);
@@ -1333,10 +1332,12 @@ std::array<size_t, 4> get_scale_tensor_dims(const size_t rows,
                                : nvfp4_scale_tensor_alignment_Y_colwise;
       alignment_X = is_rowwise ? nvfp4_scale_tensor_alignment_X_rowwise
                                : nvfp4_scale_tensor_alignment_X_colwise;
-    } else {
-      // MXFP8: gfx1250 MX pre-swizzle requires scales padded to a multiple of 4 in both dims
+    } else if (scaling_mode == NVTE_MXFP8_1D_SCALING) {
+      // gfx1250 MX pre-swizzle requires MXFP8 scales padded to a multiple of 4 in both dims (1 on other architectures)
       alignment_Y = alignment_X =
           (getDeviceComputeCapability() == 125) ? mxfp8_gfx1250_scale_tensor_alignment : 1;
+    } else {
+      alignment_Y = alignment_X = 1;
     }
 #else
     const size_t alignment_Y = is_rowwise

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -422,6 +422,8 @@ constexpr size_t scale_tensor_alignment_X_rowwise = 1;
 constexpr size_t scale_tensor_alignment_Y_rowwise = 1;
 constexpr size_t scale_tensor_alignment_X_colwise = 1;
 constexpr size_t scale_tensor_alignment_Y_colwise = 1;
+// gfx1250 MX pre-swizzle pads MXFP8 scales to a multiple of 4 in both dims
+constexpr size_t mxfp8_gfx1250_scale_tensor_alignment = 4;
 
 // For nvfp4:
 constexpr size_t nvfp4_scale_tensor_alignment_Y_rowwise = 128;


### PR DESCRIPTION
# Description

Previously failing tests on gfx1250:

```cosnole
$ tests/cpp/build/operator/test_operator "--gtest_filter=OperatorTest/CastMXFP8_GatedActTestSuite.TestCastMXFP8Swiglu/1X32X1X32Xfloat32Xfloat8e4m3XuniformXFWD"
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
