### PR TITLE
[Hot Fix] Fix OOB read in Triton MXFP8 GEMM kernel causing SIGABRT on gfx950

### DIFF
--- a/transformer_engine/pytorch/triton_kernels/gemm/gemm_kernels.py
+++ b/transformer_engine/pytorch/triton_kernels/gemm/gemm_kernels.py
@@ -128,18 +128,24 @@ def mxfp8_matmul_kernel(
     a_ptrs = a_ptr + (offs_am[:, None].to(tl.int64) * stride_am + offs_k[None, :] * stride_ak)
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :].to(tl.int64) * stride_bn)
 
+    # Bound the A/B data loads to M/N. Block sizes (64/128/256) need not divide M/N
+    # (MXFP8 only guarantees multiples of VEC_SIZE=32), so a fringe block would otherwise
+    # read rows >= M / cols >= N out of bounds.
+    mask_m = offs_am < M
+    mask_n = offs_bn < N
+
     # K-loop
     num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
     for k in range(num_k_blocks):
         # Load FP8 data
         if EVEN_K:
-            a = tl.load(a_ptrs)
-            b = tl.load(b_ptrs)
+            a = tl.load(a_ptrs, mask=mask_m[:, None], other=0.0)
+            b = tl.load(b_ptrs, mask=mask_n[None, :], other=0.0)
         else:
             k_remaining = K - k * BLOCK_SIZE_K
             mask_k = offs_k < k_remaining
-            a = tl.load(a_ptrs, mask=mask_k[None, :], other=0.0)
-            b = tl.load(b_ptrs, mask=mask_k[:, None], other=0.0)
+            a = tl.load(a_ptrs, mask=mask_m[:, None] & mask_k[None, :], other=0.0)
+            b = tl.load(b_ptrs, mask=mask_k[:, None] & mask_n[None, :], other=0.0)
 
         # Load E8M0 scales for this K-block
         # We have:


### PR DESCRIPTION
Fixes bug introduced by #667. mxfp8_matmul_kernel loaded the A/B FP8 operands without masking against M/N (the EVEN_K fast path had no mask; offs_am/offs_bn lacked the % M/% N wrap the sibling matmul_kernel uses). MXFP8 only guarantees M/K/N are multiples of 32, but block sizes are 64/128/256, so any non-dividing shape reads out of bounds. Issue manifested as failing sGPU tests on gfx950. Fix masks the data loads (scales/bias/store were already masked).



# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
