### PR TITLE
[gfx1250] detect when building on gfx1250, add to build archs

### DIFF
--- a/build_tools/rocm_utils.cmake
+++ b/build_tools/rocm_utils.cmake
@@ -34,6 +34,22 @@ message(STATUS "ROCM_PATH: ${ROCM_PATH}")
 #Configure target GPU architectures
 if(NOT DEFINED ENV{NVTE_ROCM_ARCH})
     SET(CMAKE_HIP_ARCHITECTURES gfx942 gfx950)
+    # gfx1250 is not in the default set; when building natively on such a machine
+    # add it so it is targeted without having to set NVTE_ROCM_ARCH. Skipped
+    # silently if rocminfo or a GPU is unavailable.
+    find_program(NVTE_ROCMINFO_EXECUTABLE rocminfo HINTS "${ROCM_PATH}/bin")
+    if(NVTE_ROCMINFO_EXECUTABLE)
+        execute_process(
+            COMMAND "${NVTE_ROCMINFO_EXECUTABLE}"
+            OUTPUT_VARIABLE _rocminfo_output
+            ERROR_QUIET
+            RESULT_VARIABLE _rocminfo_result
+        )
+        if(_rocminfo_result EQUAL 0 AND _rocminfo_output MATCHES "gfx1250")
+            message(STATUS "Detected gfx1250; adding to CMAKE_HIP_ARCHITECTURES")
+            list(APPEND CMAKE_HIP_ARCHITECTURES gfx1250)
+        endif()
+    endif()
 else()
     # Accept comma separated list for NVTE_ROCM_ARCH
     string(REPLACE "," ";" HIP_ARCH_LIST "$ENV{NVTE_ROCM_ARCH}")


### PR DESCRIPTION
# Description

So that NVTE_ROCM_ARCH does not need to be manually set when building on gfx1250 (both for main TE build and the tests).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
