### PR TITLE
Compile CP softmax LSE corrections with dynamic shapes

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -27,7 +27,7 @@ from transformer_engine.pytorch.quantization import FP8GlobalStateManager
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.tensor.storage.float8_tensor_storage import Float8TensorStorage
 from transformer_engine.pytorch.quantized_tensor import QuantizedTensorStorage
-from transformer_engine.pytorch.jit import jit_fuser
+from transformer_engine.pytorch.jit import jit_fuser, jit_fuser_dynamic
 from transformer_engine.pytorch.graph import is_graph_capturing
 from transformer_engine.pytorch.constants import dist_group_type
 from transformer_engine.pytorch.distributed import (
@@ -184,7 +184,7 @@ def flash_attn_fwd_second_half_out_correction(
     out_.add_(out_corrected)
 
 
-@jit_fuser
+@jit_fuser_dynamic
 def flash_attn_fwd_softmax_lse_correction(
     softmax_lse: torch.Tensor,
     softmax_lse_per_step: torch.Tensor,
@@ -196,7 +196,7 @@ def flash_attn_fwd_softmax_lse_correction(
     softmax_lse.copy_(new_scale)
 
 
-@jit_fuser
+@jit_fuser_dynamic
 def flash_attn_fwd_second_half_softmax_lse_correction(
     softmax_lse: torch.Tensor,
     softmax_lse_per_step: torch.Tensor,

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -36,9 +36,30 @@ def lazy_compile(func):
     return wrapper
 
 
+# See: https://github.com/ROCm/TransformerEngine/issues/693
+def lazy_compile_dynamic(func):
+    """Lazy compile a function with torch.compile, using dynamic shapes
+
+    Compiling dynamic up front skips the static specialization dynamo would otherwise build on
+    the first shape it sees, leaving one compiled artifact for the process instead of two.
+    """
+    compiled_func = None
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        nonlocal compiled_func
+        if compiled_func is None:
+            compiled_func = torch.compile(func, dynamic=True)
+        return compiled_func(*args, **kwargs)
+
+    return wrapper
+
+
 jit_fuser = lambda func: func
+jit_fuser_dynamic = lambda func: func
 if torch_version() >= (2, 0, 0) and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
     jit_fuser = lazy_compile
+    jit_fuser_dynamic = lazy_compile_dynamic
 
 
 # See: https://github.com/NVIDIA/TransformerEngine/issues/597


### PR DESCRIPTION
# Description

Fixes the flaky ROCm nightly test `test_qwen3_30B_A3B/test_baseline.py` in miles, where rollout-0 `log_probs` and `ref_log_probs` intermittently fail the `abs_tol=1e-8` check.

The two CP softmax LSE correction functions use `@jit_fuser`, which wraps `torch.compile`:

- `flash_attn_fwd_softmax_lse_correction`
- `flash_attn_fwd_second_half_softmax_lse_correction`

Dynamo may compile multiple variants of these functions after seeing different input shapes. On gfx950, those variants can select different launch configurations, and `libdevice.log1p` is not bit-exact across them.

In failing runs, the reference and actor forwards receive bit-identical operands but use different `log1p` paths. The resulting approximately 1-ULP difference is repeatedly introduced across the model's attention layers and produces a final `1e-5` to `2e-4` log-probability mismatch.

This PR compiles only these two functions with `dynamic=True` from their first invocation. This avoids the initial static specialization and keeps both forwards on the same numerical path.

`CP=1` is unaffected because the LSE merge is only used when `CP > 1`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add `jit_fuser_dynamic` to `jit.py`, mirroring `jit_fuser` but using `torch.compile(..., dynamic=True)`.
- Apply `jit_fuser_dynamic` only to the two CP softmax LSE correction functions.

## Verification

Tested `test_qwen3_30B_A3B/test_baseline.py` on 4× MI355X with: `CP=2`/`PP=2`/`TP=1`/`EP=2`

Comparing rollout-0 reference and actor log-probabilities:

| Configuration | Passes | Bit-identical |
|---|---:|---:|
| Before | ~2/9 | No |
| This PR | 5/5 | Yes |

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes