### PR TITLE
Deprecate ROCm-SMI

### DIFF
--- a/transformer_engine/common/comm_gemm_overlap/userbuffers/userbuffers-host.cpp
+++ b/transformer_engine/common/comm_gemm_overlap/userbuffers/userbuffers-host.cpp
@@ -22,7 +22,9 @@
 #include <utility>
 
 #include "common/util/cuda_driver.h"
+#ifndef __HIP_PLATFORM_AMD__
 #include "common/util/cuda_nvml.h"
+#endif
 #include "common/util/cuda_runtime.h"
 #include "common/util/logging.h"
 #include "common/util/system.h"
@@ -93,6 +95,7 @@ int stringCmp(const void *a, const void *b) { return strcmp((const char *)a, (co
     }                                                            \
   } while (0);
 
+#ifndef __HIP_PLATFORM_AMD__
 bool has_mnnvl_fabric(int device_id) {
 #if !defined(nvmlGpuFabricInfo_v2)
   if (getenv("NVTE_UBDEBUG")) {
@@ -142,6 +145,7 @@ bool has_mnnvl_fabric(int device_id) {
   return mnnvl_fabric_support;
 #endif
 }
+#endif
 
 int create_communicator_grouped2(communicator **comm, int myrank, int numranks, int mylocal,
                                  int numlocal, int mynode, int numnodes,


### PR DESCRIPTION
# Description

Stop including rocm_smi.h which is removed on ROCm 10. Not functional change, just build
Fixes #ROCM-30552


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

Guard headers include

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
