### PR TITLE
Disable FlashAttention on ROCm for MLA-style unequal QK/V head dims

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -830,19 +830,6 @@ def get_attention_backend(
 
     # Filter: Head dimension
     if head_dim_qk != head_dim_v:
-        # On ROCm, for MLA-style unequal head dims, pick fused attention instead of flash attention.
-        if IS_HIP_EXTENSION and (
-            use_flash_attention_2 or use_flash_attention_3 or use_flash_attention_4
-        ):
-            logger.debug(
-                "Disabling FlashAttention on ROCm for MLA (head_dim_qk != head_dim_v) to give"
-                " FusedAttention preference. Found: head_dim_qk = %s, head_dim_v = %s.",
-                head_dim_qk,
-                head_dim_v,
-            )
-            use_flash_attention_2 = False
-            use_flash_attention_3 = False
-            use_flash_attention_4 = False
         qkv_layout_group = qkv_layout.replace("b", "").replace("s", "").replace("t", "")
         if use_fused_attention and qkv_layout_group != "hd_hd_hd":
             logger.debug(
@@ -1600,10 +1587,15 @@ def get_attention_backend(
     )
 
     # Select FusedAttention for performance
-    if use_flash_attention and (not IS_HIP_EXTENSION) and use_fused_attention and device_compute_capability >= (9, 0):
+    prefer_fused_attention = (
+        # On ROCm, FusedAttention (aiter asm) is much faster than flash-attn for MLA-style unequal head dims.
+        head_dim_qk != head_dim_v
+        if IS_HIP_EXTENSION
+        else device_compute_capability >= (9, 0)
+    )
+    if use_flash_attention and use_fused_attention and prefer_fused_attention:
         logger.debug(
-            "Disabling FlashAttention to give FusedAttention preference on Hopper+ "
-            "for performance reasons"
+            "Disabling FlashAttention to give FusedAttention preference for performance reasons"
         )
         use_flash_attention = False
 

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -830,6 +830,19 @@ def get_attention_backend(
 
     # Filter: Head dimension
     if head_dim_qk != head_dim_v:
+        # For MLA-style unequal head dims, pick fused attention instead of flash attention.
+        if IS_HIP_EXTENSION and (
+            use_flash_attention_2 or use_flash_attention_3 or use_flash_attention_4
+        ):
+            logger.debug(
+                "Disabling FlashAttention on ROCm for MLA (head_dim_qk != head_dim_v) to give"
+                " FusedAttention preference. Found: head_dim_qk = %s, head_dim_v = %s.",
+                head_dim_qk,
+                head_dim_v,
+            )
+            use_flash_attention_2 = False
+            use_flash_attention_3 = False
+            use_flash_attention_4 = False
         qkv_layout_group = qkv_layout.replace("b", "").replace("s", "").replace("t", "")
         if use_fused_attention and qkv_layout_group != "hd_hd_hd":
             logger.debug(

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -830,7 +830,7 @@ def get_attention_backend(
 
     # Filter: Head dimension
     if head_dim_qk != head_dim_v:
-        # For MLA-style unequal head dims, pick fused attention instead of flash attention.
+        # On ROCm, for MLA-style unequal head dims, pick fused attention instead of flash attention.
         if IS_HIP_EXTENSION and (
             use_flash_attention_2 or use_flash_attention_3 or use_flash_attention_4
         ):


### PR DESCRIPTION
# Description

The auto attention backend selector in get_attention_backend() was falling back to a generic ck_tile backend that is ~8× slower than the aiter asm fused attention backend for MLA-style configurations where head_dim_qk != head_dim_v (e.g. DeepSeek-V3 with head_dim_qk=192, head_dim_v=128).

This regressed DeepSeek-V3 proxy model training on MI355 from ~552 TFLOP/s to ~323 TFLOP/s (260 ms → 445 ms/iter) with no change in numerics/loss.

This PR restores correct backend selection on ROCm by disabling FlashAttention 2/3/4 when head dims are unequal, so auto picks the faster FusedAttention (CK asm) path. The change is gated on IS_HIP_EXTENSION, leaving CUDA's FA3/FA4 MLA support untouched.

release_v2.15_rocm was picking fused attention for mla configs
https://github.com/ROCm/TransformerEngine/blame/e7835ed1b134f56e58c575fba2455471064cab9b/transformer_engine/pytorch/attention/dot_product_attention/utils.py#L718-L720

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
